### PR TITLE
Auto-build reverse-dependency index; move Tool into Tools menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 /target
 guerilla_tag_save/
 .baboon-prefs.json
+# Runtime caches written to the working dir in dev (entry / reverse-dep / field indexes, keywords)
+*_index.json
+*_reverse_dependencies.json
+*_keywords.json

--- a/src/app.rs
+++ b/src/app.rs
@@ -169,6 +169,8 @@ pub struct Baboon {
     folder_refactor: Option<FolderRefactorUiState>,
     /// True while a background full-scan of a loose-folder source is running.
     scanning_entries: bool,
+    /// True while a background reverse-dependency index build is running.
+    building_reverse_dependencies: bool,
     terminal: TerminalState,
     terminal_open: bool,
     /// Working directory for terminal commands (game kit root, parent of tags/).
@@ -287,6 +289,7 @@ impl Baboon {
             status: "Ready".to_owned(),
             folder_refactor: None,
             scanning_entries: false,
+            building_reverse_dependencies: false,
             terminal: TerminalState {
                 input: String::new(),
                 lines: Vec::new(),

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -60,6 +60,32 @@ impl Baboon {
                         self.field_index.install(generation, blobs);
                     }
                 }
+                WorkerMessage::ReverseDependenciesBuilt { generation, index } => {
+                    self.building_reverse_dependencies = false;
+                    // Discard a build that finished against a now-stale source.
+                    if generation != self.source_generation {
+                        continue;
+                    }
+                    if let Some(source) = self.source.as_mut() {
+                        let n = index.len();
+                        // Persist so the next launch skips the rebuild entirely.
+                        if let (Some(game), TagSource::LooseFolder { root, .. }) =
+                            (source.game.clone(), &source.source)
+                        {
+                            let root = root.clone();
+                            let to_save = index.clone();
+                            thread::spawn(move || {
+                                if let Err(e) = crate::source::save_reverse_dependency_index(
+                                    &game, &root, &to_save,
+                                ) {
+                                    eprintln!("reverse-dependency index save failed: {e}");
+                                }
+                            });
+                        }
+                        source.reverse_dependencies = Some(index);
+                        self.status = format!("Reference index complete: {n} tags");
+                    }
+                }
                 WorkerMessage::SourceLoaded {
                     result: Ok(mut loaded),
                     recent_path,
@@ -1810,13 +1836,22 @@ impl Baboon {
                     title,
                     entries: Vec::new(),
                     annotations: Vec::new(),
-                    note: Some(
-                        "Reference index unavailable — load a loose-folder source and let it \
-                         finish scanning."
-                            .to_owned(),
-                    ),
+                    note: Some(self.reference_index_unavailable_note()),
                 });
             }
+        }
+    }
+
+    /// Explain why a reference lookup found no index, tailored to whether one is
+    /// currently building (auto after the full scan, or via Tools → Build
+    /// Reference Index).
+    fn reference_index_unavailable_note(&self) -> String {
+        if self.building_reverse_dependencies || self.scanning_entries {
+            "Reference index is building — try again in a moment.".to_owned()
+        } else {
+            "Reference index unavailable — it builds automatically for loose-folder sources, or \
+             run Tools → Build Reference Index."
+                .to_owned()
         }
     }
 
@@ -1838,11 +1873,7 @@ impl Baboon {
                     title: "Unreferenced tags".to_owned(),
                     entries: Vec::new(),
                     annotations: Vec::new(),
-                    note: Some(
-                        "Reference index unavailable — load a loose-folder source and let it \
-                         finish scanning."
-                            .to_owned(),
-                    ),
+                    note: Some(self.reference_index_unavailable_note()),
                 });
             }
         }
@@ -2033,6 +2064,56 @@ impl Baboon {
         thread::spawn(move || {
             let blobs = build_field_value_index(&tag_source, &entries);
             let _ = tx.send(WorkerMessage::FieldIndexBuilt { generation, blobs });
+            ctx.request_repaint();
+        });
+    }
+
+    /// Build the reverse-dependency index in the background so the
+    /// find-references / unreferenced / Content Explorer features work without
+    /// first running a move/rename. Idempotent: skips while a build is running,
+    /// and skips an already-present index unless `force` is set (Tools →
+    /// Rebuild). Loose-folder sources only; the result is persisted to disk so
+    /// future launches load it instantly.
+    pub(super) fn begin_build_reverse_dependencies(&mut self, ctx: egui::Context, force: bool) {
+        if self.building_reverse_dependencies {
+            return;
+        }
+        let Some(source) = self.source.as_ref() else {
+            return;
+        };
+        if !matches!(source.source, TagSource::LooseFolder { .. }) {
+            return;
+        }
+        if source.reverse_dependencies.is_some() && !force {
+            return;
+        }
+        let entries = source.all_entries.clone();
+        if entries.is_empty() {
+            // The full entry set isn't ready yet. A reverse-dep index built from
+            // the partially-loaded folder would be wrong (it would flag tags as
+            // unreferenced just because their referrers weren't scanned), so
+            // kick the full scan first. `begin_scan_all_entries` is idempotent
+            // (guards on `scanning_entries`); the update loop re-enters here and
+            // builds the index once the scan lands.
+            if !self.scanning_entries {
+                self.status = "Indexing tags, then building reference index…".to_owned();
+            }
+            self.begin_scan_all_entries(ctx);
+            return;
+        }
+        let tag_source = source.source.clone();
+        let generation = self.source_generation;
+        let tx = self.tx.clone();
+        self.building_reverse_dependencies = true;
+        self.status = "Building reference index…".to_owned();
+        thread::spawn(move || {
+            let mut index = ReverseDependencyIndex::default();
+            for entry in &entries {
+                if let Ok(deps) = read_entry_dependencies(&tag_source, entry) {
+                    index.set_tag_dependencies(entry.key.clone(), deps);
+                }
+            }
+            let _ = tx.send(WorkerMessage::ReverseDependenciesBuilt { generation, index });
             ctx.request_repaint();
         });
     }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -37,6 +37,12 @@ pub(super) enum WorkerMessage {
         generation: u64,
         blobs: Vec<(String, String)>,
     },
+    // Background reverse-dependency index build finished. `generation` guards
+    // against staleness after a source reload.
+    ReverseDependenciesBuilt {
+        generation: u64,
+        index: ReverseDependencyIndex,
+    },
 }
 
 /// One tag whose field values matched a field-value search, with the first

--- a/src/app/ui.rs
+++ b/src/app/ui.rs
@@ -657,13 +657,13 @@ impl Baboon {
                             .color(text_dark()),
                     );
                     if explorer.index_unavailable {
-                        ui.label(
-                            RichText::new(
-                                "Reference index unavailable — load a loose-folder source and \
-                                 let it finish scanning.",
-                            )
-                            .color(subtle_dark()),
-                        );
+                        let note = if self.building_reverse_dependencies || self.scanning_entries {
+                            "Reference index is building — reopen this in a moment."
+                        } else {
+                            "Reference index unavailable — it builds automatically for \
+                             loose-folder sources, or run Tools → Build Reference Index."
+                        };
+                        ui.label(RichText::new(note).color(subtle_dark()));
                     }
                     ui.separator();
                     let filter_lower = filter.trim().to_ascii_lowercase();
@@ -2209,6 +2209,11 @@ impl eframe::App for Baboon {
                         }
                     });
                     ui.menu_button("Tools", |ui| {
+                        if ui.button("Run Tool...").clicked() {
+                            ui.close_menu();
+                            self.tool_commands.open = true;
+                        }
+                        ui.separator();
                         if ui
                             .add_enabled(
                                 self.selected_key.is_some(),
@@ -2236,6 +2241,31 @@ impl eframe::App for Baboon {
                         if ui.button("Find Unreferenced Tags...").clicked() {
                             ui.close_menu();
                             self.show_unreferenced_tags();
+                        }
+                        {
+                            let is_loose = self.source.as_ref().is_some_and(|source| {
+                                matches!(source.source, TagSource::LooseFolder { .. })
+                            });
+                            let has_index = self.source.as_ref().is_some_and(|source| {
+                                source.reverse_dependencies.is_some()
+                            });
+                            let label = if self.building_reverse_dependencies {
+                                "Building Reference Index…"
+                            } else if has_index {
+                                "Rebuild Reference Index"
+                            } else {
+                                "Build Reference Index"
+                            };
+                            if ui
+                                .add_enabled(
+                                    is_loose && !self.building_reverse_dependencies,
+                                    egui::Button::new(label),
+                                )
+                                .clicked()
+                            {
+                                ui.close_menu();
+                                self.begin_build_reverse_dependencies(ctx.clone(), true);
+                            }
                         }
                         if ui.button("List Scenario Map IDs...").clicked() {
                             ui.close_menu();
@@ -2316,9 +2346,6 @@ impl eframe::App for Baboon {
                             ui.close_menu();
                         }
                     });
-                    if ui.button("Tool").clicked() {
-                        self.tool_commands.open = true;
-                    }
                     ui.menu_button("Help", |ui| {
                         if ui.button("About...").clicked() {
                             self.help_panel_tab = HelpPanelTab::About;
@@ -2772,6 +2799,19 @@ impl eframe::App for Baboon {
                     // it must be called after the `source` borrow ends.
                     if need_scan {
                         self.begin_scan_all_entries(ctx.clone());
+                    }
+                    // Auto-build the reverse-dependency index so find-references
+                    // / unreferenced / Content Explorer work without first
+                    // running a move/rename. If the full entry list isn't in
+                    // yet this kicks the scan first, then builds when it lands.
+                    // Idempotent and self-gating (see the method + scan guard).
+                    if !self.building_reverse_dependencies
+                        && self.source.as_ref().is_some_and(|source| {
+                            matches!(source.source, TagSource::LooseFolder { .. })
+                                && source.reverse_dependencies.is_none()
+                        })
+                    {
+                        self.begin_build_reverse_dependencies(ctx.clone(), false);
                     }
                 } else {
                     ui.label("Use File to load a tag, folder, or monolithic cache.");


### PR DESCRIPTION
## Summary

Makes the reference-graph features work out of the box, and tidies the menu bar.

### Reverse-dependency index now builds automatically
**Find References**, **Find Unreferenced Tags**, and **Content Explorer** all depend on the reverse-dependency index, but it was only ever built as a side effect of a move/rename. On a fresh loose-folder source the index was `None`, so these features showed *"Reference index unavailable"* with no way to build it.

Now, for loose-folder sources:
- The update loop kicks the full entry scan when the tag list isn't loaded yet, then builds the index on a background thread (cheap want-stream dependency reads, not full tag parses).
- The result is installed generation-guarded (a build that finishes against a reloaded source is discarded) and persisted to `{game}_reverse_dependencies.json`, so future launches load it instantly.
- **Tools → Build / Rebuild Reference Index** added for a manual (re)build.
- The "unavailable" notes now reflect the scanning/building state.

### Menu cleanup
- The standalone **Tool** menu button is now **Tools → Run Tool...**.
- Runtime index/keyword caches are gitignored.

All 132 tests pass; `cargo check` clean.