### PR TITLE
In-process extraction (drop blam-tag-shell) + Halo CE gbxmodel/model_animations support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,7 +405,7 @@ checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 [[package]]
 name = "blam-tags"
 version = "0.1.0"
-source = "git+https://github.com/camden-smallwood/blam-tags?rev=5be44976fe1397453ed7d470483b9f69b58cefb4#5be44976fe1397453ed7d470483b9f69b58cefb4"
+source = "git+https://github.com/camden-smallwood/blam-tags?rev=d36e917e88428bed566a98c12c045c478d105e43#d36e917e88428bed566a98c12c045c478d105e43"
 dependencies = [
  "bcdec_rs",
  "flate2",
@@ -1038,7 +1038,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2773,7 +2773,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3106,7 +3106,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3287,7 +3287,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3736,7 +3736,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1"
-blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "5be44976fe1397453ed7d470483b9f69b58cefb4", features = ["audio"] }
+blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "d36e917e88428bed566a98c12c045c478d105e43", features = ["audio"] }
 eframe = { version = "0.29", default-features = false, features = ["default_fonts", "glow"] }
 egui_extras = { version = "0.29", features = ["svg"] }
 flate2 = "1"

--- a/README.md
+++ b/README.md
@@ -260,9 +260,10 @@ All extraction runs on background threads and reports progress to the status bar
   - `render_model` (`mode`), `collision_model` (`coll`), `physics_model`
     (`phmo`) — direct JMS extraction.
   - `scenario_structure_bsp` (`sbsp`) — ASS extraction.
-  - `scenario` (`scnr`) — geometry extraction via the shell.
-- **Import info** and **animation extraction** via the companion
-  `blam-tag-shell` binary.
+  - `scenario` (`scnr`) — per-BSP geometry extraction (ASS for Halo 2/3,
+    render + collision JMS for Halo CE).
+- **Import info** and **animation extraction**, all run in-process via the
+  `blam-tags` library.
 
 ### Geometry import & integrated terminal
 
@@ -350,11 +351,9 @@ separately. The `definitions/` git submodule is required; initialise it with
 `git submodule update --init` after cloning. The build script copies that
 submodule folder next to the built executable under `target/<profile>/definitions`.
 
-Geometry/animation/import-info extraction additionally relies on the companion
-`blam-tag-shell` binary. The root workspace builds Baboon and `blam-tag-shell`
-together, placing them side by side in `target/debug/` or `target/release/`.
-Ship `Baboon.exe`, `blam-tag-shell.exe`, and the `definitions/` folder in
-releases.
+Geometry, animation, and import-info extraction all run in-process via the
+`blam-tags` library — Baboon no longer shells out to a companion binary.
+Ship `Baboon.exe` and the `definitions/` folder in releases.
 
 ---
 

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -1029,7 +1029,7 @@ pub(super) fn is_hlsl_include_tag(entry: &TagEntry) -> bool {
 pub(super) fn supports_geometry_extraction(group_tag: u32) -> bool {
     matches!(
         group_tag.to_be_bytes().as_slice(),
-        b"hlmt" | b"scnr" | b"sbsp" | b"mode" | b"coll" | b"phmo"
+        b"hlmt" | b"scnr" | b"sbsp" | b"mode" | b"mod2" | b"coll" | b"phmo"
     )
 }
 
@@ -1046,6 +1046,7 @@ pub(super) fn geometry_extract_label(group_tag: u32) -> &'static str {
         b"scnr" => "Extract scenario BSP geometry...",
         b"sbsp" => "Extract BSP geometry...",
         b"mode" => "Extract render_model geometry...",
+        b"mod2" => "Extract gbxmodel geometry...",
         b"coll" => "Extract collision_model geometry...",
         b"phmo" => "Extract physics_model geometry...",
         _ => "Extract geometry...",
@@ -1053,7 +1054,7 @@ pub(super) fn geometry_extract_label(group_tag: u32) -> &'static str {
 }
 
 pub(super) fn supports_animation_extraction(group_tag: u32) -> bool {
-    matches!(group_tag.to_be_bytes().as_slice(), b"jmad" | b"hlmt")
+    matches!(group_tag.to_be_bytes().as_slice(), b"jmad" | b"hlmt" | b"antr")
 }
 
 pub(super) fn node_matches(node: &TagTreeNode, entries: &[TagEntry], filter: &str) -> bool {

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -1812,7 +1812,7 @@ impl Baboon {
         self.status = format!("Extracting animations from {}", entry.display_path);
         let tx = self.tx.clone();
         thread::spawn(move || {
-            let result = run_shell_extraction(&source, &entry, "extract-animation", &output)
+            let result = extract_animations_for_entry(&source, &entry, &output)
                 .map_err(|e| e.to_string());
             let _ = tx.send(WorkerMessage::ExportFinished(result));
             ctx.request_repaint();

--- a/src/app/editor.rs
+++ b/src/app/editor.rs
@@ -1790,6 +1790,11 @@ pub(super) fn is_model_group(group_tag: u32, names: &TagNameIndex) -> bool {
     group_tag == u32::from_be_bytes(*b"hlmt")
         || names.name_for(group_tag) == Some("model")
         || group_tag_to_extension(group_tag) == Some("model")
+        // Halo CE has no `.model` (hlmt) wrapper — objects reference a
+        // `.gbxmodel` (mod2) directly, which IS the render geometry, so
+        // treat it as previewable in its own right.
+        || group_tag == u32::from_be_bytes(*b"mod2")
+        || names.name_for(group_tag) == Some("gbxmodel")
 }
 
 pub(super) fn format_reference_path(names: &TagNameIndex, group_tag: u32, path: &str) -> String {

--- a/src/app/export.rs
+++ b/src/app/export.rs
@@ -171,7 +171,7 @@ pub(super) fn extract_geometry_for_entry(
 ) -> anyhow::Result<String> {
     match &entry.group_tag.to_be_bytes() {
         b"hlmt" => extract_model_geometry(source, entry, output),
-        b"scnr" => run_shell_extraction(source, entry, "extract-geometry", output),
+        b"scnr" => extract_scenario_geometry(source, entry, output),
         b"sbsp" => {
             let tag = read_entry(source, entry)?;
             let ass = AssFile::from_scenario_structure_bsp(&tag)?;
@@ -902,98 +902,73 @@ pub(super) fn render_model_prefers_ass(tag: &TagFile) -> bool {
     instance_mesh_index >= 0 && placements_len > 0
 }
 
-pub(super) fn run_shell_extraction(
+/// Adapts a [`TagSource`] into a [`blam_tags::extract::TagResolver`] so the
+/// shared extraction orchestration can resolve child tag references
+/// (jmad → render_model, scenario → structure_bsp/stli) through Baboon's
+/// cache- and classic-aware loader.
+struct SourceResolver<'a> {
+    source: &'a TagSource,
+}
+
+impl blam_tags::extract::TagResolver for SourceResolver<'_> {
+    fn resolve(
+        &self,
+        reference: &str,
+        group_ext: &str,
+        group_tag: u32,
+    ) -> Result<TagFile, blam_tags::extract::ExtractError> {
+        load_referenced_tag_from_source(self.source, reference, group_ext, &group_tag.to_be_bytes())
+            .map_err(|error| blam_tags::extract::ExtractError::resolve(error.to_string()))
+    }
+}
+
+/// Extract every animation in `entry` (a jmad, `.model`, object tag, or
+/// Halo CE `model_animations`) to JMA-family files under
+/// `<output>/<stem>/animations/`, in-process via `blam_tags::extract`.
+pub(super) fn extract_animations_for_entry(
     source: &TagSource,
     entry: &TagEntry,
-    command_name: &str,
     output: &Path,
 ) -> anyhow::Result<String> {
-    let shell = shell_binary_path()?;
-    let mut command = Command::new(&shell);
-    if let Some(definitions_parent) = locate_definitions_root().parent() {
-        command.current_dir(definitions_parent);
+    let tag = read_entry(source, entry)?;
+    let resolver = SourceResolver { source };
+    let stem = tag_file_stem(entry);
+    let summary = blam_tags::extract::animation::animations_to_dir(&tag, &resolver, output, &stem)?;
+    let mut message = format!(
+        "Extracted {} animation(s) from {} into {}",
+        summary.written,
+        entry.display_path,
+        output.display(),
+    );
+    if summary.skipped > 0 {
+        message.push_str(&format!(" ({} skipped)", summary.skipped));
     }
-    match source {
-        TagSource::MonolithicCache { root, .. } => {
-            command.arg("--cache").arg(root);
-        }
-        TagSource::LooseFolder {
-            game: Some(game), ..
-        } => {
-            command.arg("--game").arg(game);
-        }
-        _ => {}
-    }
-    command.arg(command_name);
-    command.arg(shell_entry_arg(entry)?);
-    if command_name == "extract-geometry" && entry.group_tag == u32::from_be_bytes(*b"hlmt") {
-        command.arg("all");
-    }
-    let output_arg = if output.is_absolute() {
-        output.to_path_buf()
-    } else {
-        std::env::current_dir()
-            .map(|cwd| cwd.join(output))
-            .unwrap_or_else(|_| output.to_path_buf())
-    };
-    command.arg("--output").arg(output_arg);
-    let output_data = command.output()?;
-    if !output_data.status.success() {
-        let stderr = String::from_utf8_lossy(&output_data.stderr);
-        let stdout = String::from_utf8_lossy(&output_data.stdout);
-        anyhow::bail!(
-            "{} failed: {}{}",
-            command_name,
-            stderr.trim(),
-            if stdout.trim().is_empty() {
-                String::new()
-            } else {
-                format!(" {}", stdout.trim())
-            }
-        );
-    }
-    let stdout = String::from_utf8_lossy(&output_data.stdout);
-    let message = stdout.lines().last().unwrap_or("").trim();
-    if message.is_empty() {
-        Ok(format!(
-            "{} completed into {}",
-            command_name,
-            output.display()
-        ))
-    } else {
-        Ok(format!("{command_name}: {message}"))
-    }
+    Ok(message)
 }
 
-pub(super) fn shell_binary_path() -> anyhow::Result<PathBuf> {
-    let exe = std::env::current_exe()?;
-    let file_name = if cfg!(windows) {
-        "blam-tag-shell.exe"
-    } else {
-        "blam-tag-shell"
-    };
-    if let Some(parent) = exe.parent() {
-        let sibling = parent.join(file_name);
-        if sibling.exists() {
-            return Ok(sibling);
-        }
+/// Extract per-BSP scenario geometry — one ASS (Halo 2 / Halo 3) or render +
+/// collision JMS (Halo CE) per structure BSP — under
+/// `<output>/<stem>/structure/`, in-process via `blam_tags::extract`.
+pub(super) fn extract_scenario_geometry(
+    source: &TagSource,
+    entry: &TagEntry,
+    output: &Path,
+) -> anyhow::Result<String> {
+    let tag = read_entry(source, entry)?;
+    let resolver = SourceResolver { source };
+    let stem = tag_file_stem(entry);
+    let summary =
+        blam_tags::extract::geometry::scenario_geometry_to_dir(&tag, &resolver, output, &stem)?;
+    let mut message = format!(
+        "Extracted {} geometry file(s) from {} into {}",
+        summary.emitted.len(),
+        entry.display_path,
+        output.display(),
+    );
+    if !summary.warnings.is_empty() {
+        message.push_str(&format!(" ({} warning(s))", summary.warnings.len()));
     }
-    let fallback = PathBuf::from("target").join("debug").join(file_name);
-    if fallback.exists() {
-        return Ok(fallback);
-    }
-    anyhow::bail!("could not find {file_name}; build the workspace with `cargo build --release`")
-}
-
-pub(super) fn shell_entry_arg(entry: &TagEntry) -> anyhow::Result<PathBuf> {
-    match &entry.location {
-        TagEntryLocation::LooseFile(path) => Ok(path.clone()),
-        TagEntryLocation::Monolithic { name, group_tag } => Ok(PathBuf::from(format!(
-            "{}.{}",
-            name,
-            format_group_tag(*group_tag)
-        ))),
-    }
+    Ok(message)
 }
 
 pub(super) fn tag_to_json(tag: &TagFile, entry: &TagEntry) -> Value {

--- a/src/app/model_preview.rs
+++ b/src/app/model_preview.rs
@@ -205,7 +205,7 @@ fn ensure_model_preview_loaded(
     state.loaded_key = Some(entry.key.clone());
     state.data = Some(
         std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            load_model_preview(model_tag, names, source)
+            load_model_preview(model_tag, entry, names, source)
         }))
         .map_err(|_| "Render model preview crashed while parsing this tag.".to_owned())
         .and_then(|result| result)
@@ -222,9 +222,30 @@ fn ensure_model_preview_loaded(
 
 fn load_model_preview(
     model_tag: &TagFile,
+    entry: &TagEntry,
     names: &TagNameIndex,
     source: Option<&TagSource>,
 ) -> Result<ModelPreviewData, String> {
+    // Halo CE `gbxmodel` (mod2) and a bare `render_model` (mode) ARE the
+    // render geometry — there is no `.model` (hlmt) wrapper carrying a
+    // "render model" reference, so preview the tag itself.
+    let group = model_tag.header.group_tag.to_be_bytes();
+    if matches!(&group, b"mode" | b"mod2") {
+        let preview = build_render_preview(model_tag)?;
+        if preview.batches.is_empty() {
+            return Err("This render tag has no previewable draw batches.".to_owned());
+        }
+        let max_preview_edge = preview_edge_limit(preview.bounds_min, preview.bounds_max);
+        let draw_triangles = build_model_source_triangles(&preview, max_preview_edge);
+        return Ok(ModelPreviewData {
+            source_key: entry.key.clone(),
+            render_model_path: entry.display_path.clone(),
+            preview,
+            draw_triangles,
+            variants: Vec::new(),
+        });
+    }
+
     let Some((group_tag, rel_path)) = model_tag.root().read_tag_ref_with_group("render model")
     else {
         return Err("This model tag has no render model reference.".to_owned());
@@ -259,16 +280,7 @@ fn load_model_preview(
     };
     let render_tag =
         read_entry(source.unwrap(), &render_entry).map_err(|error| error.to_string())?;
-    let preview = if render_tag.classic_engine().is_some() {
-        let jms = render_jms_for_game(&render_tag).map_err(|error| error.to_string())?;
-        let region_perms = read_render_region_permutations(&render_tag);
-        preview_from_jms(&jms, &region_perms)
-    } else {
-        let render_model = RenderModel::from_tag(&render_tag).map_err(|error| error.to_string())?;
-        let render_meshes =
-            RenderModel::derive_render_meshes(&render_tag).map_err(|error| error.to_string())?;
-        render_model_to_preview(&render_model, &render_meshes)
-    };
+    let preview = build_render_preview(&render_tag)?;
     if preview.batches.is_empty() {
         return Err("Referenced render_model has no previewable draw batches.".to_owned());
     }
@@ -281,6 +293,23 @@ fn load_model_preview(
         draw_triangles,
         variants: read_model_variants(model_tag),
     })
+}
+
+/// Build preview geometry from a render-geometry tag — a `render_model`
+/// (`mode`), a Halo CE `gbxmodel` (`mod2`), or a Halo 2 `render_model`.
+/// Classic engines go through the JMS path; gen3 uses the render_model
+/// mesh path directly.
+fn build_render_preview(render_tag: &TagFile) -> Result<RenderModelPreview, String> {
+    if render_tag.classic_engine().is_some() {
+        let jms = render_jms_for_game(render_tag).map_err(|error| error.to_string())?;
+        let region_perms = read_render_region_permutations(render_tag);
+        Ok(preview_from_jms(&jms, &region_perms))
+    } else {
+        let render_model = RenderModel::from_tag(render_tag).map_err(|error| error.to_string())?;
+        let render_meshes =
+            RenderModel::derive_render_meshes(render_tag).map_err(|error| error.to_string())?;
+        Ok(render_model_to_preview(&render_model, &render_meshes))
+    }
 }
 
 fn preview_from_jms(


### PR DESCRIPTION
Two related changes.

## Extract in-process; drop the `blam-tag-shell` dependency

Animation extraction and scenario (`scnr`) geometry extraction previously shelled out to the companion `blam-tag-shell` binary. Both now run in-process against a new `blam_tags::extract` library module (import-info was already native), so Baboon no longer spawns a subprocess for any extraction.

- New `SourceResolver` adapts `TagSource` to `blam_tags::extract::TagResolver` (via the cache- and classic-aware `load_referenced_tag_from_source`), plus `extract_animations_for_entry` and `extract_scenario_geometry`.
- Rewired `begin_extract_animation` and the `scnr` geometry arm to the library; deleted `run_shell_extraction` / `shell_binary_path` / `shell_entry_arg`.
- Bumped the `blam-tags` rev to the commit carrying `blam_tags::extract`.

Output is byte-identical to the former subprocess path (verified against a 2263-file golden set covering H3/H2/CE animations and scenarios). Baboon no longer needs the `blam-tag-shell` binary at runtime — ship just `Baboon.exe` + `definitions/`.

## Halo CE `gbxmodel` / `model_animations` support

Halo CE has no `.model` (hlmt) wrapper — objects reference a `.gbxmodel` (mod2) and `.model_animations` (antr) directly — so these were never surfaced in the UI even though the backends already handle them.

- Offer geometry extraction on `.gbxmodel` (render JMS via `JmsFile::from_gbxmodel`) and animation extraction on `.model_animations` (the CE animation path) in the browser context menu.
- Show the render-model preview on a `.gbxmodel` tag directly: treat a render-geometry tag (mod2/mode) as its own render geometry instead of requiring a "render model" reference, reusing the existing classic JMS preview pipeline.