### PR TITLE
Reference-jump to field, filter-mode field search, and startup session options

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,11 @@ silently skipped.
 - **Field-value search** — search across tags' *field values* (not just names),
   run on a background worker against an in-memory field index and optionally
   scoped to a tag group; results open in a clickable window.
-- **Find references** — list every tag that references the current tag.
+- **Find references** — list every tag that references the current tag; click a
+  result to open it and **jump straight to the exact field** where the reference
+  lives (ancestor blocks expanded, the field scrolled into view and briefly
+  glowed). When a tag references the target in more than one place, an expander
+  under its row lists every occurrence, each individually clickable.
 - **Content Explorer** — a reference-graph navigator centred on one tag: who
   references it (parents) and what it references (children), with back/forward
   history and a filter box.
@@ -111,6 +115,8 @@ silently skipped.
   amber tint + ● marker when it has unsaved edits.
 - **Tear off** any tab into a floating, resizable window — and drag it back onto
   the rack (or click *dock*) to re-dock it.
+- **Right-click a tab** to reveal that tag in the browser tree, or to close all
+  tabs / all tabs but this one.
 - An LRU cache bounds how many parsed tags and tabs are kept in memory at once,
   trimming least-recently-used documents automatically.
 
@@ -134,8 +140,11 @@ pageable resources — with inline editing for loose little-endian tags:
   style **explanation blocks** inline.
 - **Undo / redo** — every edit (field, block, structural) is journaled;
   `Ctrl+Z` / `Ctrl+Y` and the Edit menu step through the history.
-- **Guerilla-style "Search fields"** — type a block or field name to collapse the
-  editor down to just the matching node(s) and their ancestors.
+- **Guerilla-style "Search fields"** — type a block or field name to filter the
+  editor down to just the matching fields and the blocks/structs/arrays that
+  contain them; everything else is hidden. Available on every field-tree tag,
+  including sound tags. Blocks and structs keep their expand state as you page
+  through a block's elements, and structs are expanded by default.
 - **Expert mode** toggle to reveal advanced/normally-hidden fields.
 - Monolithic-cache and big-endian tags are opened **read-only**; only
   little-endian loose tags can be saved back to disk.
@@ -297,6 +306,12 @@ Browser mode, prefix display, expert mode, dark/light theme, the Blender path,
 custom editing-kit folder names, recent folders, keyword and palette sidecars,
 and per-kit terminal state are persisted to `%APPDATA%\Baboon` and restored on
 launch.
+
+On launch Baboon can reopen the windows from your previous session. The startup
+behaviour is a three-way choice in *File → Settings* — **Ask** which windows to
+reopen (a prompt lists them), **Always** reopen automatically, or **Never** — and
+the reopen prompt itself carries a *Don't ask again* option (OK remembers
+*Always*, Cancel remembers *Never*).
 
 ---
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -128,11 +128,10 @@ pub struct Baboon {
     show_browser_prefixes: bool,
     folders_before_tags: bool,
     double_click_to_open_tags: bool,
-    auto_restore_last_session: bool,
+    session_restore: SessionRestore,
     show_block_sizes: bool,
     scroll_to_cycle_dropdowns: bool,
     expert_mode: bool,
-    field_search_passive: bool,
     dark_mode: bool,
     ui_scale: f32,
     pending_ui_scale: f32,
@@ -216,6 +215,19 @@ pub struct Baboon {
     game_banner_textures: HashMap<String, egui::TextureHandle>,
     /// Clipboard for copy/paste of a block element between identical tags.
     block_clipboard: Option<BlockClipboard>,
+    /// A reference-jump awaiting its referrer tag to finish loading before we
+    /// can walk it to locate the exact referencing field. Set from the
+    /// "References to X" popup; drained by `apply_field_nav`.
+    pending_ref_jump: Option<PendingRefJump>,
+    /// Active reference-jump navigation: force ancestor blocks open and glow the
+    /// exact referencing field until its glow window expires.
+    field_nav: Option<FieldNav>,
+    /// Which referrer rows in the "References to X" popup are expanded to show
+    /// their per-occurrence list. Keyed by row index; reset per references query.
+    ref_jump_expanded: HashSet<usize>,
+    /// Lazily-computed occurrences per expanded referrer row. A present-but-empty
+    /// vec means "walked, none found"; absence means "not yet walked (loading)".
+    ref_jump_occurrences: HashMap<usize, Vec<RefOccurrence>>,
 }
 
 impl Baboon {
@@ -230,8 +242,8 @@ impl Baboon {
         let names = TagNameIndex::load_from_definitions(&locate_definitions_root());
         let (tx, rx) = mpsc::channel();
         let last_session = load_last_session().and_then(LastOpenedWindowsPrompt::from_session);
-        let (last_opened_windows, auto_restore_session) = if prefs.auto_restore_last_session {
-            match last_session {
+        let (last_opened_windows, auto_restore_session) = match prefs.session_restore {
+            SessionRestore::Always => match last_session {
                 Some(prompt) => {
                     let tags = prompt.checked_tags();
                     if tags.is_empty() {
@@ -244,9 +256,11 @@ impl Baboon {
                     }
                 }
                 None => (None, None),
-            }
-        } else {
-            (last_session, None)
+            },
+            // Show the prompt.
+            SessionRestore::Ask => (last_session, None),
+            // Start fresh — never reopen, never ask.
+            SessionRestore::Never => (None, None),
         };
         let mut app = Self {
             default_names: names.clone(),
@@ -275,11 +289,10 @@ impl Baboon {
             show_browser_prefixes: prefs.show_browser_prefixes,
             folders_before_tags: prefs.folders_before_tags,
             double_click_to_open_tags: prefs.double_click_to_open_tags,
-            auto_restore_last_session: prefs.auto_restore_last_session,
+            session_restore: prefs.session_restore,
             show_block_sizes: prefs.show_block_sizes,
             scroll_to_cycle_dropdowns: prefs.scroll_to_cycle_dropdowns,
             expert_mode: prefs.expert_mode,
-            field_search_passive: prefs.field_search_passive,
             dark_mode: prefs.dark_mode,
             ui_scale: prefs.ui_scale,
             pending_ui_scale: prefs.ui_scale,
@@ -317,6 +330,10 @@ impl Baboon {
             palette_last_dir: prefs.palette_last_dir.clone(),
             function_popup: None,
             query_results: None,
+            pending_ref_jump: None,
+            field_nav: None,
+            ref_jump_expanded: HashSet::new(),
+            ref_jump_occurrences: HashMap::new(),
             tag_diff: None,
             content_explorer: None,
             keywords: KeywordStore::default(),

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -66,6 +66,7 @@ impl Baboon {
                                 entries,
                                 annotations,
                                 note,
+                                ref_target: None,
                             });
                         }
                         Err(error) => {
@@ -2373,7 +2374,14 @@ impl Baboon {
         let Some(entry) = self.entry_for_key(key).cloned() else {
             return;
         };
+        // Fresh query — drop any expander state from a previous references popup.
+        self.ref_jump_expanded.clear();
+        self.ref_jump_occurrences.clear();
         let title = format!("References to {}", entry.display_path.replace('\\', "/"));
+        // The referenced tag's dependency path, so a clicked row can jump to the
+        // exact field that points here.
+        let ref_target = dependency_entry_reference_path(&entry, &self.names)
+            .map(|rel| (entry.group_tag, rel));
         match self.references_to_entry(&entry) {
             Some(entries) => {
                 let note = entries
@@ -2384,6 +2392,7 @@ impl Baboon {
                     entries,
                     annotations: Vec::new(),
                     note,
+                    ref_target,
                 });
             }
             None => {
@@ -2392,7 +2401,136 @@ impl Baboon {
                     entries: Vec::new(),
                     annotations: Vec::new(),
                     note: Some(self.reference_index_unavailable_note()),
+                    ref_target: None,
                 });
+            }
+        }
+    }
+
+    /// Once-per-frame driver for reference-jumps. Expires a finished glow, and —
+    /// when a pending jump's referrer tag has become the focused, parsed tab —
+    /// walks it for the exact field referencing the target and navigates there.
+    pub(super) fn apply_field_nav(&mut self, ctx: &egui::Context) {
+        let now = ctx.input(|input| input.time);
+        if let Some(nav) = &self.field_nav {
+            if now >= nav.glow_until {
+                self.field_nav = None;
+            } else {
+                // Keep frames coming so the glow expires on time even when idle.
+                ctx.request_repaint();
+            }
+        }
+        let Some(jump) = self.pending_ref_jump.clone() else {
+            return;
+        };
+        // Wait until the referrer is the focused tab and finished loading.
+        if self.selected_key.as_deref() != Some(jump.tag_key.as_str()) {
+            return;
+        }
+        let Some(doc) = self.parsed_tags.get(&jump.tag_key) else {
+            return; // still loading — retry next frame
+        };
+        let mut refs = Vec::new();
+        collect_tag_references(doc.tag.root(), "", &mut refs);
+        let target = normalize_ref(&jump.rel_path);
+        let hit = refs.into_iter().find(|reference| {
+            reference.group_tag == jump.group_tag && normalize_ref(&reference.rel_path) == target
+        });
+        self.pending_ref_jump = None;
+        match hit {
+            Some(reference) => self.navigate_to_field(ctx, &jump.tag_key, &reference.field_path),
+            None => {
+                self.status = format!(
+                    "Could not locate the referencing field in {}",
+                    jump.tag_key.replace('\\', "/")
+                );
+            }
+        }
+    }
+
+    /// Drive the editor to reveal `field_path` in the tag `tag_key`: select the
+    /// element index at every ancestor block, scroll the exact leaf into view,
+    /// and glow it briefly. Element selection and scroll targets are written once
+    /// via egui temp-data; the glow/force-open persist via `self.field_nav`.
+    pub(super) fn navigate_to_field(
+        &mut self,
+        ctx: &egui::Context,
+        tag_key: &str,
+        field_path: &str,
+    ) {
+        // Select the referenced element at each ancestor block level. The block's
+        // selection is keyed by view-scope; write both so it lands whether the tab
+        // is docked or floating.
+        for (block_path, index) in ancestor_block_indices(field_path) {
+            for scope in ["docked", "floating"] {
+                let id = egui::Id::new(("field_edit", scope, tag_key, ("block_sel", block_path.as_str())));
+                ctx.data_mut(|data| data.insert_temp(id, index));
+            }
+        }
+        // Scroll the exact leaf field into view next frame, plus the enclosing
+        // block header as a fallback for non-value leaves.
+        ctx.data_mut(|data| data.insert_temp(field_jump_target_id(), field_path.to_owned()));
+        if let Some(block) = parent_block_path(field_path) {
+            ctx.data_mut(|data| data.insert_temp(jump_target_id(), block));
+        }
+        self.field_nav = Some(FieldNav {
+            tag_key: tag_key.to_owned(),
+            field_path: field_path.to_owned(),
+            glow_until: ctx.input(|input| input.time) + 2.5,
+        });
+        ctx.request_repaint();
+    }
+
+    /// Populate `ref_jump_occurrences` for any expanded, uncached referrer row in
+    /// the current "References to X" popup. Parsed referrers are walked in place;
+    /// unparsed ones trigger a background load and stay uncached ("loading…").
+    pub(super) fn refresh_ref_jump_occurrences(&mut self, ctx: &egui::Context) {
+        let Some((group_tag, rel_path)) = self
+            .query_results
+            .as_ref()
+            .and_then(|results| results.ref_target.clone())
+        else {
+            return;
+        };
+        // Snapshot (row, key) for expanded-but-uncached rows before borrowing
+        // `parsed_tags` / triggering loads.
+        let pending: Vec<(usize, String)> = self
+            .query_results
+            .as_ref()
+            .map(|results| {
+                self.ref_jump_expanded
+                    .iter()
+                    .filter(|index| !self.ref_jump_occurrences.contains_key(index))
+                    .filter_map(|&index| {
+                        results
+                            .entries
+                            .get(index)
+                            .map(|entry| (index, entry.key.clone()))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let target = normalize_ref(&rel_path);
+        for (index, key) in pending {
+            match self.parsed_tags.get(&key) {
+                Some(doc) => {
+                    let mut refs = Vec::new();
+                    collect_tag_references(doc.tag.root(), "", &mut refs);
+                    let occurrences = refs
+                        .into_iter()
+                        .filter(|reference| {
+                            reference.group_tag == group_tag
+                                && normalize_ref(&reference.rel_path) == target
+                        })
+                        .map(|reference| RefOccurrence {
+                            label: occurrence_label(&reference.field_path),
+                            field_path: reference.field_path,
+                        })
+                        .collect();
+                    self.ref_jump_occurrences.insert(index, occurrences);
+                }
+                None => self.ensure_tag_loading(key.clone(), ctx.clone()),
             }
         }
     }
@@ -2421,6 +2559,7 @@ impl Baboon {
                     entries,
                     annotations: Vec::new(),
                     note,
+                    ref_target: None,
                 });
             }
             None => {
@@ -2429,6 +2568,7 @@ impl Baboon {
                     entries: Vec::new(),
                     annotations: Vec::new(),
                     note: Some(self.reference_index_unavailable_note()),
+                    ref_target: None,
                 });
             }
         }
@@ -2444,6 +2584,7 @@ impl Baboon {
                 entries: Vec::new(),
                 annotations: Vec::new(),
                 note: Some("No source loaded.".to_owned()),
+                ref_target: None,
             });
             return;
         };
@@ -2480,6 +2621,7 @@ impl Baboon {
             entries,
             annotations,
             note,
+            ref_target: None,
         });
     }
 
@@ -2520,6 +2662,7 @@ impl Baboon {
                 entries: Vec::new(),
                 annotations: Vec::new(),
                 note: Some("No source loaded.".to_owned()),
+                ref_target: None,
             });
             return;
         };
@@ -2557,6 +2700,7 @@ impl Baboon {
             entries,
             annotations,
             note,
+            ref_target: None,
         });
     }
 
@@ -2570,6 +2714,7 @@ impl Baboon {
                 entries: Vec::new(),
                 annotations: Vec::new(),
                 note: Some("No source loaded.".to_owned()),
+                ref_target: None,
             });
             return;
         };
@@ -2591,6 +2736,7 @@ impl Baboon {
             entries,
             annotations,
             note,
+            ref_target: None,
         });
     }
 
@@ -2654,6 +2800,7 @@ impl Baboon {
                 entries,
                 annotations,
                 note,
+                ref_target: None,
             });
             return;
         }
@@ -2918,6 +3065,7 @@ impl Baboon {
             entries,
             annotations: Vec::new(),
             note,
+            ref_target: None,
         });
     }
 
@@ -3022,11 +3170,10 @@ impl Baboon {
             show_browser_prefixes: self.show_browser_prefixes,
             folders_before_tags: self.folders_before_tags,
             double_click_to_open_tags: self.double_click_to_open_tags,
-            auto_restore_last_session: self.auto_restore_last_session,
+            session_restore: self.session_restore,
             show_block_sizes: self.show_block_sizes,
             scroll_to_cycle_dropdowns: self.scroll_to_cycle_dropdowns,
             expert_mode: self.expert_mode,
-            field_search_passive: self.field_search_passive,
             dark_mode: self.dark_mode,
             ui_scale: self.ui_scale,
             model_preview_size: self.model_preview_size,
@@ -3447,14 +3594,21 @@ impl Baboon {
                 self.last_opened_windows = None;
                 self.settings_open = true;
             }
-            LastOpenedWindowsAction::Cancel => {
+            LastOpenedWindowsAction::Cancel { remember } => {
+                if remember {
+                    self.session_restore = SessionRestore::Never;
+                }
                 self.last_opened_windows = None;
             }
             LastOpenedWindowsAction::Restore {
                 source_kind,
                 source_path,
                 tags,
+                remember,
             } => {
+                if remember {
+                    self.session_restore = SessionRestore::Always;
+                }
                 self.last_opened_windows = None;
                 self.begin_last_session_restore(source_kind, source_path, tags, ctx.clone());
             }
@@ -3534,7 +3688,6 @@ impl Baboon {
                     let field_filter = compute_pending_field_filter(
                         &doc.tag,
                         supports_field_search,
-                        self.field_search_passive,
                         &key,
                         &self.field_search,
                         &mut self.field_search_applied,
@@ -3600,6 +3753,7 @@ impl Baboon {
                         block_clipboard: self.block_clipboard.as_ref(),
                         block_clip_request: &mut block_clip_request,
                         field_filter: field_filter.as_ref(),
+                        field_nav: self.field_nav.as_ref(),
                     };
                     if is_bitmap_tag(&entry) {
                         let preview = self.bitmap_previews.entry(key.clone()).or_default();
@@ -3843,8 +3997,13 @@ enum LastOpenedWindowsAction {
         source_kind: LastSessionSourceKind,
         source_path: PathBuf,
         tags: Vec<LastSessionTag>,
+        /// "Don't ask again" was ticked — remember this as `Always`.
+        remember: bool,
     },
-    Cancel,
+    Cancel {
+        /// "Don't ask again" was ticked — remember this as `Never`.
+        remember: bool,
+    },
 }
 
 fn render_last_opened_windows_prompt(
@@ -3895,6 +4054,12 @@ fn render_last_opened_windows_prompt(
                 }
             });
             ui.add_space(6.0);
+            ui.checkbox(&mut prompt.dont_ask_again, "Don't ask again")
+                .on_hover_text(
+                    "Remember this choice: OK always reopens the last session, \
+                     Cancel never does. Change it later in File > Settings.",
+                );
+            ui.add_space(4.0);
             ui.horizontal_wrapped(|ui| {
                 ui.label(
                     RichText::new("Options for this window available in")
@@ -3911,7 +4076,9 @@ fn render_last_opened_windows_prompt(
                     .add(egui::Button::new("Cancel").min_size(Vec2::new(78.0, 24.0)))
                     .clicked()
                 {
-                    action = LastOpenedWindowsAction::Cancel;
+                    action = LastOpenedWindowsAction::Cancel {
+                        remember: prompt.dont_ask_again,
+                    };
                 }
                 if ui
                     .add(egui::Button::new("OK").min_size(Vec2::new(78.0, 24.0)))
@@ -3922,6 +4089,7 @@ fn render_last_opened_windows_prompt(
                         source_kind: prompt.source_kind,
                         source_path: prompt.source_path.clone(),
                         tags,
+                        remember: prompt.dont_ask_again,
                     };
                 }
             });
@@ -4259,6 +4427,46 @@ pub(super) fn open_terminal_log(path: &Path) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ancestor_block_indices_splits_indexed_path() {
+        // Nested blocks: each pair's path is the drawn `path_prefix` (parent
+        // indices kept, own index dropped).
+        assert_eq!(
+            ancestor_block_indices("custom references[3]/sounds[1]/melee sound"),
+            vec![
+                ("custom references".to_owned(), 3),
+                ("custom references[3]/sounds".to_owned(), 1),
+            ],
+        );
+        // A plain struct segment between blocks carries no selection.
+        assert_eq!(
+            ancestor_block_indices("weapon[2]/melee/damage sound"),
+            vec![("weapon".to_owned(), 2)],
+        );
+        // A top-level (unindexed) reference field has no ancestor blocks.
+        assert_eq!(
+            ancestor_block_indices("havok cleanup resources"),
+            Vec::<(String, usize)>::new(),
+        );
+    }
+
+    #[test]
+    fn occurrence_label_keeps_indices_and_cleans_names() {
+        assert_eq!(
+            occurrence_label("custom references[3]/melee sound"),
+            "custom references[3] › melee sound",
+        );
+        assert_eq!(occurrence_label("havok cleanup resources"), "havok cleanup resources");
+    }
+
+    #[test]
+    fn normalize_ref_matches_dependency_key_form() {
+        assert_eq!(
+            normalize_ref("Sound/Materials/Hard/Human_Weap_Melee"),
+            normalize_ref("sound\\materials\\hard\\human_weap_melee"),
+        );
+    }
 
     fn collect_terminal_output(input: &[u8]) -> Vec<(&'static str, String)> {
         let (tx, rx) = std::sync::mpsc::channel();
@@ -5049,6 +5257,57 @@ fn fix_tag_dependencies_in_tag(
 
     report.lines.push(report.status());
     report
+}
+
+/// Canonical form of a dependency reference path for comparison: backslash
+/// separators, lowercased. Mirrors [`dependency_key`]'s normalization so a
+/// target path and a `collect_tag_references` hit compare equal.
+fn normalize_ref(rel_path: &str) -> String {
+    rel_path.replace('/', "\\").to_ascii_lowercase()
+}
+
+/// Break an indexed field path into the `(block_path, element_index)` pairs for
+/// every block/array element on the way to the leaf, so each can be selected.
+/// e.g. `custom references[3]/sounds[1]/melee sound`
+///   → `[("custom references", 3), ("custom references[3]/sounds", 1)]`.
+/// The `block_path` for each pair is exactly the `path_prefix` that block is
+/// drawn with (parent indices included, its own index excluded).
+fn ancestor_block_indices(field_path: &str) -> Vec<(String, usize)> {
+    let mut out = Vec::new();
+    let mut acc = String::new();
+    for segment in field_path.split('/') {
+        let (name, index) = match segment.strip_suffix(']').and_then(|s| s.rsplit_once('[')) {
+            Some((name, idx)) => (name, idx.parse::<usize>().ok()),
+            None => (segment, None),
+        };
+        let node_path = if acc.is_empty() {
+            name.to_owned()
+        } else {
+            format!("{acc}/{name}")
+        };
+        match index {
+            Some(index) => {
+                out.push((node_path.clone(), index));
+                acc = format!("{node_path}[{index}]");
+            }
+            None => acc = node_path,
+        }
+    }
+    out
+}
+
+/// Human breadcrumb for a reference occurrence, keeping element indices so
+/// sibling elements are distinguishable:
+/// `custom references[3]/melee sound` → `custom references[3] › melee sound`.
+fn occurrence_label(field_path: &str) -> String {
+    field_path
+        .split('/')
+        .map(|segment| match segment.split_once('[') {
+            Some((name, rest)) => format!("{}[{rest}", clean_field_name(name)),
+            None => clean_field_name(segment).to_string(),
+        })
+        .collect::<Vec<_>>()
+        .join(" › ")
 }
 
 fn collect_tag_references(

--- a/src/app/foundation.rs
+++ b/src/app/foundation.rs
@@ -17,14 +17,12 @@ pub(super) fn strip_node_indices(path: &str) -> String {
     out
 }
 
-/// Whether a tag offers the "Search fields" box. Shader/material tags use the
-/// dedicated grid surface and sound tags have no meaningful block tree, so they
-/// are excluded.
+/// Whether a tag offers the "Search fields" box. Shader/material tags are
+/// excluded because they use the dedicated grid surface rather than the block
+/// tree; every other tag (including sound tags, which have a full field tree
+/// below their audition surface) supports it.
 pub(super) fn supports_field_search(entry: &TagEntry) -> bool {
-    !(is_material_tag(entry)
-        || is_material_shader_tag(entry)
-        || is_shader_tag(entry)
-        || &entry.group_tag.to_be_bytes() == b"snd!")
+    !(is_material_tag(entry) || is_material_shader_tag(entry) || is_shader_tag(entry))
 }
 
 /// Resolve the field-filter action to apply *this* frame. Returns `Some` only
@@ -34,7 +32,6 @@ pub(super) fn supports_field_search(entry: &TagEntry) -> bool {
 pub(super) fn compute_pending_field_filter(
     tag: &TagFile,
     supports: bool,
-    passive: bool,
     tag_key: &str,
     field_search: &HashMap<String, String>,
     field_search_applied: &mut HashMap<String, String>,
@@ -52,49 +49,36 @@ pub(super) fn compute_pending_field_filter(
             .remove(tag_key)
             .map(|_| FieldFilterAction::RestoreDefaults);
     }
-    if passive {
-        // Passive mode highlights + keeps matches open every frame (it never
-        // collapses), so re-apply continuously rather than one-shot.
-        field_search_applied.insert(tag_key.to_owned(), query.clone());
-        return Some(FieldFilterAction::Apply(compute_field_filter(
-            tag, &query, true,
-        )));
-    }
-    if field_search_applied.get(tag_key).map(String::as_str) == Some(query.as_str()) {
-        // Already applied; leave the user's manual expand/collapse intact.
-        return None;
-    }
+    // Apply every frame while a query is present. Hiding non-matches is a
+    // per-frame render decision (not a one-shot collapse), so the filter must
+    // stay live.
     field_search_applied.insert(tag_key.to_owned(), query.clone());
-    Some(FieldFilterAction::Apply(compute_field_filter(
-        tag, &query, false,
-    )))
+    Some(FieldFilterAction::Apply(compute_field_filter(tag, &query)))
 }
 
 /// Build the set of collapsible nodes to open for a "Search fields" query:
 /// every struct / block / array whose (display) name contains `query`, plus
 /// all of their ancestor nodes, plus the ancestors of any matching leaf field.
 /// `query` must already be lowercased and non-empty.
-pub(super) fn compute_field_filter(tag: &TagFile, query: &str, passive: bool) -> FieldFilter {
-    let mut open_paths = std::collections::HashSet::new();
-    let mut highlight_paths = std::collections::HashSet::new();
-    collect_open_paths(tag.root(), "", query, &mut open_paths, &mut highlight_paths);
-    FieldFilter {
-        open_paths,
-        highlight_paths,
-        passive,
-    }
+pub(super) fn compute_field_filter(tag: &TagFile, query: &str) -> FieldFilter {
+    let mut visible_paths = std::collections::HashSet::new();
+    collect_visible_paths(tag.root(), "", query, false, &mut visible_paths);
+    FieldFilter { visible_paths }
 }
 
-/// Returns whether `tag_struct` (or anything beneath it) matched, so the
-/// caller can mark the containing node open. Records every node on a match path
-/// in `open_paths`, and every field (leaf or node) whose own name matched in
-/// `highlight_paths`.
-fn collect_open_paths(
+/// Records, in `visible_paths`, every field that should render while searching:
+/// a name match, an ancestor container of a match, or anything inside a
+/// name-matched container. Anything else is omitted, so a container with no
+/// match beneath it is hidden entirely. Returns whether this subtree had a
+/// match, so the caller can mark itself an ancestor-of-match.
+fn collect_visible_paths(
     tag_struct: TagStruct<'_>,
     canon_prefix: &str,
     query: &str,
-    open_paths: &mut std::collections::HashSet<String>,
-    highlight_paths: &mut std::collections::HashSet<String>,
+    // True when an ancestor container's *own name* matched — its whole subtree is
+    // part of that match, so everything under it stays visible.
+    under_matched: bool,
+    visible_paths: &mut std::collections::HashSet<String>,
 ) -> bool {
     let mut any = false;
     for field in tag_struct.fields() {
@@ -108,31 +92,28 @@ fn collect_open_paths(
             format!("{canon_prefix}/{}", field.name())
         };
 
-        if name_matches {
-            highlight_paths.insert(canon.clone());
-        }
-
+        let child_under = under_matched || name_matches;
         let child_matched = if let Some(nested) = field.as_struct() {
-            collect_open_paths(nested, &canon, query, open_paths, highlight_paths)
+            collect_visible_paths(nested, &canon, query, child_under, visible_paths)
         } else if let Some(block) = field.as_block() {
             block
                 .element(0)
-                .map(|el| collect_open_paths(el, &canon, query, open_paths, highlight_paths))
+                .map(|el| collect_visible_paths(el, &canon, query, child_under, visible_paths))
                 .unwrap_or(false)
         } else if let Some(array) = field.as_array() {
             array
                 .element(0)
-                .map(|el| collect_open_paths(el, &canon, query, open_paths, highlight_paths))
+                .map(|el| collect_visible_paths(el, &canon, query, child_under, visible_paths))
                 .unwrap_or(false)
         } else {
-            // Leaf field: a name match opens its ancestors but adds no node.
             false
         };
 
-        let is_node =
-            field.as_struct().is_some() || field.as_block().is_some() || field.as_array().is_some();
-        if is_node && (name_matches || child_matched) {
-            open_paths.insert(canon);
+        // A field renders only if it matched, is an ancestor of a match, or lives
+        // inside a name-matched container. A container with no match anywhere
+        // beneath it never enters the set, so it is hidden entirely.
+        if name_matches || child_matched || under_matched {
+            visible_paths.insert(canon);
         }
         any |= name_matches || child_matched;
     }
@@ -162,7 +143,9 @@ pub(super) fn draw_struct_fields(
     draw_foundation_group(
         ui,
         title,
-        ("struct", path_prefix, depth),
+        // Index-stripped so the struct's open state survives paging through a
+        // parent block/array's element indices (see `strip_node_indices`).
+        ("struct", strip_node_indices(path_prefix), depth),
         depth,
         depth <= 1,
         open_override,
@@ -200,7 +183,7 @@ pub(super) fn draw_inherited_object_fields(
         draw_foundation_group(
             ui,
             title,
-            ("inherited_struct", path_prefix.as_str()),
+            ("inherited_struct", strip_node_indices(path_prefix)),
             0,
             true,
             open_override,
@@ -277,6 +260,9 @@ pub(super) fn draw_fields_with_docs(
     let entries: &[DefEntry] = edit.docs.map(|docs| docs.entries_for(&guid)).unwrap_or(&[]);
     let parent_raw = tag_struct.raw();
     let reference_value_width = shared_tag_reference_value_width(ui, depth);
+    // In active filter mode, injected explanation/section headers are suppressed
+    // so a filtered view shows only matches and their containers (no orphans).
+    let show_explanations = !edit.is_active_filter();
     let mut cursor = 0usize;
     for field in tag_struct.fields_all() {
         if skip_field == Some(field.name()) {
@@ -292,13 +278,15 @@ pub(super) fn draw_fields_with_docs(
             }) {
                 for (offset, entry) in entries[cursor..match_idx].iter().enumerate() {
                     if let DefEntry::Explanation { title, body } = entry {
-                        draw_foundation_explanation_row(
-                            ui,
-                            title,
-                            Some(body),
-                            depth,
-                            (path_prefix, cursor + offset),
-                        );
+                        if show_explanations {
+                            draw_foundation_explanation_row(
+                                ui,
+                                title,
+                                Some(body),
+                                depth,
+                                (path_prefix, cursor + offset),
+                            );
+                        }
                     }
                 }
                 if let DefEntry::Field {
@@ -352,13 +340,15 @@ pub(super) fn draw_fields_with_docs(
     // Any explanations after the last matched field.
     for (offset, entry) in entries[cursor..].iter().enumerate() {
         if let DefEntry::Explanation { title, body } = entry {
-            draw_foundation_explanation_row(
-                ui,
-                title,
-                Some(body),
-                depth,
-                (path_prefix, cursor + offset),
-            );
+            if show_explanations {
+                draw_foundation_explanation_row(
+                    ui,
+                    title,
+                    Some(body),
+                    depth,
+                    (path_prefix, cursor + offset),
+                );
+            }
         }
     }
 }
@@ -378,6 +368,11 @@ pub(super) fn draw_field(
     tag_reference_value_width: f32,
 ) {
     let field_path = append_field_path(path_prefix, field.name());
+    // Active (filter) field-search: hide everything that isn't a match, an
+    // ancestor container of one, or inside a name-matched container.
+    if !edit.field_visible(&field_path) {
+        return;
+    }
     // `meta_override` carries help/units recovered from the JSON definition
     // (shipped tags strip them); fall back to parsing the tag's own field name.
     let meta = meta_override.unwrap_or_else(|| field_display_meta(field.name()));
@@ -410,12 +405,21 @@ pub(super) fn draw_field(
         }
         _ => {}
     }
-    // Passive field-search: tint rows whose name matched the query.
-    let highlight = edit.field_highlighted(&field_path);
-    let highlight_fill = egui::Color32::from_rgba_unmultiplied(255, 214, 0, 38);
+    // Reference-jump glow/scroll: pulse and scroll to the field a "References to"
+    // jump landed on. The input clock and temp-data are only touched while a nav
+    // is actually in flight.
+    let glow = edit
+        .field_nav
+        .is_some_and(|_| edit.field_nav_glow(&field_path, ui.input(|i| i.time)));
+    let scroll_here = edit.field_nav.is_some()
+        && ui
+            .data(|d| d.get_temp::<String>(field_jump_target_id()))
+            .as_deref()
+            == Some(field_path.as_str());
+    let glow_fill = egui::Color32::from_rgba_unmultiplied(255, 214, 0, 38);
     if let Some(function) = field.as_function() {
-        if highlight {
-            egui::Frame::none().fill(highlight_fill).show(ui, |ui| {
+        if glow {
+            egui::Frame::none().fill(glow_fill).show(ui, |ui| {
                 draw_foundation_function_row(ui, &meta, &function, depth, &field_path, edit);
             });
         } else {
@@ -427,8 +431,13 @@ pub(super) fn draw_field(
         if is_hidden_non_expert_value(&value, expert_mode) {
             return;
         }
-        if highlight {
-            egui::Frame::none().fill(highlight_fill).show(ui, |ui| {
+        if glow || scroll_here {
+            let fill = if glow {
+                glow_fill
+            } else {
+                egui::Color32::TRANSPARENT
+            };
+            let framed = egui::Frame::none().fill(fill).show(ui, |ui| {
                 draw_foundation_value_row(
                     ui,
                     field,
@@ -444,6 +453,11 @@ pub(super) fn draw_field(
                     tag_reference_value_width,
                 );
             });
+            if scroll_here {
+                ui.scroll_to_rect(framed.response.rect, Some(egui::Align::Center));
+                ui.data_mut(|d| d.remove::<String>(field_jump_target_id()));
+                ui.ctx().request_repaint();
+            }
         } else {
             draw_foundation_value_row(
                 ui,
@@ -477,12 +491,16 @@ pub(super) fn draw_field(
             );
             return;
         }
-        let nested_default_open = depth == 0 || is_priority_section(field.name());
+        // A struct is a single fixed sub-structure (not a paginated collection
+        // like a block/array), so show it expanded by default — matching
+        // Foundation/Guerilla. The user can still collapse it, and that choice
+        // persists (collapse state is keyed index-free; see `strip_node_indices`).
+        let nested_default_open = true;
         let open_override = edit.resolve_open(&field_path, nested_default_open);
         draw_foundation_group(
             ui,
             visible_container_title(field.name(), path_prefix),
-            ("field_struct", &field_path),
+            ("field_struct", strip_node_indices(&field_path)),
             depth + 1,
             nested_default_open,
             open_override,
@@ -1336,7 +1354,7 @@ pub(super) fn draw_foundation_array(
 /// The parent block/array path for a block path, for "jump to parent". Strips
 /// the last `/segment` and a trailing element index, e.g.
 /// `regions[0]/permutations` → `regions`. `None` for a top-level block.
-fn parent_block_path(path: &str) -> Option<String> {
+pub(super) fn parent_block_path(path: &str) -> Option<String> {
     let cut = path.rfind('/')?;
     let mut parent = path[..cut].to_string();
     if parent.ends_with(']') {
@@ -1359,8 +1377,15 @@ fn breadcrumb_for_path(path: &str) -> String {
 
 /// egui-memory key holding the block path that a pending "jump to parent" should
 /// scroll into view on the next frame.
-fn jump_target_id() -> egui::Id {
+pub(super) fn jump_target_id() -> egui::Id {
     egui::Id::new("foundation_jump_to_block")
+}
+
+/// egui-memory key holding the exact (indexed) field path that a pending
+/// reference-jump should scroll into view and pulse on the next frame. Consumed
+/// by [`draw_field`] when it draws the matching leaf.
+pub(super) fn field_jump_target_id() -> egui::Id {
+    egui::Id::new("foundation_jump_to_field")
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1390,11 +1415,16 @@ pub(super) fn draw_foundation_block_control(
     add_contents: impl FnOnce(&mut Ui),
 ) -> BlockHeaderActions {
     let mut actions = BlockHeaderActions::default();
+    // Key collapse state on the index-stripped path so a nested block/array
+    // stays open/closed as the user pages through a parent element's indices
+    // (matching resolve_open / search-highlight, which also ignore indices).
+    // `path_salt` keeps its indexed form for the jump-to-block scroll below.
+    let canonical_path = strip_node_indices(path_salt);
     let id = ui.make_persistent_id((
         "foundation_block_control",
         view_scope,
         tag_key,
-        path_salt,
+        canonical_path.as_str(),
         depth,
         name,
     ));
@@ -1696,24 +1726,11 @@ pub(super) fn draw_foundation_block_control(
                 top: 8.0,
                 bottom: 8.0,
             })
-            .show(ui, |ui| {
-                if depth > 0 {
-                    egui::ScrollArea::vertical()
-                        .id_salt((
-                            "foundation_block_body",
-                            view_scope,
-                            tag_key,
-                            path_salt,
-                            depth,
-                        ))
-                        .max_height(420.0)
-                        .min_scrolled_height(160.0)
-                        .auto_shrink([false, false])
-                        .show(ui, add_contents);
-                } else {
-                    add_contents(ui);
-                }
-            });
+            // Render the body inline — no nested ScrollArea. The single outer
+            // ScrollArea in `draw_tag_fields_scroll` owns all scrolling, so a
+            // block element expands to its full height instead of growing an
+            // inner scrollbar (which also let cross-boundary scroll-to fail).
+            .show(ui, add_contents);
     });
 
     actions
@@ -4036,6 +4053,7 @@ mod tests {
             tsv_paste_request: &mut tsv_paste_request,
             block_clip_request: &mut block_clip_request,
             field_filter: None,
+            field_nav: None,
         };
         assertion(&edit);
     }

--- a/src/app/prefs.rs
+++ b/src/app/prefs.rs
@@ -87,10 +87,17 @@ pub(super) fn load_gui_prefs() -> GuiPrefs {
             .get("double_click_to_open_tags")
             .and_then(Value::as_bool)
             .unwrap_or(false),
-        auto_restore_last_session: value
-            .get("auto_restore_last_session")
-            .and_then(Value::as_bool)
-            .unwrap_or(false),
+        session_restore: value
+            .get("session_restore")
+            .and_then(Value::as_str)
+            .and_then(SessionRestore::from_str)
+            .unwrap_or_else(|| {
+                // Migrate the old boolean: true → Always, absent/false → Ask.
+                match value.get("auto_restore_last_session").and_then(Value::as_bool) {
+                    Some(true) => SessionRestore::Always,
+                    _ => SessionRestore::Ask,
+                }
+            }),
         show_block_sizes: value
             .get("show_block_sizes")
             .and_then(Value::as_bool)
@@ -101,10 +108,6 @@ pub(super) fn load_gui_prefs() -> GuiPrefs {
             .unwrap_or(true),
         expert_mode: value
             .get("expert_mode")
-            .and_then(Value::as_bool)
-            .unwrap_or(false),
-        field_search_passive: value
-            .get("field_search_passive")
             .and_then(Value::as_bool)
             .unwrap_or(false),
         dark_mode: value
@@ -303,11 +306,10 @@ pub(super) fn save_gui_prefs(
         "show_browser_prefixes": prefs.show_browser_prefixes,
         "folders_before_tags": prefs.folders_before_tags,
         "double_click_to_open_tags": prefs.double_click_to_open_tags,
-        "auto_restore_last_session": prefs.auto_restore_last_session,
+        "session_restore": prefs.session_restore.as_str(),
         "show_block_sizes": prefs.show_block_sizes,
         "scroll_to_cycle_dropdowns": prefs.scroll_to_cycle_dropdowns,
         "expert_mode": prefs.expert_mode,
-        "field_search_passive": prefs.field_search_passive,
         "dark_mode": prefs.dark_mode,
         "ui_scale": prefs.ui_scale,
         "model_preview_size": prefs.model_preview_size,

--- a/src/app/shader.rs
+++ b/src/app/shader.rs
@@ -5378,6 +5378,7 @@ pub(super) fn draw_shader_grid_row_readonly(
         tsv_paste_request: &mut tsv_paste_request,
         block_clip_request: &mut block_clip_request,
         field_filter: None,
+        field_nav: None,
     };
     draw_shader_grid_row(ui, row, depth, color_popup, function_popup, &mut ctx);
 }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -203,6 +203,39 @@ pub(super) struct TagQueryResults {
     pub(super) annotations: Vec<String>,
     /// Optional explanatory note (e.g. when the reference index is unavailable).
     pub(super) note: Option<String>,
+    /// For a "References to X" query: the referenced tag's `(group_tag, rel_path)`
+    /// so a clicked row can jump to the exact referencing field. `None` for other
+    /// query kinds (unreferenced, map-id, …), which only open the tag.
+    pub(super) ref_target: Option<(u32, String)>,
+}
+
+/// One place a referrer tag points at the "References to X" target, shown in the
+/// popup's per-referrer expander. `field_path` is the exact indexed path handed
+/// to `navigate_to_field`; `label` is its human breadcrumb.
+pub(super) struct RefOccurrence {
+    pub(super) field_path: String,
+    pub(super) label: String,
+}
+
+/// A reference-jump awaiting its referrer tag to finish loading. Once that tag
+/// is the focused tab and parsed, the controller walks it for the exact field
+/// referencing `(group_tag, rel_path)` and hands off to a [`FieldNav`].
+#[derive(Clone)]
+pub(super) struct PendingRefJump {
+    pub(super) tag_key: String,
+    pub(super) group_tag: u32,
+    pub(super) rel_path: String,
+}
+
+/// Active "jump to a referencing field" navigation: force the target field's
+/// ancestor blocks open and glow the field until `glow_until` (egui time,
+/// seconds). Element selection along the path and the scroll target are set once
+/// via egui temp-data when the nav is created.
+pub(super) struct FieldNav {
+    pub(super) tag_key: String,
+    /// Exact indexed field path, e.g. `custom references[3]/sounds[1]/melee sound`.
+    pub(super) field_path: String,
+    pub(super) glow_until: f64,
 }
 
 /// Drag-and-drop payload carried when dragging a tag from the browser onto a
@@ -287,6 +320,36 @@ pub(super) enum SettingsTab {
     Tools,
 }
 
+/// What Baboon does with the previous session's open windows on startup.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(super) enum SessionRestore {
+    /// Ask which windows to reopen (shows the "Last Opened Windows" prompt).
+    Ask,
+    /// Silently reopen the last session.
+    Always,
+    /// Start fresh — never reopen and never ask.
+    Never,
+}
+
+impl SessionRestore {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            SessionRestore::Ask => "ask",
+            SessionRestore::Always => "always",
+            SessionRestore::Never => "never",
+        }
+    }
+
+    pub(super) fn from_str(value: &str) -> Option<Self> {
+        match value {
+            "ask" => Some(SessionRestore::Ask),
+            "always" => Some(SessionRestore::Always),
+            "never" => Some(SessionRestore::Never),
+            _ => None,
+        }
+    }
+}
+
 /// Memoized search results for the tag browser.
 ///
 /// Filtering the full tag set (100k+ entries) and lowercasing each name is far
@@ -357,7 +420,7 @@ pub(super) struct GuiPrefs {
     pub(super) show_browser_prefixes: bool,
     pub(super) folders_before_tags: bool,
     pub(super) double_click_to_open_tags: bool,
-    pub(super) auto_restore_last_session: bool,
+    pub(super) session_restore: SessionRestore,
     pub(super) show_block_sizes: bool,
     pub(super) scroll_to_cycle_dropdowns: bool,
     pub(super) expert_mode: bool,
@@ -365,8 +428,6 @@ pub(super) struct GuiPrefs {
     pub(super) ui_scale: f32,
     pub(super) model_preview_size: f32,
     pub(super) blender_path: Option<PathBuf>,
-    /// Field search: passive (highlight matches) vs active (collapse to matches).
-    pub(super) field_search_passive: bool,
     pub(super) ek_folder_aliases: Vec<EkFolderAlias>,
     pub(super) tool_commands_window_pos: Option<egui::Pos2>,
     pub(super) tool_commands_window_size: Option<Vec2>,
@@ -489,6 +550,8 @@ pub(super) struct LastOpenedWindowsPrompt {
     pub(super) source_path: PathBuf,
     pub(super) source_available: bool,
     pub(super) entries: Vec<LastOpenedWindowEntry>,
+    /// "Don't ask again": on OK, remember as Always; on Cancel, as Never.
+    pub(super) dont_ask_again: bool,
 }
 
 impl LastOpenedWindowsPrompt {
@@ -530,6 +593,7 @@ impl LastOpenedWindowsPrompt {
             source_path: session.source_path,
             source_available,
             entries,
+            dont_ask_again: false,
         })
     }
 
@@ -881,6 +945,9 @@ pub(super) struct FieldEditContext<'a> {
     /// rest closed, or restored to defaults when the query is cleared), then
     /// later frames leave `None` so the user can expand/collapse freely again.
     pub(super) field_filter: Option<&'a FieldFilterAction>,
+    /// Active reference-jump navigation. When set for this tag, its target
+    /// field's ancestor blocks are force-opened and the field is glowed.
+    pub(super) field_nav: Option<&'a FieldNav>,
 }
 
 impl FieldEditContext<'_> {
@@ -893,42 +960,82 @@ impl FieldEditContext<'_> {
     /// stored state alone" (no filter applied this frame); `Some(open)` forces
     /// it this frame.
     pub(super) fn resolve_open(&self, node_path: &str, default_open: bool) -> Option<bool> {
+        // A reference-jump forces every ancestor of its target field open so the
+        // field can be scrolled into view. Takes precedence over the search filter.
+        if let Some(nav) = self.field_nav {
+            if nav.tag_key == self.tag_key
+                && path_is_ancestor(
+                    &strip_node_indices(node_path),
+                    &strip_node_indices(&nav.field_path),
+                )
+            {
+                return Some(true);
+            }
+        }
         match self.field_filter? {
             // Query cleared: snap every node back to its normal default.
             FieldFilterAction::RestoreDefaults => Some(default_open),
             FieldFilterAction::Apply(filter) => {
                 let canon = strip_node_indices(node_path);
-                // The implicit root group has no path — always keep it visible
-                // so the matched nodes inside it can be reached.
-                if canon.is_empty() || filter.open_paths.contains(&canon) {
+                // Every rendered container is on a match path (others are hidden
+                // by `field_visible`), so expand it to reveal the match in
+                // context. The implicit root group has no path — always open.
+                if canon.is_empty() || filter.visible_paths.contains(&canon) {
                     Some(true)
-                } else if filter.passive {
-                    // Passive (highlight) mode: open matches' ancestors but leave
-                    // everything else as the user left it — never force-collapse.
-                    None
                 } else {
-                    // Active mode: collapse everything that isn't on a match path.
                     Some(false)
                 }
             }
         }
     }
 
-    /// Whether `path`'s field should be highlighted as a search match. Only true
-    /// in passive (highlight) mode for fields whose own name matched the query.
-    pub(super) fn field_highlighted(&self, path: &str) -> bool {
-        matches!(
-            self.field_filter,
-            Some(FieldFilterAction::Apply(filter)) if filter.passive
-                && filter.highlight_paths.contains(&strip_node_indices(path))
-        )
+    /// Whether a "Search fields" filter is applied this frame — i.e. the editor
+    /// is hiding non-matches. Used to also suppress injected section/explanation
+    /// rows so no orphan headers remain.
+    pub(super) fn is_active_filter(&self) -> bool {
+        matches!(self.field_filter, Some(FieldFilterAction::Apply(_)))
     }
+
+    /// Whether `path`'s field should render at all. While a query is active only
+    /// matches, their ancestor containers, and name-matched containers' contents
+    /// are shown; everything else is hidden. Always visible with no query.
+    pub(super) fn field_visible(&self, path: &str) -> bool {
+        match self.field_filter {
+            Some(FieldFilterAction::Apply(filter)) => {
+                filter.visible_paths.contains(&strip_node_indices(path))
+            }
+            _ => true,
+        }
+    }
+
+    /// Whether the exact `indexed_path` field is the live reference-jump target
+    /// and still within its glow window — used to pulse the landed-on field.
+    pub(super) fn field_nav_glow(&self, indexed_path: &str, now: f64) -> bool {
+        self.field_nav.is_some_and(|nav| {
+            nav.tag_key == self.tag_key && nav.field_path == indexed_path && now < nav.glow_until
+        })
+    }
+}
+
+/// Whether `ancestor` is `target` itself or an ancestor of it, compared
+/// segment-wise so `"custom references"` is an ancestor of
+/// `"custom references/sounds"` but not of `"custom references extra"`. Both
+/// paths must already be index-stripped (see [`strip_node_indices`]).
+fn path_is_ancestor(ancestor: &str, target: &str) -> bool {
+    if ancestor.is_empty() {
+        return true;
+    }
+    target == ancestor
+        || (target.len() > ancestor.len()
+            && target.as_bytes()[ancestor.len()] == b'/'
+            && target.starts_with(ancestor))
 }
 
 /// What a "Search fields" change should do to the editor's collapse state on
 /// the frame it is applied.
 pub(super) enum FieldFilterAction {
-    /// Collapse to the matched nodes (+ ancestors); everything else closed.
+    /// Hide everything except matches and their ancestor containers; expand the
+    /// containers that remain.
     Apply(FieldFilter),
     /// Re-expand every node to its normal default (query was cleared).
     RestoreDefaults,
@@ -938,13 +1045,10 @@ pub(super) enum FieldFilterAction {
 /// canonical field paths with element indices (`[3]`) stripped, so they're
 /// independent of which block element happens to be selected.
 pub(super) struct FieldFilter {
-    pub(super) open_paths: std::collections::HashSet<String>,
-    /// Canonical paths of fields whose own name matched the query — tinted in
-    /// passive (highlight) mode. Empty/unused in active (collapse) mode.
-    pub(super) highlight_paths: std::collections::HashSet<String>,
-    /// Passive = highlight matches without collapsing the rest; active = collapse
-    /// to matches (the original behaviour).
-    pub(super) passive: bool,
+    /// Canonical paths of every field that should render while searching:
+    /// matches, their ancestor containers, and the contents of name-matched
+    /// containers. Fields absent from this set are hidden.
+    pub(super) visible_paths: std::collections::HashSet<String>,
 }
 
 #[derive(Clone)]
@@ -971,7 +1075,6 @@ impl Default for GuiPrefs {
             show_browser_prefixes: false,
             folders_before_tags: false,
             double_click_to_open_tags: false,
-            auto_restore_last_session: false,
             show_block_sizes: false,
             scroll_to_cycle_dropdowns: true,
             expert_mode: false,
@@ -979,7 +1082,7 @@ impl Default for GuiPrefs {
             ui_scale: DEFAULT_UI_SCALE,
             model_preview_size: DEFAULT_MODEL_PREVIEW_SIZE,
             blender_path: None,
-            field_search_passive: false,
+            session_restore: SessionRestore::Ask,
             ek_folder_aliases: Vec::new(),
             tool_commands_window_pos: None,
             tool_commands_window_size: None,

--- a/src/app/ui.rs
+++ b/src/app/ui.rs
@@ -232,12 +232,13 @@ impl Baboon {
             {
                 query.clear();
             }
-            ui.separator();
-            ui.checkbox(&mut self.field_search_passive, "Highlight")
-                .on_hover_text(
-                    "Passive: highlight matches and keep them open without \
-                     collapsing the rest. Off: collapse to matches only.",
-                );
+            ui.label(
+                RichText::new(
+                    "shows only matches and the blocks/structs that contain them",
+                )
+                .color(subtle_dark())
+                .small(),
+            );
         });
         ui.add_space(4.0);
     }
@@ -1005,12 +1006,19 @@ impl Baboon {
     }
 
     fn draw_query_results_window(&mut self, ctx: &egui::Context) {
+        // Walk any expanded-but-uncached referrer rows before we take the results
+        // (this reads `self.query_results`).
+        self.refresh_ref_jump_occurrences(ctx);
         let Some(results) = self.query_results.take() else {
             return;
         };
         let mut open = true;
         let mut to_open: Option<String> = None;
         let mut to_reveal: Option<String> = None;
+        let mut to_toggle: Vec<usize> = Vec::new();
+        let mut to_jump: Option<(String, String)> = None;
+        let expanded = &self.ref_jump_expanded;
+        let occurrences = &self.ref_jump_occurrences;
         egui::Window::new(&results.title)
             .id(egui::Id::new("tag_query_results"))
             .open(&mut open)
@@ -1041,6 +1049,9 @@ impl Baboon {
                         }
                     });
                     ui.separator();
+                    // A references popup lets each row expand to its per-occurrence
+                    // list; other query kinds render a plain clickable row.
+                    let expandable = results.ref_target.is_some();
                     egui::ScrollArea::vertical()
                         .max_height(460.0)
                         .show(ui, |ui| {
@@ -1050,12 +1061,35 @@ impl Baboon {
                                     Some(annotation) => format!("{annotation}  —  {path}"),
                                     None => path,
                                 };
-                                let row = ui
-                                    .add(
-                                        egui::Label::new(RichText::new(label).color(text_dark()))
+                                let is_expanded = expanded.contains(&index);
+                                let make_row = |ui: &mut egui::Ui| {
+                                    ui.add(
+                                        egui::Label::new(RichText::new(&label).color(text_dark()))
                                             .sense(Sense::click()),
                                     )
-                                    .on_hover_text("Click to open · right-click to reveal");
+                                    .on_hover_text(
+                                        "Click to jump to the first reference · right-click to reveal",
+                                    )
+                                };
+                                let row = if expandable {
+                                    ui.horizontal(|ui| {
+                                        let arrow = if is_expanded { "▼" } else { "▶" };
+                                        if ui
+                                            .add(
+                                                egui::Button::new(RichText::new(arrow).small())
+                                                    .frame(false),
+                                            )
+                                            .on_hover_text("Show every field that references this tag")
+                                            .clicked()
+                                        {
+                                            to_toggle.push(index);
+                                        }
+                                        make_row(ui)
+                                    })
+                                    .inner
+                                } else {
+                                    make_row(ui)
+                                };
                                 if row.clicked() {
                                     to_open = Some(entry.key.clone());
                                 }
@@ -1069,11 +1103,83 @@ impl Baboon {
                                         ui.close_menu();
                                     }
                                 });
+                                if expandable && is_expanded {
+                                    match occurrences.get(&index) {
+                                        Some(list) if !list.is_empty() => {
+                                            for occ in list {
+                                                ui.horizontal(|ui| {
+                                                    ui.add_space(22.0);
+                                                    if ui
+                                                        .add(
+                                                            egui::Label::new(
+                                                                RichText::new(format!("↳ {}", occ.label))
+                                                                    .color(subtle_dark()),
+                                                            )
+                                                            .sense(Sense::click()),
+                                                        )
+                                                        .on_hover_text("Jump to this field")
+                                                        .clicked()
+                                                    {
+                                                        to_jump = Some((
+                                                            entry.key.clone(),
+                                                            occ.field_path.clone(),
+                                                        ));
+                                                    }
+                                                });
+                                            }
+                                        }
+                                        Some(_) => {
+                                            ui.horizontal(|ui| {
+                                                ui.add_space(22.0);
+                                                ui.label(
+                                                    RichText::new("no direct field found")
+                                                        .italics()
+                                                        .color(subtle_dark())
+                                                        .small(),
+                                                );
+                                            });
+                                        }
+                                        None => {
+                                            ui.horizontal(|ui| {
+                                                ui.add_space(22.0);
+                                                ui.label(
+                                                    RichText::new("loading…")
+                                                        .italics()
+                                                        .color(subtle_dark())
+                                                        .small(),
+                                                );
+                                            });
+                                        }
+                                    }
+                                }
                             }
                         });
                 }
             });
+        for index in to_toggle {
+            if self.ref_jump_expanded.remove(&index) {
+                // Collapsed — drop the cache so a re-expand re-reads fresh.
+                self.ref_jump_occurrences.remove(&index);
+            } else {
+                self.ref_jump_expanded.insert(index);
+            }
+        }
+        if let Some((key, field_path)) = to_jump {
+            // The referrer is already loaded (we walked it for occurrences), so
+            // focus it and navigate to the exact field directly.
+            self.select_entry(key.clone(), ctx.clone());
+            self.navigate_to_field(ctx, &key, &field_path);
+        }
         if let Some(key) = to_open {
+            // For a "References to X" result, queue a jump to the exact field in
+            // the referrer that points at X (resolved once the tag loads).
+            if let Some((group_tag, rel_path)) = &results.ref_target {
+                self.pending_ref_jump = Some(PendingRefJump {
+                    tag_key: key.clone(),
+                    group_tag: *group_tag,
+                    rel_path: rel_path.clone(),
+                });
+            }
             self.select_entry(key, ctx.clone());
         }
         if let Some(key) = to_reveal {
@@ -1132,9 +1238,24 @@ impl Baboon {
     fn draw_settings_startup_tab(&mut self, ui: &mut Ui) {
         ui.label(RichText::new("Startup").color(text_dark()).strong());
         ui.add_space(4.0);
-        ui.checkbox(
-            &mut self.auto_restore_last_session,
-            "Automatically reopen last session on startup",
+        ui.label(
+            RichText::new("When reopening Baboon with a previous session:").color(text_dark()),
+        );
+        ui.add_space(2.0);
+        ui.radio_value(
+            &mut self.session_restore,
+            SessionRestore::Ask,
+            "Ask which windows to reopen",
+        );
+        ui.radio_value(
+            &mut self.session_restore,
+            SessionRestore::Always,
+            "Reopen the last session automatically",
+        );
+        ui.radio_value(
+            &mut self.session_restore,
+            SessionRestore::Never,
+            "Start fresh (never reopen)",
         );
     }
 
@@ -3048,6 +3169,7 @@ impl eframe::App for Baboon {
                     let mut pop_key = None;
                     let mut close_all = false;
                     let mut close_all_but = None;
+                    let mut reveal_key = None;
                     let mut rack_rect = None;
                     if self.open_tabs.is_empty() {
                         let response = ui.label(
@@ -3171,6 +3293,11 @@ impl eframe::App for Baboon {
                                                     close_key = Some(key.clone());
                                                 }
                                                 label_response.context_menu(|ui| {
+                                                    if ui.button("Reveal in browser").clicked() {
+                                                        reveal_key = Some(key.clone());
+                                                        ui.close_menu();
+                                                    }
+                                                    ui.separator();
                                                     if ui.button("Close all").clicked() {
                                                         close_all = true;
                                                         ui.close_menu();
@@ -3222,6 +3349,9 @@ impl eframe::App for Baboon {
                     } else if let Some(key) = pop_key {
                         self.pop_tab(&key);
                     }
+                    if let Some(key) = reveal_key {
+                        self.reveal_in_browser(&key);
+                    }
                     self.tab_rack_rect = rack_rect;
                     ui.add_space(6.0);
                 } else {
@@ -3259,7 +3389,6 @@ impl eframe::App for Baboon {
                         let field_filter = compute_pending_field_filter(
                             &doc.tag,
                             supports_field_search,
-                            self.field_search_passive,
                             &selected_key,
                             &self.field_search,
                             &mut self.field_search_applied,
@@ -3320,6 +3449,7 @@ impl eframe::App for Baboon {
                             block_clipboard: self.block_clipboard.as_ref(),
                             block_clip_request: &mut block_clip_request,
                             field_filter: field_filter.as_ref(),
+                            field_nav: self.field_nav.as_ref(),
                         };
                         if is_bitmap_tag(&entry) {
                             let preview = self
@@ -3545,6 +3675,7 @@ impl eframe::App for Baboon {
         self.handle_save_changes_prompt(ctx);
         self.handle_last_opened_windows_prompt(ctx);
         self.process_pending_open(ctx);
+        self.apply_field_nav(ctx);
         // Drain queued sound-player actions: resolve the permutation against the
         // FMOD banks, decode (cached), and play/stop. Runs every frame so voices
         // are reaped even when idle; the tags root is only cloned when acting.


### PR DESCRIPTION
## Summary

A batch of editor UX improvements to references, field search, session restore, and general polish.

### Reference-jump
- Clicking a result in the **References to X** popup now opens the referrer and jumps straight to the **exact field** where the reference lives — ancestor blocks are expanded, the element selected at each level, and the field scrolled into view and briefly glowed.
- When a tag references the target in more than one place, an **expander** under its row lists every occurrence, each individually clickable.

### Field search is now a filter
- **Search fields** now filters the editor down to just the matching fields and the blocks/structs/arrays that contain them, **hiding everything else** — replacing the old collapse-only behaviour and the "Highlight" toggle.
- Enabled for **sound tags** too (they have a full field tree below the audition surface).

### Editor behaviour
- Blocks and structs **keep their expand state** as you page through a block's element indices, and **structs are expanded by default**.
- **Only the main editor scrolls** — removed the nested per-block scroll area so block/struct bodies expand to full height.

### Startup session restore
- The startup behaviour is now a **three-way choice** — **Ask** / **Always** / **Never** — in *File → Settings*, with a **"Don't ask again"** option on the reopen prompt (OK remembers *Always*, Cancel remembers *Never*). The old boolean preference is migrated automatically.

### Misc
- **Right-click a tag tab** to reveal that tag in the browser tree.
- README updated to match.

## Testing
- `cargo build` clean, `cargo test` green (163 passed).
