### PR TITLE
Fix classic tag corruption when clearing/creating tag references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 [[package]]
 name = "blam-tags"
 version = "0.1.0"
-source = "git+https://github.com/camden-smallwood/blam-tags?rev=00df6c26bce7de7e1c16a8b7c724e93f62b9f03e#00df6c26bce7de7e1c16a8b7c724e93f62b9f03e"
+source = "git+https://github.com/camden-smallwood/blam-tags?rev=cfe673f5e05a8a8f65c966fe2fcffe802430b054#cfe673f5e05a8a8f65c966fe2fcffe802430b054"
 dependencies = [
  "bcdec_rs",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1"
-blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "00df6c26bce7de7e1c16a8b7c724e93f62b9f03e", features = ["audio"] }
+blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "cfe673f5e05a8a8f65c966fe2fcffe802430b054", features = ["audio"] }
 eframe = { version = "0.29", default-features = false, features = ["default_fonts", "glow"] }
 egui_extras = { version = "0.29", features = ["svg"] }
 flate2 = "1"

--- a/src/app/editor.rs
+++ b/src/app/editor.rs
@@ -4020,6 +4020,72 @@ mod tests {
         }
     }
 
+    /// Regression (skip-if-absent): clearing a classic Halo CE tag_reference to
+    /// NONE — or saving a freshly-created reference — must reset the inline
+    /// group + path-length words. When the reference's sub-chunk payload is
+    /// emptied (`TagReferenceData::to_bytes(None)` yields no bytes), the classic
+    /// encoder used to leave the stale on-disk path length in place while
+    /// writing no trailing path, so re-decoding hit "unexpected EOF reading
+    /// tag_reference path: need N bytes, have M" and `write_atomic` failed
+    /// verification — corrupting Save As / new-tag saves. This drives the exact
+    /// Baboon load→edit→save path (read_tag_at_path → apply_field_edit →
+    /// write_atomic) that the field reported.
+    #[test]
+    #[ignore]
+    fn ce_shader_model_clear_reference_saves() {
+        let defs = std::path::Path::new("/Users/camden/Source/blam-tags/definitions");
+        let tag_path = std::path::Path::new(
+            "/Users/camden/Halo/haloce_mcc/tags/characters/crewman/shaders/crewman_body.shader_model",
+        );
+        if !tag_path.exists() || !defs.exists() {
+            eprintln!("skip: no CE tag/defs");
+            return;
+        }
+        let group = u32::from_be_bytes(*b"soso");
+        let out = std::env::temp_dir().join("baboon_ce_clear_ref.shader_model");
+        let load = || {
+            crate::source::read_tag_at_path(tag_path, Some("haloce_mcc"), Some(defs), group)
+                .expect("read CE shader_model tag")
+        };
+
+        // Save As of the unmodified tag round-trips.
+        load().write_atomic(&out).expect("Save As of unmodified tag");
+
+        // Setting a reference to a new path round-trips (the pre-existing path).
+        let mut edited = load();
+        apply_field_edit(&mut edited, "maps/base map", "weapons\\smg\\bitmaps\\smg.bitmap")
+            .expect("set base map");
+        edited.write_atomic(&out).expect("save after set");
+
+        // Clearing a long-path reference to NONE round-trips (the regression).
+        let mut cleared = load();
+        apply_field_edit(&mut cleared, "maps/base map", "none").expect("clear base map");
+        cleared
+            .write_atomic(&out)
+            .expect("save after clear-to-none must verify");
+
+        // The cleared reference reads back as a null reference — an empty path,
+        // the same shape a genuine stock null (e.g. the detail map) decodes to,
+        // which Baboon renders as NONE.
+        let reread = crate::source::read_tag_at_path(&out, Some("haloce_mcc"), Some(defs), group)
+            .expect("reread cleared tag");
+        let root = reread.root();
+        let base = root
+            .field_path("maps/base map")
+            .and_then(|f| f.value())
+            .expect("base map field present");
+        match base {
+            TagFieldData::TagReference(r) => {
+                let path = r.group_tag_and_name.as_ref().map(|(_, p)| p.as_str());
+                assert!(
+                    path.is_none_or(str::is_empty),
+                    "cleared ref should have no path, got {path:?}"
+                );
+            }
+            other => panic!("expected tag reference, got {other:?}"),
+        }
+    }
+
     /// Classic Halo CE inline audio (skip-if-absent): read the classic `.sound`
     /// tag, extract the permutation's inline `samples` exactly as the player
     /// does, and decode the Ogg Vorbis — the path `AudioState` takes for a


### PR DESCRIPTION
## Problem

Saving a new tag, or clearing a bitmap reference in a `shader_model` (and other classic Halo CE / Halo 2 tags), corrupted the tag and failed save verification with:

```
saved classic tag failed verification: unexpected EOF reading tag_reference path: need N bytes, have M
```

## Root cause

A classic `tag_reference` whose sub-chunk payload is **empty** — either edited to NONE (`TagReferenceData::to_bytes(None)` yields no bytes) or freshly created (`new_default` seeds an empty payload) — was re-encoded with its **stale on-disk group and path-length words intact but no trailing path emitted**. On the next decode the reader tried to consume a phantom path off the end of the buffer and hit EOF, so the write-back verification failed and the on-disk tag was corrupt.

This is why creating a new `shader_model` and clearing/replacing a reference both broke.

## Fix

- **Engine (`blam-tags` → `cfe673f`):** `sync_fixed_counts` now writes a canonical null (group = `-1`, length = `0`) for an empty `tag_reference` payload, which decodes as NONE for both CE and H2.
- **Engine hardening:** `write_atomic` committed the temp file over the original *before* verifying the re-parse, so a bad encode clobbered the tag already on disk even while reporting failure. It now verifies the temp file first and commits only on success, so a failed save leaves the original untouched.

## Testing

- Reproduced the exact error, then confirmed both fixes.
- Swept **all 540 stock CE `shader_model` tags** through clear-to-none + re-set via the real `write_atomic` verify: 0 failures.
- Full engine suite (163) and full Baboon suite (182) green.
- Added a skip-if-absent regression test driving the exact `read_tag_at_path → apply_field_edit → write_atomic` path for a Halo CE `shader_model`.