### PR TITLE
Foundation field addressing + function editor, JMS marker scope, UI polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 guerilla_tag_save/
+.baboon-last-session.json
 .baboon-prefs.json
 # Runtime caches written to the working dir in dev (entry / reverse-dep / field indexes, keywords)
 *_index.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 [[package]]
 name = "blam-tags"
 version = "0.1.0"
-source = "git+https://github.com/camden-smallwood/blam-tags?rev=cfe673f5e05a8a8f65c966fe2fcffe802430b054#cfe673f5e05a8a8f65c966fe2fcffe802430b054"
+source = "git+https://github.com/camden-smallwood/blam-tags?rev=5e44015d83148453aa4a1bda5341c9cae53c4a69#5e44015d83148453aa4a1bda5341c9cae53c4a69"
 dependencies = [
  "bcdec_rs",
  "flate2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 [[package]]
 name = "blam-tags"
 version = "0.1.0"
-source = "git+https://github.com/camden-smallwood/blam-tags?rev=8f314389dadd3c7de423a9e322195355198845d4#8f314389dadd3c7de423a9e322195355198845d4"
+source = "git+https://github.com/camden-smallwood/blam-tags?rev=19b240518b3b7bc28d4a895845b1b3c3788821c4#19b240518b3b7bc28d4a895845b1b3c3788821c4"
 dependencies = [
  "bcdec_rs",
  "flate2",
@@ -1039,7 +1039,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2849,7 +2849,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3194,7 +3194,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3375,7 +3375,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3830,7 +3830,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 [[package]]
 name = "blam-tags"
 version = "0.1.0"
-source = "git+https://github.com/camden-smallwood/blam-tags?rev=5e44015d83148453aa4a1bda5341c9cae53c4a69#5e44015d83148453aa4a1bda5341c9cae53c4a69"
+source = "git+https://github.com/camden-smallwood/blam-tags?rev=8f314389dadd3c7de423a9e322195355198845d4#8f314389dadd3c7de423a9e322195355198845d4"
 dependencies = [
  "bcdec_rs",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1"
-blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "cfe673f5e05a8a8f65c966fe2fcffe802430b054", features = ["audio"] }
+blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "5e44015d83148453aa4a1bda5341c9cae53c4a69", features = ["audio"] }
 eframe = { version = "0.29", default-features = false, features = ["default_fonts", "glow"] }
 egui_extras = { version = "0.29", features = ["svg"] }
 flate2 = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1"
-blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "5e44015d83148453aa4a1bda5341c9cae53c4a69", features = ["audio"] }
+blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "8f314389dadd3c7de423a9e322195355198845d4", features = ["audio"] }
 eframe = { version = "0.29", default-features = false, features = ["default_fonts", "glow"] }
 egui_extras = { version = "0.29", features = ["svg"] }
 flate2 = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1"
-blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "8f314389dadd3c7de423a9e322195355198845d4", features = ["audio"] }
+blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "19b240518b3b7bc28d4a895845b1b3c3788821c4", features = ["audio"] }
 eframe = { version = "0.29", default-features = false, features = ["default_fonts", "glow"] }
 egui_extras = { version = "0.29", features = ["svg"] }
 flate2 = "1"

--- a/src/app.rs
+++ b/src/app.rs
@@ -21,9 +21,10 @@ use blam_tags::render_method::{
 };
 use blam_tags::{
     AssFile, Bitmap, ColorGraphType, Endian, FunctionFlags, FunctionKind, FunctionType, JmsFile,
-    RenderModel, StringIdData, TagBlock, TagField, TagFieldData, TagFieldType, TagFile,
-    TagFunction, TagReferenceData, TagResource, TagResourceKind, TagStruct, format_group_tag,
-    parse_group_tag,
+    RenderModel, StringIdData, TagBlock, TagField, TagFieldData, TagFieldType, TagFile, TagFunction,
+    TagFunctionEditor, TagReferenceData, TagResource, TagResourceKind, TagStruct,
+    FoundationMasterType as EngineMasterType, PERIODIC_FUNCTIONS, TRANSITION_FUNCTIONS,
+    format_group_tag, parse_group_tag,
 };
 use eframe::egui::{
     self, Align2, Color32, FontData, FontDefinitions, FontFamily, FontId, Frame, RichText,

--- a/src/app.rs
+++ b/src/app.rs
@@ -645,6 +645,15 @@ mod tests {
             "contact points/markers"
         );
         assert_eq!(strip_node_indices("unit/object"), "unit/object");
+        // Positional `#ordinal` tokens are stripped too, alongside `[index]`.
+        assert_eq!(
+            strip_node_indices("color#10/Mapping#5/Function Type#1"),
+            "color/Mapping/Function Type"
+        );
+        assert_eq!(
+            strip_node_indices("regions#3[0]/permutations#7[2]"),
+            "regions/permutations"
+        );
     }
 
     #[test]
@@ -2474,6 +2483,62 @@ mod tests {
             .unwrap();
         assert_eq!(halo2_function_bytes_from_struct(mapping).unwrap(), bytes);
         assert_h2_write_atomic_verifies(&tag, "h2_function_empty_create");
+    }
+
+    /// The reported bug: editing a field inside an H2 particle's `Mapping`
+    /// struct failed because the schema has a `custom` placeholder named
+    /// "Mapping" *before* the real `Mapping: struct`. With positional
+    /// (`name#ordinal`) paths the edit targets the exact struct field.
+    #[test]
+    fn h2_particle_mapping_field_edit_targets_exact_field() {
+        // Loads a real H2 particle; skipped when the tag isn't present (CI).
+        let tag_path =
+            "/Users/camden/Halo/halo2_mcc/tags/effects/generic/smoke/steam.particle";
+        let def = test_definition_path("halo2_mcc/particle.json");
+        if !std::path::Path::new(tag_path).exists() || !std::path::Path::new(&def).exists() {
+            eprintln!("skipping: H2 particle/definition not present");
+            return;
+        }
+        let bytes = std::fs::read(tag_path).unwrap();
+        let layout = blam_tags::layout::TagLayout::from_json(&def).unwrap();
+        let mut tag = blam_tags::classic::read_classic_tag_file(&bytes, layout).unwrap();
+
+        // Build the resolvable path exactly as the render walk does, via
+        // `append_field_path_for` (which appends each field's `#ordinal`).
+        let path = {
+            let root = tag.root();
+            let color_field = root
+                .fields_all()
+                .find(|f| f.name() == "color" && f.as_struct().is_some())
+                .expect("color struct");
+            let color = color_field.as_struct().unwrap();
+            // The FIRST "Mapping" is the custom leaf; select the struct one.
+            assert!(
+                color.field("Mapping").and_then(|f| f.as_struct()).is_none(),
+                "first 'Mapping' should be the non-struct custom placeholder"
+            );
+            let mapping_field = color
+                .fields_all()
+                .find(|f| f.name() == "Mapping" && f.as_struct().is_some())
+                .expect("Mapping struct");
+            let mapping = mapping_field.as_struct().unwrap();
+            let ft = mapping
+                .fields_all()
+                .find(|f| f.name() == "Function Type")
+                .expect("Function Type");
+            let p = append_field_path_for("", &color_field);
+            let p = append_field_path_for(&p, &mapping_field);
+            append_field_path_for(&p, &ft)
+        };
+        assert!(path.contains("Mapping#"), "path should carry ordinals: {path}");
+
+        // Edit through the positional path; it must resolve and set the field.
+        apply_field_edit(&mut tag, &path, "4").unwrap();
+        let value = tag.root().field_path(&path).and_then(|f| f.value());
+        assert!(
+            matches!(value, Some(TagFieldData::CharInteger(4))),
+            "Function Type not set via positional path: {value:?}"
+        );
     }
 
     fn h2_classic_shader_tag() -> TagFile {

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -5434,6 +5434,16 @@ mod tests {
             ancestor_block_indices("havok cleanup resources"),
             Vec::<(String, usize)>::new(),
         );
+        // Positional `#ordinal` tokens are kept in the block paths (they stay
+        // resolvable and must match the render-walk's `path_prefix`), while the
+        // element index is still extracted from `[N]`.
+        assert_eq!(
+            ancestor_block_indices("custom references#5[3]/sounds#2[1]/melee sound#4"),
+            vec![
+                ("custom references#5".to_owned(), 3),
+                ("custom references#5[3]/sounds#2".to_owned(), 1),
+            ],
+        );
     }
 
     #[test]
@@ -5445,6 +5455,11 @@ mod tests {
         assert_eq!(
             occurrence_label("havok cleanup resources"),
             "havok cleanup resources"
+        );
+        // `#ordinal` tokens are stripped for display; `[index]` is kept.
+        assert_eq!(
+            occurrence_label("custom references#5[3]/melee sound#4"),
+            "custom references[3] › melee sound",
         );
     }
 
@@ -6291,11 +6306,20 @@ fn occurrence_label(field_path: &str) -> String {
     field_path
         .split('/')
         .map(|segment| match segment.split_once('[') {
-            Some((name, rest)) => format!("{}[{rest}", clean_field_name(name)),
-            None => clean_field_name(segment).to_string(),
+            // Keep the `[index]` element selector; drop the `#ordinal` token.
+            Some((name, rest)) => {
+                format!("{}[{rest}", clean_field_name(strip_ordinal_token(name)))
+            }
+            None => clean_field_name(strip_ordinal_token(segment)).to_string(),
         })
         .collect::<Vec<_>>()
         .join(" › ")
+}
+
+/// Drop a trailing `#ordinal` positional token from a path segment's name
+/// part, leaving the display name (`Mapping#5` → `Mapping`).
+fn strip_ordinal_token(name: &str) -> &str {
+    name.split('#').next().unwrap_or(name)
 }
 
 fn collect_tag_references(
@@ -6304,7 +6328,10 @@ fn collect_tag_references(
     refs: &mut Vec<TagReferenceUse>,
 ) {
     for field in tag_struct.fields() {
-        let field_path = append_field_path(path_prefix, field.name());
+        // Emit the positional `#ordinal` form so the collected path matches the
+        // render walk's field_path exactly (reference-jump keys on it) and so
+        // the write targets the exact field. Display helpers strip the ordinal.
+        let field_path = append_field_path_for(path_prefix, &field);
         if let Some(value) = field.value() {
             if let TagFieldData::TagReference(reference) = value
                 && let Some((group_tag, rel_path)) = reference.group_tag_and_name

--- a/src/app/editor.rs
+++ b/src/app/editor.rs
@@ -2655,6 +2655,21 @@ pub(super) fn append_field_path(prefix: &str, field_name: &str) -> String {
     }
 }
 
+/// Like [`append_field_path`] but appends the field's positional `#ordinal`
+/// token (`name#N`), so the path resolves to this EXACT field even when a
+/// sibling shares its name/type — Foundation-style positional addressing (see
+/// `blam_tags::TagField::ordinal`). Use for RESOLVABLE paths (edits, block ops,
+/// function data). Canonical/display paths use the plain-name form and strip
+/// the ordinal via `strip_node_indices`.
+pub(super) fn append_field_path_for(prefix: &str, field: &TagField) -> String {
+    let segment = format!("{}#{}", field.name(), field.ordinal());
+    if prefix.is_empty() {
+        segment
+    } else {
+        format!("{prefix}/{segment}")
+    }
+}
+
 pub(super) fn escape_field_path_segment(field_name: &str) -> String {
     field_name.replace('\\', "\\\\").replace('/', "\\/")
 }

--- a/src/app/foundation.rs
+++ b/src/app/foundation.rs
@@ -1,17 +1,24 @@
 use super::*;
 
-/// Remove `[index]` segments from a rendered field path so it can be matched
-/// against the index-independent paths in a [`FieldFilter`].
-/// e.g. `"contact points[0]/markers[2]"` → `"contact points/markers"`.
+/// Canonicalize a rendered field path to plain names — dropping both the
+/// `[index]` element selectors AND the `#ordinal` positional tokens — so it can
+/// be matched against the index/ordinal-independent paths in a [`FieldFilter`],
+/// collapse-state keys, and nav comparisons.
+/// e.g. `"contact points#3[0]/markers#7[2]"` → `"contact points/markers"`.
 pub(super) fn strip_node_indices(path: &str) -> String {
     let mut out = String::with_capacity(path.len());
-    let mut in_bracket = false;
+    // Skip everything from a `#` (ordinal) or `[` (element index) up to the
+    // next `/` segment boundary.
+    let mut skipping = false;
     for ch in path.chars() {
         match ch {
-            '[' => in_bracket = true,
-            ']' => in_bracket = false,
-            _ if !in_bracket => out.push(ch),
-            _ => {}
+            '/' => {
+                skipping = false;
+                out.push('/');
+            }
+            '#' | '[' => skipping = true,
+            _ if skipping => {}
+            _ => out.push(ch),
         }
     }
     out
@@ -367,7 +374,11 @@ pub(super) fn draw_field(
     semantic_short_index: Option<(Vec<String>, String)>,
     tag_reference_value_width: f32,
 ) {
-    let field_path = append_field_path(path_prefix, field.name());
+    // RESOLVABLE path: carries the field's `#ordinal` so edits target the exact
+    // field even when a sibling shares its name (e.g. the H2 particle "Mapping"
+    // custom-vs-struct pair). Canonical consumers (filter, collapse, nav) strip
+    // the ordinal via `strip_node_indices`.
+    let field_path = append_field_path_for(path_prefix, &field);
     // Active (filter) field-search: hide everything that isn't a match, an
     // ancestor container of one, or inside a name-matched container.
     if !edit.field_visible(&field_path) {
@@ -1419,7 +1430,11 @@ pub(super) fn parent_block_path(path: &str) -> Option<String> {
 /// dropped) joined with ` › `, e.g. `regions[0]/permutations` → `regions › permutations`.
 fn breadcrumb_for_path(path: &str) -> String {
     path.split('/')
-        .map(|segment| clean_field_name(segment.split('[').next().unwrap_or(segment)))
+        .map(|segment| {
+            // Strip both the `[index]` and `#ordinal` tokens for display.
+            let base = segment.split('[').next().unwrap_or(segment);
+            clean_field_name(base.split('#').next().unwrap_or(base))
+        })
         .filter(|segment| !segment.is_empty())
         .collect::<Vec<_>>()
         .join(" › ")

--- a/src/app/foundation.rs
+++ b/src/app/foundation.rs
@@ -1641,7 +1641,6 @@ pub(super) fn draw_foundation_block_control(
                             }
                         }
                     });
-                foundation_header_icon_cell(ui, "[]");
 
                 // Keep the previous arrow directly beside the selected
                 // reference, with the next arrow following it.
@@ -1937,20 +1936,6 @@ pub(super) fn foundation_header_toggle_cell(
 
 pub(super) fn foundation_selected_width(row_width: f32) -> f32 {
     (row_width - 190.0 - 24.0 * 4.0 - 54.0 * 5.0 - 92.0).clamp(120.0, 420.0)
-}
-
-pub(super) fn foundation_header_icon_cell(ui: &mut Ui, text: &str) {
-    let (rect, _) = ui.allocate_exact_size(Vec2::new(24.0, 22.0), Sense::hover());
-    ui.painter().rect_filled(rect, 4.0, foundation_input());
-    ui.painter()
-        .rect_stroke(rect, 4.0, Stroke::new(1.0, foundation_input_edge()));
-    ui.painter().text(
-        rect.center(),
-        Align2::CENTER_CENTER,
-        text,
-        FontId::proportional(11.0),
-        subtle_dark(),
-    );
 }
 
 pub(super) fn foundation_header_value_cell(ui: &mut Ui, text: &str, max_width: f32) {

--- a/src/app/function_editor.rs
+++ b/src/app/function_editor.rs
@@ -336,26 +336,16 @@ impl FoundationMasterType {
         }
     }
 
-    fn target_function_type(self) -> Option<FunctionType> {
-        match self {
-            Self::Basic => Some(FunctionType::Constant),
-            // Creating a valid MultiSpline needs the compact constructors and
-            // derived-data rebuild support requested from blam-tags.
-            Self::Curve => None,
-            Self::Periodic => Some(FunctionType::Periodic),
-            Self::Exponent => Some(FunctionType::Exponent),
-            Self::Transition => Some(FunctionType::Transition),
-        }
-    }
 }
 
-fn foundation_master_type_combo(ui: &mut Ui, function: &mut TagFunction, editable: bool) -> bool {
-    let current = FoundationMasterType::from_function_type(function.function_type());
+fn foundation_master_type_combo(ui: &mut Ui, view: &mut FunctionView, editable: bool) -> bool {
+    let current = FoundationMasterType::from_function_type(view.function.function_type());
     if !editable {
         foundation_input_cell(ui, current.label(), 130.0);
         return false;
     }
     let mut changed = false;
+    let mut pick = None;
     egui::ComboBox::from_id_salt("foundation_fn_type")
         .selected_text(current.label())
         .width(130.0)
@@ -367,32 +357,49 @@ fn foundation_master_type_combo(ui: &mut Ui, function: &mut TagFunction, editabl
                 FoundationMasterType::Exponent,
                 FoundationMasterType::Transition,
             ] {
-                let response = ui.add_enabled(
-                    master.target_function_type().is_some() || master == current,
-                    egui::SelectableLabel::new(master == current, master.label()),
-                );
-                let response = if master == FoundationMasterType::Curve && master != current {
-                    response.on_hover_text(
-                        "Creating a curve is disabled until blam-tags can create a valid MultiSpline compact.",
-                    )
-                } else {
-                    response
-                };
-                if response.clicked() && master != current {
-                    if let Some(kind) = master.target_function_type() {
-                        function.set_function_type(kind);
-                        changed = true;
-                    }
+                if ui
+                    .selectable_label(master == current, master.label())
+                    .clicked()
+                    && master != current
+                {
+                    pick = Some(master);
                 }
             }
         });
+    if let Some(master) = pick {
+        // The engine converts to a valid target — including a real identity
+        // MultiSpline for `curve` — preserving the header and range state.
+        changed |= edit_function(view, |ed| ed.set_master_type(engine_master_type(master)).is_ok());
+    }
     changed
 }
 
-/// The H3+ Foundation presentation.  It deliberately avoids raw compact-byte
-/// mutation: controls which need the pending blam-tags compact API are shown
-/// as read-only, while header, color, wrapper, and existing LinearKey edits
-/// remain safe and update the preview live.
+/// Apply a `TagFunctionEditor` operation to the view's function, writing the
+/// result back on success. The editor owns the compact/editor-trailer
+/// serialization so the UI never patches bytes itself.
+fn edit_function(view: &mut FunctionView, op: impl FnOnce(&mut TagFunctionEditor) -> bool) -> bool {
+    let mut editor = TagFunctionEditor::from_function(view.function.clone());
+    if op(&mut editor) {
+        view.function = editor.into_function();
+        true
+    } else {
+        false
+    }
+}
+
+fn engine_master_type(master: FoundationMasterType) -> EngineMasterType {
+    match master {
+        FoundationMasterType::Basic => EngineMasterType::Basic,
+        FoundationMasterType::Curve => EngineMasterType::Curve,
+        FoundationMasterType::Periodic => EngineMasterType::Periodic,
+        FoundationMasterType::Exponent => EngineMasterType::Exponent,
+        FoundationMasterType::Transition => EngineMasterType::Transition,
+    }
+}
+
+/// The H3+ Foundation presentation.  Structural + compact edits go through
+/// [`TagFunctionEditor`] (blam-tags), which regenerates a valid blob with its
+/// editor-data trailer; the UI never patches compact bytes itself.
 pub(super) fn draw_foundation_h3_function_editor_contents(
     ui: &mut Ui,
     view: &mut FunctionView,
@@ -429,15 +436,16 @@ pub(super) fn draw_foundation_h3_function_editor_contents(
             &mut view.input_name,
             input_editable,
         );
-        let mut ranged = view.function.flags().is_ranged();
+        let mut ranged = view.function.is_ranged();
         if ui
-            .add_enabled(false, egui::Checkbox::new(&mut ranged, "Range:"))
-            .on_hover_text("Ranged compact creation requires the pending blam-tags editing API.")
+            .add_enabled(editable, egui::Checkbox::new(&mut ranged, "Range:"))
             .changed()
         {
-            unreachable!("disabled range checkbox cannot change");
+            // The engine builds/removes a valid second graph (mirrors the
+            // primary kind) and keeps the compact sizes + trailer consistent.
+            changed |= edit_function(view, |ed| ed.set_ranged(ranged).is_ok());
         }
-        if ranged {
+        if view.function.is_ranged() {
             changed |= seeded_name_combo(
                 ui,
                 "foundation_fn_range",
@@ -450,7 +458,7 @@ pub(super) fn draw_foundation_h3_function_editor_contents(
         ui.label(RichText::new("Output:").color(text_dark()).small());
         changed |= output_type_combo(ui, &mut view.output_index, output_editable);
         ui.label(RichText::new("Function type:").color(text_dark()).small());
-        changed |= foundation_master_type_combo(ui, &mut view.function, editable);
+        changed |= foundation_master_type_combo(ui, view, editable);
     });
 
     let master = FoundationMasterType::from_function_type(view.function.function_type());
@@ -500,56 +508,173 @@ pub(super) fn draw_foundation_h3_function_editor_contents(
     });
 
     ui.add_space(8.0);
+    let graphs = view.function.graph_count();
     match master {
         FoundationMasterType::Curve => {
             ui.label(RichText::new("Curve").color(text_dark()).strong());
-            if view.function.linear_key_points().is_some() {
-                ui.label(
-                    RichText::new("Drag/select points in the graph. Multi-segment controls are pending blam-tags compact editing support.")
-                        .color(subtle_dark())
-                        .small(),
-                );
-            } else {
-                ui.label(
-                    RichText::new("This curve form is displayed without conversion; segment editing is pending blam-tags compact editing support.")
-                        .color(subtle_dark())
-                        .small(),
-                );
+            ui.label(
+                RichText::new("Drag points in the graph. Add points by clicking an empty area; Delete removes the selected point.")
+                    .color(subtle_dark())
+                    .small(),
+            );
+        }
+        FoundationMasterType::Periodic => {
+            for slot in 0..graphs {
+                changed |= draw_periodic_panel(ui, view, slot, editable);
             }
         }
-        FoundationMasterType::Periodic => draw_pending_compact_panel(
-            ui,
-            "Periodic",
-            &["Function", "Frequency", "Max", "Phase", "Min"],
-        ),
         FoundationMasterType::Exponent => {
-            draw_pending_compact_panel(ui, "Exponent", &["Exponent", "Max", "Min"])
+            for slot in 0..graphs {
+                changed |= draw_exponent_panel(ui, view, slot, editable);
+            }
         }
         FoundationMasterType::Transition => {
-            draw_pending_compact_panel(ui, "Transition", &["Function", "Max", "Min"])
+            for slot in 0..graphs {
+                changed |= draw_transition_panel(ui, view, slot, editable);
+            }
         }
         FoundationMasterType::Basic => unreachable!(),
     }
     changed
 }
 
-fn draw_pending_compact_panel(ui: &mut Ui, title: &str, fields: &[&str]) {
-    ui.label(RichText::new(title).color(text_dark()).strong());
-    ui.horizontal_wrapped(|ui| {
-        for field in fields {
-            ui.label(
-                RichText::new(format!("{field}:"))
-                    .color(subtle_dark())
-                    .small(),
+/// Label for a graph slot ("graph"/"range graph" when the function is ranged).
+fn graph_slot_label(slot: usize, graphs: usize) -> String {
+    if graphs < 2 {
+        "Graph".to_owned()
+    } else if slot == 0 {
+        "Graph 0".to_owned()
+    } else {
+        "Graph 1 (range)".to_owned()
+    }
+}
+
+/// Editable combo over a numeric option table (index → label).
+fn function_index_combo(
+    ui: &mut Ui,
+    id: &str,
+    value: &mut u8,
+    options: &[&str],
+    editable: bool,
+) -> bool {
+    let label = options
+        .get(*value as usize)
+        .copied()
+        .unwrap_or("(unknown)");
+    if !editable {
+        foundation_input_cell(ui, label, 160.0);
+        return false;
+    }
+    let mut changed = false;
+    egui::ComboBox::from_id_salt(id)
+        .selected_text(label)
+        .width(160.0)
+        .show_ui(ui, |ui| {
+            for (i, name) in options.iter().enumerate() {
+                if ui.selectable_label(*value as usize == i, *name).clicked() && *value as usize != i {
+                    *value = i as u8;
+                    changed = true;
+                }
+            }
+        });
+    changed
+}
+
+fn param_drag(ui: &mut Ui, label: &str, value: &mut f32, speed: f32, editable: bool) -> bool {
+    ui.label(RichText::new(label).color(subtle_dark()).small());
+    ui.add_enabled(editable, egui::DragValue::new(value).speed(speed))
+        .changed()
+}
+
+fn draw_periodic_panel(ui: &mut Ui, view: &mut FunctionView, slot: usize, editable: bool) -> bool {
+    let editor = TagFunctionEditor::from_function(view.function.clone());
+    let Some(mut p) = editor.periodic_params(slot) else {
+        return false;
+    };
+    let graphs = view.function.graph_count();
+    let mut changed = false;
+    ui.group(|ui| {
+        ui.label(
+            RichText::new(format!("Periodic — {}", graph_slot_label(slot, graphs)))
+                .color(text_dark())
+                .strong(),
+        );
+        ui.horizontal_wrapped(|ui| {
+            ui.label(RichText::new("Function:").color(subtle_dark()).small());
+            changed |= function_index_combo(
+                ui,
+                &format!("periodic_fn_{slot}"),
+                &mut p.function_index,
+                &PERIODIC_FUNCTIONS,
+                editable,
             );
-            foundation_input_cell(ui, "—", 72.0);
-        }
+            changed |= param_drag(ui, "Frequency:", &mut p.frequency, 0.05, editable);
+            changed |= param_drag(ui, "Phase:", &mut p.phase, 0.05, editable);
+            changed |= param_drag(ui, "Min:", &mut p.amplitude_min, 0.01, editable);
+            changed |= param_drag(ui, "Max:", &mut p.amplitude_max, 0.01, editable);
+        });
     });
-    ui.label(
-        RichText::new("Compact parameter editing (including the ranged second graph) awaits the required blam-tags API.")
-            .color(subtle_dark())
-            .small(),
-    );
+    if changed {
+        edit_function(view, |ed| ed.set_periodic_params(slot, p).is_ok());
+    }
+    changed
+}
+
+fn draw_exponent_panel(ui: &mut Ui, view: &mut FunctionView, slot: usize, editable: bool) -> bool {
+    let editor = TagFunctionEditor::from_function(view.function.clone());
+    let Some(mut p) = editor.exponent_params(slot) else {
+        return false;
+    };
+    let graphs = view.function.graph_count();
+    let mut changed = false;
+    ui.group(|ui| {
+        ui.label(
+            RichText::new(format!("Exponent — {}", graph_slot_label(slot, graphs)))
+                .color(text_dark())
+                .strong(),
+        );
+        ui.horizontal_wrapped(|ui| {
+            changed |= param_drag(ui, "Exponent:", &mut p.exponent, 0.05, editable);
+            changed |= param_drag(ui, "Min:", &mut p.amplitude_min, 0.01, editable);
+            changed |= param_drag(ui, "Max:", &mut p.amplitude_max, 0.01, editable);
+        });
+    });
+    if changed {
+        edit_function(view, |ed| ed.set_exponent_params(slot, p).is_ok());
+    }
+    changed
+}
+
+fn draw_transition_panel(ui: &mut Ui, view: &mut FunctionView, slot: usize, editable: bool) -> bool {
+    let editor = TagFunctionEditor::from_function(view.function.clone());
+    let Some(mut p) = editor.transition_params(slot) else {
+        return false;
+    };
+    let graphs = view.function.graph_count();
+    let mut changed = false;
+    ui.group(|ui| {
+        ui.label(
+            RichText::new(format!("Transition — {}", graph_slot_label(slot, graphs)))
+                .color(text_dark())
+                .strong(),
+        );
+        ui.horizontal_wrapped(|ui| {
+            ui.label(RichText::new("Function:").color(subtle_dark()).small());
+            changed |= function_index_combo(
+                ui,
+                &format!("transition_fn_{slot}"),
+                &mut p.function_index,
+                &TRANSITION_FUNCTIONS,
+                editable,
+            );
+            changed |= param_drag(ui, "Min:", &mut p.amplitude_min, 0.01, editable);
+            changed |= param_drag(ui, "Max:", &mut p.amplitude_max, 0.01, editable);
+        });
+    });
+    if changed {
+        edit_function(view, |ed| ed.set_transition_params(slot, p).is_ok());
+    }
+    changed
 }
 
 /// The interactive function editor body. When `editable` is false every
@@ -1933,7 +2058,9 @@ mod tests {
                 "{kind:?} should retain the curve presentation"
             );
         }
-        assert_eq!(FoundationMasterType::Curve.target_function_type(), None);
+        // Curve now maps to a real engine conversion target (a valid identity
+        // MultiSpline), no longer gated off.
+        assert_eq!(engine_master_type(FoundationMasterType::Curve), EngineMasterType::Curve);
     }
 
     #[test]

--- a/src/app/style.rs
+++ b/src/app/style.rs
@@ -67,6 +67,47 @@ pub(super) fn foundation_fonts() -> FontDefinitions {
         }
     }
 
+    // Symbol/technical-glyph fallback. The UI uses box-drawing (─), arrows
+    // (→ ← ↑ ↳ ⇒ ⇱), geometric shapes (▸ ▾ ▼ ●), and math operators
+    // (× · − ≤ ≥ Σ) that egui's *proportional* text font (Ubuntu-Light) does
+    // not cover — so they render as tofu (□). egui's own bundled monospace
+    // font ("Hack") covers them but is only in the Monospace family; add it as
+    // a proportional fallback (always present, cross-platform). When a nicer
+    // broad-coverage system symbol font is available, prefer it. Appended
+    // LAST so glyphs already covered by earlier fonts are unaffected.
+    let mut symbol_fallbacks: Vec<String> = Vec::new();
+    let system_symbol = [
+        r"C:\Windows\Fonts\seguisym.ttf", // Segoe UI Symbol
+        r"C:\Windows\Fonts\arialuni.ttf",
+        "/System/Library/Fonts/Apple Symbols.ttf",
+        "/Library/Fonts/Arial Unicode.ttf",
+        "/System/Library/Fonts/Supplemental/Arial Unicode.ttf",
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+        "/usr/share/fonts/truetype/noto/NotoSansSymbols2-Regular.ttf",
+    ]
+    .iter()
+    .find_map(|path| std::fs::read(path).ok());
+    if let Some(bytes) = system_symbol {
+        const SYMBOLS: &str = "foundation_symbols";
+        fonts
+            .font_data
+            .insert(SYMBOLS.to_owned(), FontData::from_owned(bytes));
+        symbol_fallbacks.push(SYMBOLS.to_owned());
+    }
+    // egui's bundled "Hack" (present with the `default_fonts` feature) has
+    // broad symbol coverage and guarantees no tofu even with no system font.
+    if fonts.font_data.contains_key("Hack") {
+        symbol_fallbacks.push("Hack".to_owned());
+    }
+    for family in [FontFamily::Proportional, FontFamily::Monospace] {
+        let list = fonts.families.entry(family).or_default();
+        for key in &symbol_fallbacks {
+            if !list.contains(key) {
+                list.push(key.clone());
+            }
+        }
+    }
+
     // Bold face for headers (Foundation uses FontWeight=Bold). Try common
     // system bold fonts across platforms; gracefully degrade to the regular
     // family if none are present so the named family is always valid.
@@ -577,3 +618,33 @@ mod tests {
     }
 }
 pub(super) const FOUNDATION_LABEL_WIDTH: f32 = 280.0;
+
+#[cfg(test)]
+mod symbol_font_tests {
+    use super::foundation_fonts;
+    use eframe::egui::{self, FontId};
+
+    /// The UI uses box-drawing, arrows, geometric shapes and math operators
+    /// that egui's proportional text font (Ubuntu-Light) lacks. After the
+    /// symbol-fallback wiring, the Proportional family must resolve them all
+    /// (else they render as tofu). This would fail before the fallback.
+    #[test]
+    fn proportional_family_covers_ui_symbol_glyphs() {
+        let ctx = egui::Context::default();
+        ctx.set_fonts(foundation_fonts());
+        let _ = ctx.run(egui::RawInput::default(), |_| {});
+        let fid = FontId::proportional(14.0);
+        // Technical glyphs that were tofu in proportional text (Hack covers
+        // these), plus ones from Ubuntu/emoji fonts as a sanity check.
+        for c in [
+            '→', '─', '●', '↑', '↳', '▾', '▸', '←', '▼', '⇱', '⇒', '◀', '▶',
+            '×', '·', '−', '≤', '≥', 'Σ', '★', '…', '›', '‹', '⚠', '⬇',
+        ] {
+            assert!(
+                ctx.fonts(|f| f.has_glyph(&fid, c)),
+                "proportional family has no glyph for {c:?} (U+{:04X})",
+                c as u32
+            );
+        }
+    }
+}

--- a/src/app/ui.rs
+++ b/src/app/ui.rs
@@ -407,7 +407,7 @@ impl Baboon {
             let mut remove: Option<String> = None;
             for keyword in &existing {
                 if ui
-                    .small_button(format!("{keyword}  ✕"))
+                    .small_button(format!("{keyword}  ×"))
                     .on_hover_text("Remove keyword")
                     .clicked()
                 {


### PR DESCRIPTION
Foundation-faithful field addressing, a Foundation function editor backend, JMS marker fixes, and UI polish.

## Foundation-compatible `mapping_function` editor
- Wires the upstream function-editor UI to the new blam-tags editing API.

## Positional (`name#ordinal`) field paths
Fixes **"edit failed"** when editing H2 particle / emitter / particle-mapping fields. H2 schemas declare two same-named fields per animation property (a 0-byte `custom` placeholder before the real `Mapping: struct`), so name-based path resolution matched the leaf first and couldn't descend. Adopts Foundation's positional addressing:
- Baboon emits `name#ordinal` for resolvable paths; canonicalization (`strip_node_indices`, breadcrumbs, occurrence labels, reference-jump keys) strips the ordinal for display/comparison.
- Backed by the engine change in blam-tags (path grammar gained a `#ordinal` token; ordinal-primary resolution with name fallback).

## JMS marker region/permutation export
`render_model` marker extraction now emits the region/permutation scope in the marker name — `(<permutation> <region>)<name>` — matching the H3 exporter convention, with global markers keeping their plain name. Previously scoped markers collapsed to a single name and Blender's importer renamed the duplicates `.001`/`.002`, losing the association. Verified byte-identical to the import-info source JMS.

## UI
- Remove the always-`[]` placeholder icon cell from block/array headers.
- Fix tofu (□) glyphs by adding a symbol-font fallback to the UI font families.
- Ignore the `.baboon-last-session.json` dev runtime file.

## Testing
- Baboon: 188 tests passing.
- blam-tags: full suite green, incl. new `marker_display_name` tests and the H2 particle positional-path integration test.
