### PR TITLE
Fix H2 tag corruption when pasting a block element into an empty block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,7 +407,7 @@ checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 [[package]]
 name = "blam-tags"
 version = "0.1.0"
-source = "git+https://github.com/camden-smallwood/blam-tags?rev=19b240518b3b7bc28d4a895845b1b3c3788821c4#19b240518b3b7bc28d4a895845b1b3c3788821c4"
+source = "git+https://github.com/camden-smallwood/blam-tags?rev=978c7b1fe1d96d7556a1f5f6453272aae4524878#978c7b1fe1d96d7556a1f5f6453272aae4524878"
 dependencies = [
  "bcdec_rs",
  "flate2",
@@ -1078,7 +1078,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2898,7 +2898,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3254,7 +3254,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3441,7 +3441,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3896,7 +3896,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1"
-blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "19b240518b3b7bc28d4a895845b1b3c3788821c4", features = ["audio"] }
+blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "978c7b1fe1d96d7556a1f5f6453272aae4524878", features = ["audio"] }
 eframe = { version = "0.29", default-features = false, features = ["default_fonts", "glow"] }
 egui_extras = { version = "0.29", features = ["svg"] }
 flate2 = "1"


### PR DESCRIPTION
## Problem

Copy/pasting a block element into a Halo 2 (`halo2_mcc`) block that is **empty on disk** corrupts the tag on save. Repro from the report: copy the *ready properties* element from `jackal.character` and paste it into `jackal_ultra.character` (whose *ready properties* block is empty). The paste applies fine, but saving fails verification with:

```
Save failed: saved classic tag failed verification: corrupt block header: count=1952605796 element_size=0
```

`1952605796` is the ASCII bytes `dfbt` — the H2 block-header signature — being misread as a `count` after a serializer cursor desync.

## Root cause

An empty-on-disk H2 block has `count = 0` and therefore **no `dfbt` header** (empty H2 blocks are headerless; `classic_block_header == None`).

`TagBlockMut::paste_element` spliced the element bytes and marked the block structurally dirty, but — unlike `add_element` / `insert_element` — it never called `ensure_h2_classic_header_for_nonempty`. So the block ended up with one element but still no header. On write, `canonical_h2_block_header` bails on the missing header, and `encode_block` emits the element with **no 16-byte header in front of it**. The verification re-read then consumes element bytes as a header and desyncs, landing on a nested `dfbt` signature where a `count` belongs (or running off the end → unexpected EOF).

Pasting into a *populated* block, or a block emptied via `clear()`, never triggered this — `clear()` preserves the original header.

## Fix

The actual fix is in the `blam-tags` engine (`camden-smallwood/blam-tags@978c7b1`): `paste_element` now calls `ensure_h2_classic_header_for_nonempty` before inserting, mirroring `add_element` / `insert_element`. It's a no-op for MCC/CE and for already-populated blocks, so byte-exact roundtrips are unchanged.

This PR bumps the pinned `blam-tags` rev to `978c7b1`.

## Verification

- New engine regression `tests/h2_block_paste_roundtrip.rs` (opt-in; skips without local tags): snapshots a *ready properties* element from `jackal.character` and pastes it into `elite_major.character` (empty block), then saves + rereads. Fails without the fix, passes with it.
- Full engine suite green: 208 lib + 11 versioned-struct roundtrip + 2 corruption tests, byte-exactness preserved.
- Baboon builds clean against the new rev.