### PR TITLE
Fix Reach/H3 dialogue & sounds playing the wrong FMOD variant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,7 +407,7 @@ checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 [[package]]
 name = "blam-tags"
 version = "0.1.0"
-source = "git+https://github.com/camden-smallwood/blam-tags?rev=978c7b1fe1d96d7556a1f5f6453272aae4524878#978c7b1fe1d96d7556a1f5f6453272aae4524878"
+source = "git+https://github.com/camden-smallwood/blam-tags?rev=5462808644d492eee50da40f2ee69a3ae4fba6a9#5462808644d492eee50da40f2ee69a3ae4fba6a9"
 dependencies = [
  "bcdec_rs",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1"
-blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "978c7b1fe1d96d7556a1f5f6453272aae4524878", features = ["audio"] }
+blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "5462808644d492eee50da40f2ee69a3ae4fba6a9", features = ["audio"] }
 eframe = { version = "0.29", default-features = false, features = ["default_fonts", "glow"] }
 egui_extras = { version = "0.29", features = ["svg"] }
 flate2 = "1"

--- a/src/app/audio.rs
+++ b/src/app/audio.rs
@@ -102,9 +102,15 @@ pub(super) enum InlineCodec {
 }
 
 pub(super) enum SoundAction {
-    /// Play the FMOD bank subsound named `key` (a permutation string-id).
-    /// Used by Halo 3+ whose audio is paged out to `<game>/fmod/pc/*.fsb`.
-    Play { key: String, label: String },
+    /// Play an FMOD bank subsound (Halo 3+, audio paged out to
+    /// `<game>/fmod/pc/*.fsb`). `id` is the engine's `fmod bank subsound id
+    /// hash` (preferred, collision-free); `key` is the permutation leaf name
+    /// (legacy fallback for banks without a `.fsb.info` manifest).
+    Play {
+        id: Option<u32>,
+        key: String,
+        label: String,
+    },
     /// Play encoded audio stored *inline* in the tag (classic Halo CE/H2).
     /// `chunk_offsets` are H2 per-chunk byte offsets into `bytes` (each chunk is
     /// an independent stream, concatenated on decode); empty = one stream (CE).
@@ -256,12 +262,25 @@ impl AudioState {
         self.banks.as_ref()
     }
 
-    /// Resolve an FMOD permutation `key` to a decoded (cached) buffer. Shared by
+    /// Resolve an FMOD permutation to a decoded (cached) buffer. Shared by
     /// audition and extraction; the bank borrow is scoped so it drops before the
     /// cache insert.
-    fn bank_pcm(&mut self, tags_root: &Path, key: &str) -> Result<Arc<DecodedPcm>, BankError> {
+    ///
+    /// Prefers the engine's `fmod bank subsound id hash` (`id`), which uniquely
+    /// identifies the intended permutation across the whole bank. Falls back to
+    /// the legacy `key` (permutation leaf name) when the id isn't available or
+    /// the bank has no `.fsb.info` — the name lookup is ambiguous (many tags
+    /// share a leaf) but is all older/non-MCC banks offer.
+    fn bank_pcm(
+        &mut self,
+        tags_root: &Path,
+        id: Option<u32>,
+        key: &str,
+    ) -> Result<Arc<DecodedPcm>, BankError> {
         let resolved = match self.ensure_banks(tags_root) {
-            Some(banks) => banks.resolve(key),
+            Some(banks) => id
+                .and_then(|id| banks.resolve_by_id(id))
+                .or_else(|| banks.resolve(key)),
             None => return Err(BankError::NoBank),
         };
         let Some((bank_index, sub_index)) = resolved else {
@@ -315,9 +334,9 @@ impl AudioState {
                         write_wav_pcm16(&item.out_path, &pcm.samples, pcm.channels, pcm.sample_rate)
                             .map_err(|e| e.to_string())
                     }),
-                ExtractSource::Bank { key } => match request.tags_root.as_deref() {
+                ExtractSource::Bank { id, key } => match request.tags_root.as_deref() {
                     None => Err("no source loaded".to_owned()),
-                    Some(tags_root) => match self.bank_pcm(tags_root, &key) {
+                    Some(tags_root) => match self.bank_pcm(tags_root, id, &key) {
                         Ok(pcm) => write_wav_pcm16(
                             &item.out_path,
                             &pcm.samples,
@@ -457,7 +476,7 @@ impl AudioState {
         let Some(action) = self.pending.take() else {
             return;
         };
-        let (key, label) = match action {
+        let (id, key, label) = match action {
             SoundAction::SetVolume(v) => {
                 let v = v.clamp(0.0, 1.0);
                 self.volume = Volume(v);
@@ -520,7 +539,7 @@ impl AudioState {
                 }
                 return;
             }
-            SoundAction::Play { key, label } => (key, label),
+            SoundAction::Play { id, key, label } => (id, key, label),
         };
         self.wwise_deferred = None; // FMOD playback supersedes a pending event
 
@@ -529,7 +548,7 @@ impl AudioState {
             return;
         };
 
-        match self.bank_pcm(tags_root, &key) {
+        match self.bank_pcm(tags_root, id, &key) {
             Ok(pcm) => self.play_decoded(&pcm, &label),
             Err(BankError::NoBank) => {
                 self.status = Some("no FMOD bank under <game>/fmod/pc".to_owned())

--- a/src/app/conversion.rs
+++ b/src/app/conversion.rs
@@ -4438,8 +4438,19 @@ mod tests {
                 if catalog.unusable_schema_reason(group, source_game).is_some() {
                     continue;
                 }
-                let source = TagFile::new(root.join(source_game).join(format!("{group}.json")))
-                    .unwrap_or_else(|error| panic!("{source_game}/{group}: {error}"));
+                // Resolve the schema by its real (cased) filename via `by_tag`.
+                // `group` is a lowercased `by_name` key, so `{group}.json` only
+                // matches the file on case-insensitive filesystems (macOS/Windows)
+                // — a few schema files are mixed-case (e.g.
+                // `GameEngineFirefightVariantTag.json`) and would be missed on
+                // Linux. The runtime loader uses the `by_tag` casing, so match it.
+                let index = &indexes[source_index];
+                let name = index
+                    .by_tag
+                    .get(&index.by_name[group])
+                    .map_or(group.as_str(), String::as_str);
+                let source = TagFile::new(root.join(source_game).join(format!("{name}.json")))
+                    .unwrap_or_else(|error| panic!("{source_game}/{name}: {error}"));
                 for (target_index, target_game) in CONVERSION_GAMES.iter().enumerate() {
                     if source_game == target_game
                         || !indexes[target_index].by_name.contains_key(group)

--- a/src/app/editor/sound.rs
+++ b/src/app/editor/sound.rs
@@ -593,16 +593,42 @@ pub(super) fn sound_permutation_rows(tag: &TagFile) -> Vec<SoundPermRow> {
     rows
 }
 
+/// A `.sound` tag's `<tags root>`-relative path without extension (e.g.
+/// `.../tags/sound/dialog/.../ambush.sound` → `sound\dialog\...\ambush`), for
+/// building the FMOD subsound id. Backslash-normalized; the hash lowercases.
+fn sound_tag_rel(abs: &std::path::Path, tags_root: &std::path::Path) -> Option<String> {
+    let rel = abs.strip_prefix(tags_root).ok()?;
+    Some(rel.with_extension("").to_string_lossy().replace('/', "\\"))
+}
+
+/// The engine's `fmod bank subsound id hash` for a Halo 3+ permutation row —
+/// the collision-free key that resolves to the exact intended variant. Needs the
+/// owning `.sound` tag's rel path (e.g. `sound\dialog\...\ambush`); returns
+/// `None` when it's unknown, and playback then falls back to leaf-name lookup.
+/// Folds in the pitch-range folder per the engine rule, and hashes the
+/// permutation's raw string-id (`row.name`) — matching the tool's own build.
+fn row_bank_id(sound_rel: Option<&str>, multi_pr: bool, row: &SoundPermRow) -> Option<u32> {
+    let sound_rel = sound_rel?;
+    let pitch = blam_tags::audio::fmod_pitch_range_folder(&row.pitch_range, multi_pr);
+    Some(blam_tags::audio::fmod_bank_subsound_id_hash(
+        sound_rel, pitch, &row.name,
+    ))
+}
+
 /// The play action for a permutation row (bank subsound / CE inline Ogg / H2
 /// inline blob). Returns `None` if the inline bytes can't be re-extracted.
+/// `sound_rel`/`multi_pr` disambiguate the FMOD subsound (see [`row_bank_id`]).
 fn row_play_action(
     tag: &TagFile,
     row: &SoundPermRow,
     h2_params: Option<(super::audio::InlineCodec, u16, u32)>,
+    sound_rel: Option<&str>,
+    multi_pr: bool,
 ) -> Option<super::audio::SoundAction> {
     use super::audio::{InlineCodec, SoundAction};
     match &row.kind {
         RowKind::Bank => Some(SoundAction::Play {
+            id: row_bank_id(sound_rel, multi_pr, row),
             key: row.name.clone(),
             label: row.name.clone(),
         }),
@@ -646,10 +672,13 @@ fn row_extract_source(
     row: &SoundPermRow,
     h2_params: Option<(super::audio::InlineCodec, u16, u32)>,
     raw_ce: bool,
+    sound_rel: Option<&str>,
+    multi_pr: bool,
 ) -> Option<ExtractSource> {
     use super::audio::InlineCodec;
     match &row.kind {
         RowKind::Bank => Some(ExtractSource::Bank {
+            id: row_bank_id(sound_rel, multi_pr, row),
             key: row.name.clone(),
         }),
         RowKind::InlineCe {
@@ -762,11 +791,12 @@ pub(super) fn build_extract_items(
     h2_params: Option<(super::audio::InlineCodec, u16, u32)>,
     base: &std::path::Path,
     raw_ce: bool,
+    sound_rel: Option<&str>,
 ) -> Vec<ExtractItem> {
     let multi_pr = rows_span_multiple_pitch_ranges(rows);
     rows.iter()
         .filter_map(|row| {
-            let source = row_extract_source(tag, row, h2_params, raw_ce)?;
+            let source = row_extract_source(tag, row, h2_params, raw_ce, sound_rel, multi_pr)?;
             let rel = perm_relative_path(multi_pr, row, row_extract_ext(&row.kind, raw_ce));
             Some(ExtractItem {
                 out_path: base.join(rel),
@@ -891,6 +921,13 @@ pub(in crate::app) fn draw_sound_player(
         .tag_key
         .strip_prefix("file:")
         .map(std::path::PathBuf::from);
+    // This tag's rel path (e.g. `sound\dialog\...\ambush`) + whether it spans
+    // multiple pitch ranges — both feed the FMOD subsound id hash.
+    let sound_rel = abs_tag_path
+        .as_deref()
+        .zip(edit.tags_root)
+        .and_then(|(abs, root)| sound_tag_rel(abs, root));
+    let multi_pr = rows_span_multiple_pitch_ranges(&rows);
 
     egui::CollapsingHeader::new(
         RichText::new(format!("Sound \u{2014} {} permutation(s)", rows.len())).color(text_dark()),
@@ -942,7 +979,8 @@ pub(in crate::app) fn draw_sound_player(
                         .pick_folder()
                 });
                 if let Some(base) = base {
-                    let items = build_extract_items(tag, &rows, h2_params, &base, raw_ce);
+                    let items =
+                        build_extract_items(tag, &rows, h2_params, &base, raw_ce, sound_rel.as_deref());
                     let label = base
                         .file_name()
                         .map(|name| name.to_string_lossy().into_owned())
@@ -976,7 +1014,8 @@ pub(in crate::app) fn draw_sound_player(
                                 _ => "Play this permutation (inline tag audio)",
                             };
                             if ui.small_button("\u{25B6}").on_hover_text(hover).clicked() {
-                                *edit.sound_play_request = row_play_action(tag, row, h2_params);
+                                *edit.sound_play_request =
+                                    row_play_action(tag, row, h2_params, sound_rel.as_deref(), multi_pr);
                             }
                             if ui
                                 .small_button("\u{2B07}")
@@ -992,9 +1031,14 @@ pub(in crate::app) fn draw_sound_player(
                                     ))
                                     .save_file()
                                 {
-                                    if let Some(source) =
-                                        row_extract_source(tag, row, h2_params, raw_ce)
-                                    {
+                                    if let Some(source) = row_extract_source(
+                                        tag,
+                                        row,
+                                        h2_params,
+                                        raw_ce,
+                                        sound_rel.as_deref(),
+                                        multi_pr,
+                                    ) {
                                         *edit.sound_extract_request = Some(ExtractRequest {
                                             items: vec![ExtractItem {
                                                 out_path: path,
@@ -1112,8 +1156,12 @@ fn load_referenced_sound(
 }
 
 /// The play action for the first playable unit of a (referenced) sound tag:
-/// a Wwise event (H4) or the first pitch-range permutation.
-fn referenced_sound_play_action(tag: &TagFile) -> Option<super::audio::SoundAction> {
+/// a Wwise event (H4) or the first pitch-range permutation. `sound_rel` is the
+/// referenced tag's rel path, used to compute the FMOD subsound id.
+fn referenced_sound_play_action(
+    tag: &TagFile,
+    sound_rel: Option<&str>,
+) -> Option<super::audio::SoundAction> {
     if let Some((_, name)) = h4_event_names(tag).into_iter().next() {
         return Some(super::audio::SoundAction::PlayEvent {
             event_name: name.clone(),
@@ -1122,17 +1170,23 @@ fn referenced_sound_play_action(tag: &TagFile) -> Option<super::audio::SoundActi
     }
 
     let rows = sound_permutation_rows(tag);
+    let multi_pr = rows_span_multiple_pitch_ranges(&rows);
     let is_h2 = rows
         .iter()
         .any(|row| matches!(row.kind, RowKind::InlineH2 { .. }));
     let h2_params = is_h2.then(|| h2_codec_params(tag));
     rows.first()
-        .and_then(|row| row_play_action(tag, row, h2_params))
+        .and_then(|row| row_play_action(tag, row, h2_params, sound_rel, multi_pr))
 }
 
 /// Extract items for a whole (referenced) sound tag under `base` — Wwise events
 /// or pitch-range permutations, matching the primary extractor's layout.
-fn referenced_sound_extract_items(tag: &TagFile, base: &std::path::Path) -> Vec<ExtractItem> {
+/// `sound_rel` is the referenced tag's rel path (for the FMOD subsound id).
+fn referenced_sound_extract_items(
+    tag: &TagFile,
+    base: &std::path::Path,
+    sound_rel: Option<&str>,
+) -> Vec<ExtractItem> {
     let events = h4_event_names(tag);
     if !events.is_empty() {
         return events
@@ -1148,7 +1202,7 @@ fn referenced_sound_extract_items(tag: &TagFile, base: &std::path::Path) -> Vec<
         .iter()
         .any(|row| matches!(row.kind, RowKind::InlineH2 { .. }));
     let h2_params = is_h2.then(|| h2_codec_params(tag));
-    build_extract_items(tag, &rows, h2_params, base, false)
+    build_extract_items(tag, &rows, h2_params, base, false, sound_rel)
 }
 
 /// Render a set of `.sound` refs with a ▶ Play, ⬇ Extract, and the clickable
@@ -1184,7 +1238,7 @@ fn draw_referenced_sound_cell(
                     if let Some((sound, _)) =
                         load_referenced_sound(game, tags_root, definitions_root, path, *group)
                     {
-                        play = referenced_sound_play_action(&sound);
+                        play = referenced_sound_play_action(&sound, Some(path.as_str()));
                     }
                 }
                 if is_sound
@@ -1199,7 +1253,8 @@ fn draw_referenced_sound_cell(
                         if let Some(base) =
                             tags_root.and_then(|root| reimport_base_dir_lang(root, &abs, language))
                         {
-                            let items = referenced_sound_extract_items(&sound, &base);
+                            let items =
+                                referenced_sound_extract_items(&sound, &base, Some(path.as_str()));
                             let label = path.rsplit(['\\', '/']).next().unwrap_or(path).to_owned();
                             extract = Some(ExtractRequest {
                                 items,

--- a/src/app/editor/tests.rs
+++ b/src/app/editor/tests.rs
@@ -120,6 +120,129 @@ mod tests {
         assert!(resolved > 0);
     }
 
+    /// Coverage audit (skip-if-absent): walk *every* `.sound` tag under a game's
+    /// tags tree, compute each permutation's `fmod bank subsound id hash` exactly
+    /// as the sound player does, and check it resolves in the FMOD banks. Reports
+    /// id-coverage and, for id-misses, whether the legacy name lookup would have
+    /// found *anything* — so a miss is attributed to a genuinely absent subsound
+    /// vs. a hash/reconstruction gap. Run with:
+    ///   SND_TAGS_ROOT=/Users/camden/Halo/haloreach_mcc/tags \
+    ///     cargo test fmod_id_resolves_every_permutation -- --ignored --nocapture
+    #[test]
+    #[ignore]
+    fn fmod_id_resolves_every_permutation() {
+        use blam_tags::audio::{fmod_bank_subsound_id_hash, fmod_pitch_range_folder, SoundBanks};
+
+        let root = std::env::var("SND_TAGS_ROOT")
+            .unwrap_or_else(|_| "/Users/camden/Halo/haloreach_mcc/tags".to_owned());
+        let tags_root = std::path::Path::new(&root);
+        if !tags_root.exists() {
+            eprintln!("skip: no tags at {}", tags_root.display());
+            return;
+        }
+        let banks = SoundBanks::open_pc(tags_root).expect("open FMOD banks");
+
+        // Recursively collect every .sound tag.
+        let mut sound_tags = Vec::new();
+        let mut stack = vec![tags_root.to_path_buf()];
+        while let Some(dir) = stack.pop() {
+            let Ok(entries) = std::fs::read_dir(&dir) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let p = entry.path();
+                if p.is_dir() {
+                    stack.push(p);
+                } else if p.extension().is_some_and(|e| e == "sound") {
+                    sound_tags.push(p);
+                }
+            }
+        }
+        eprintln!("scanning {} .sound tags under {}", sound_tags.len(), root);
+
+        let (mut perms, mut by_id, mut by_name, mut id_miss_name_hit, mut absent, mut no_pr) =
+            (0usize, 0usize, 0usize, 0usize, 0usize, 0usize);
+        let mut hash_gaps: Vec<String> = Vec::new();
+
+        for tag_path in &sound_tags {
+            let Ok(tag) = blam_tags::TagFile::read(tag_path) else {
+                continue;
+            };
+            let tag_root = tag.root();
+            let Some(pitch_ranges) = find_block_field(&tag_root, "pitch range") else {
+                no_pr += 1;
+                continue;
+            };
+            // Tag rel path (backslash, no extension) — the hash input's tag part.
+            let rel = tag_path
+                .strip_prefix(tags_root)
+                .unwrap_or(tag_path)
+                .with_extension("")
+                .to_string_lossy()
+                .replace('/', "\\");
+            let multi_pr = pitch_ranges.len() > 1;
+            for pr_index in 0..pitch_ranges.len() {
+                let Some(pr) = pitch_ranges.element(pr_index) else {
+                    continue;
+                };
+                let pr_name = find_full_field_name(&pr, "name")
+                    .and_then(|full| pr.read_string_id(full))
+                    .unwrap_or_default();
+                let folder = fmod_pitch_range_folder(&pr_name, multi_pr);
+                let Some(permutations) = find_block_field(&pr, "permutation") else {
+                    continue;
+                };
+                for perm_index in 0..permutations.len() {
+                    let Some(perm) = permutations.element(perm_index) else {
+                        continue;
+                    };
+                    let Some(name) = find_full_field_name(&perm, "name")
+                        .and_then(|full| perm.read_string_id(full))
+                        .filter(|n| !n.is_empty())
+                    else {
+                        continue;
+                    };
+                    perms += 1;
+                    let id = fmod_bank_subsound_id_hash(&rel, folder, &name);
+                    let id_hit = banks.resolve_by_id(id).is_some();
+                    let name_hit = banks.resolve(&name).is_some();
+                    if id_hit {
+                        by_id += 1;
+                    }
+                    if name_hit {
+                        by_name += 1;
+                    }
+                    if !id_hit {
+                        if name_hit {
+                            id_miss_name_hit += 1;
+                            if hash_gaps.len() < 30 {
+                                hash_gaps.push(format!("{rel}\\{}#{perm_index} :: {name}", pr_name));
+                            }
+                        } else {
+                            absent += 1;
+                        }
+                    }
+                }
+            }
+        }
+
+        eprintln!("permutations: {perms}");
+        eprintln!(
+            "  resolved by id  : {by_id} ({:.2}%)",
+            100.0 * by_id as f64 / perms.max(1) as f64
+        );
+        eprintln!("  resolved by name: {by_name} (legacy, ambiguous)");
+        eprintln!("  id-miss, name-hit (potential hash gap): {id_miss_name_hit}");
+        eprintln!("  id-miss, name-miss (subsound absent from bank): {absent}");
+        eprintln!("  tags without a pitch-range block (Wwise/classic): {no_pr}");
+        if !hash_gaps.is_empty() {
+            eprintln!("  sample hash gaps:");
+            for g in &hash_gaps {
+                eprintln!("    {g}");
+            }
+        }
+    }
+
     /// H2 investigation (skip-if-absent): walk the classic `.sound` tag and dump
     /// every non-empty `data` field with its path + size + first bytes, to locate
     /// the inline audio and characterize its framing. Point at a tag with
@@ -426,7 +549,7 @@ mod tests {
         let wav_dir = std::env::temp_dir().join("baboon_ce_extract_wav");
         let _ = std::fs::remove_dir_all(&wav_dir);
 
-        let items = build_extract_items(&tag, &rows, None, &wav_dir, false);
+        let items = build_extract_items(&tag, &rows, None, &wav_dir, false, None);
         let mut audio = super::audio::AudioState::default();
         audio.run_extract(ExtractRequest {
             items,
@@ -442,7 +565,7 @@ mod tests {
         // Raw .ogg passthrough should be byte-identical to the inline samples.
         let ogg_dir = std::env::temp_dir().join("baboon_ce_extract_ogg");
         let _ = std::fs::remove_dir_all(&ogg_dir);
-        let items = build_extract_items(&tag, &rows, None, &ogg_dir, true);
+        let items = build_extract_items(&tag, &rows, None, &ogg_dir, true, None);
         audio.run_extract(ExtractRequest {
             items,
             tags_root: None,
@@ -482,7 +605,7 @@ mod tests {
         let h2_params = Some(h2_codec_params(&tag));
         let dir = std::env::temp_dir().join("baboon_h2_extract");
         let _ = std::fs::remove_dir_all(&dir);
-        let items = build_extract_items(&tag, &rows, h2_params, &dir, false);
+        let items = build_extract_items(&tag, &rows, h2_params, &dir, false, None);
         let count = items.len();
         let mut audio = super::audio::AudioState::default();
         audio.run_extract(ExtractRequest {
@@ -523,7 +646,7 @@ mod tests {
         assert!(!rows.is_empty());
         let dir = std::env::temp_dir().join("baboon_bank_extract");
         let _ = std::fs::remove_dir_all(&dir);
-        let items = build_extract_items(&tag, &rows, None, &dir, false);
+        let items = build_extract_items(&tag, &rows, None, &dir, false, None);
         let mut audio = super::audio::AudioState::default();
         audio.run_extract(ExtractRequest {
             items,

--- a/src/app/sound_extract.rs
+++ b/src/app/sound_extract.rs
@@ -40,9 +40,10 @@ pub(super) enum ExtractSource {
         sample_rate: u32,
         chunk_offsets: Vec<usize>,
     },
-    /// Resolve an FMOD bank subsound by permutation name (H3/ODST/Reach),
-    /// decode, write WAV.
-    Bank { key: String },
+    /// Resolve an FMOD bank subsound (H3/ODST/Reach), decode, write WAV.
+    /// `id` is the engine's `fmod bank subsound id hash` (preferred); `key` is
+    /// the permutation leaf name (legacy fallback). See `AudioState::bank_pcm`.
+    Bank { id: Option<u32>, key: String },
     /// Resolve a Wwise event by name (H4), decode, write WAV.
     Event { name: String },
 }


### PR DESCRIPTION
## Problem

The sound player resolved FMOD bank subsounds by the **bare permutation leaf name** (e.g. `ambush_1`). Those names are *not* unique — `ambush_1` recurs across 12+ dialogue characters and hundreds of tags — so the name lookup (`index_of`/`find_substr`) returned an arbitrary tag's permutation. Reach dialogue was the visible symptom: playing `civilian_1`'s `ambush_1` gave some other character's line. It also affected extraction and any Halo 3+ FMOD sound.

## Fix

Resolve by the engine's own collision-free key: the **`fmod bank subsound id hash`**. This is a djb2 hash (seed 5381, mult 33) over the source path `data\<tag_path>[\<pitch_range>]\<permutation>` with the constant `data\sound\` prefix skipped — reverse-engineered from `reach_tag_test.exe` (`sub_140256B00`) and verified against the shipped `*.fsb.info` manifests.

- **blam-tags** (bumped to `5462808`): adds `fmod_bank_subsound_id_hash` + `fmod_pitch_range_folder`, parses the per-subsound id column from `<bank>.fsb.info` into an id index, and adds `SoundBanks::resolve_by_id`. Falls back to the legacy name lookup for banks without a manifest, so nothing regresses.
- **Baboon**: `SoundAction::Play` / `ExtractSource::Bank` carry the subsound id; `bank_pcm` resolves by id first, then name. The tag's rel path + pitch-range are threaded through the primary player, the dialogue/referenced player, and both extract paths.

## Verification

Audited **every** real `.sound` tag against the real banks (new ignored, skip-if-absent test `fmod_id_resolves_every_permutation`):

| Game | Permutations | Resolved by id |
|------|-------------:|---------------:|
| Halo 3 | 49,293 | **100.00%** |
| Reach | 47,663 | **99.86%** |

The Reach remainder is deduplicated/absent source audio (CE-Anniversary DLC ambience whose audio lives under the campaign path, plus a handful of subsounds not shipped in the bank) — those fall back to name resolution, so everything that was playable still plays. id-resolution resolves *more* than the old name path did (47,595 vs 47,468) and without the wrong-variant mismatches. Applies equally to ODST (shared MCC sound pipeline).