### PR TITLE
Consolidate field-path/name logic into blam-tags; fix range-hint field resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,7 +407,7 @@ checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 [[package]]
 name = "blam-tags"
 version = "0.1.0"
-source = "git+https://github.com/camden-smallwood/blam-tags?rev=5462808644d492eee50da40f2ee69a3ae4fba6a9#5462808644d492eee50da40f2ee69a3ae4fba6a9"
+source = "git+https://github.com/camden-smallwood/blam-tags?rev=3dfe74f62f92dc6b576436070d232005ba8c312d#3dfe74f62f92dc6b576436070d232005ba8c312d"
 dependencies = [
  "bcdec_rs",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1"
-blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "5462808644d492eee50da40f2ee69a3ae4fba6a9", features = ["audio"] }
+blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "3dfe74f62f92dc6b576436070d232005ba8c312d", features = ["audio"] }
 eframe = { version = "0.29", default-features = false, features = ["default_fonts", "glow"] }
 egui_extras = { version = "0.29", features = ["svg"] }
 flate2 = "1"

--- a/src/app.rs
+++ b/src/app.rs
@@ -705,6 +705,66 @@ mod tests {
     }
 
     #[test]
+    fn clean_field_name_strips_every_markup_form() {
+        // Display-label cleaning must strip all Guerilla markup so a segment
+        // built from a field name never carries a path-grammar character. These
+        // are the forms the compatibility sweep found across all 5 MCC kits.
+        assert_eq!(clean_field_name("jump velocity"), "jump velocity");
+        assert_eq!(clean_field_name("ambient color:[0,255]"), "ambient color");
+        assert_eq!(clean_field_name("max sounds per tag [1,16]"), "max sounds per tag");
+        assert_eq!(clean_field_name("shader flags*"), "shader flags");
+        assert_eq!(clean_field_name("activity!"), "activity");
+        assert_eq!(clean_field_name("activity name^"), "activity name");
+        assert_eq!(clean_field_name("acoustics{background sounds}*"), "acoustics");
+        assert_eq!(clean_field_name("bounds 480i&bounds 4x3 (640x480)"), "bounds 480i");
+        // H2 model_animation_graph dumper artifact `name|CODE`.
+        assert_eq!(clean_field_name("animations|ABCDCC"), "animations");
+    }
+
+    #[test]
+    fn canonical_field_path_normalizes_names_paths_and_codes() {
+        // Single names normalize to their clean form.
+        assert_eq!(canonical_field_path("ambient color:[0,255]"), "ambient color");
+        // Multi-segment paths drop element indices AND field ordinals per segment,
+        // cleaning each name — the form the conversion loss-detector relies on.
+        assert_eq!(
+            canonical_field_path("bitmaps#21[0]/signature#0"),
+            "bitmaps/signature"
+        );
+        assert_eq!(
+            canonical_field_path("resources#0/animations|ABCDCC#8"),
+            "resources/animations"
+        );
+        assert_eq!(
+            canonical_field_path(
+                "new damage info#19[0]/damage sections#26[0]/instant responses#3[0]/response type#0"
+            ),
+            "new damage info/damage sections/instant responses/response type"
+        );
+        // clean_field_key is the lowercased canonical form.
+        assert_eq!(clean_field_key("Shader Flags*"), "shader flags");
+        assert_eq!(clean_field_key("Bitmaps#21[0]/Signature#0"), "bitmaps/signature");
+    }
+
+    #[test]
+    fn resolvable_and_canonical_path_flavors_stay_consistent() {
+        // The search-filter invariant (see `collect_visible_paths` /
+        // `field_visible`): the canonical key a container is stored under equals
+        // `strip_node_indices` of the resolvable render path. This only holds
+        // because resolvable paths carry CLEAN names (a range hint left in the
+        // name would strip-to a different key and break the filter).
+        //
+        // Simulate the two flavors for a markup-named field. `resolvable` is what
+        // `append_field_path_for` emits (clean name + ordinal, plus a parent
+        // element index); `canon` is what `collect_visible_paths` records.
+        let seg = clean_field_name("max sounds per tag [1,16]"); // build-time clean
+        let resolvable = format!("ambient color#5[0]/{seg}#9");
+        let canon = format!("ambient color/{seg}");
+        assert_eq!(strip_node_indices(&resolvable), canon);
+        assert_eq!(canon, "ambient color/max sounds per tag");
+    }
+
+    #[test]
     fn tag_ref_path_helpers() {
         // Null terminator stripped so the ref resolves on disk.
         assert_eq!(

--- a/src/app/editor/tests.rs
+++ b/src/app/editor/tests.rs
@@ -1141,6 +1141,28 @@ mod tests {
     }
 
     #[test]
+    fn field_meta_uses_foundation_marker_semantics() {
+        // Foundation semantics (adopted from `TagFieldNameInfo`): `*` = read-only,
+        // `!` = hidden/expert-only (Baboon's `advanced` gate). Presence-tested, so
+        // order and combination don't matter — the old `ends_with` parser dropped
+        // `*` on `angle*!`.
+        let ro = field_display_meta("a position*");
+        assert!(ro.read_only && !ro.advanced, "'*' => read-only");
+
+        let hidden = field_display_meta("activity!");
+        assert!(hidden.advanced && !hidden.read_only, "'!' => hidden/advanced");
+
+        let both = field_display_meta("angle*!");
+        assert!(both.read_only, "combined: '*' still read-only");
+        assert!(both.advanced, "combined: '!' still hidden");
+        assert_eq!(both.label, "angle");
+
+        let both_rev = field_display_meta("aabb center!*");
+        assert!(both_rev.read_only && both_rev.advanced, "order-independent");
+        assert_eq!(both_rev.label, "aabb center");
+    }
+
+    #[test]
     fn field_meta_separates_range_from_unit_and_suffix_shows_both() {
         // Range in the unit slot: unit is empty, range captured; suffix shows
         // the type (no unit) followed by the range.

--- a/src/app/editor/value_parser.rs
+++ b/src/app/editor/value_parser.rs
@@ -23,7 +23,12 @@ pub(in crate::app) fn append_field_path(prefix: &str, field_name: &str) -> Strin
 /// block ops, function data). Canonical/display paths use the plain-name
 /// form and strip the ordinal via `strip_node_indices`.
 pub(in crate::app) fn append_field_path_for(prefix: &str, field: &TagField<'_>) -> String {
-    let segment = format!("{}#{}", field.name(), field.ordinal());
+    // Emit the CLEAN (markup-free) name so field-name markup — `:units`,
+    // `[range]`, `#help` — can't collide with the path grammar's own `type:`,
+    // `[index]`, and `#ordinal` tokens (the range-hint-as-index bug). The engine
+    // resolves the ordinal positionally; the clean name is the readable/fallback
+    // key. See `blam_tags::field_name` / `blam_tags::TagFieldPath`.
+    let segment = format!("{}#{}", field.clean_name(), field.ordinal());
     if prefix.is_empty() {
         segment
     } else {
@@ -480,50 +485,20 @@ pub(in crate::app) fn parse_tag_reference(input: &str) -> Result<TagReferenceDat
 }
 
 pub(in crate::app) fn field_display_meta(name: &str) -> FieldDisplayMeta {
-    let mut text = name.trim().to_owned();
-
-    let advanced = text.ends_with('*');
-    if advanced {
-        text.pop();
-    }
-    let read_only = text.ends_with('!');
-    if read_only {
-        text.pop();
-    }
-    let (text, help) = match text.split_once('#') {
-        Some((label, help)) => (label.trim().to_owned(), Some(help.trim().to_owned())),
-        None => (text, None),
-    };
-    // A `[min,max]` range may sit in the unit slot (`name:[0,1]`) or bare in the
-    // name (`max sounds [1,16]`); pull it out so the unit and range are distinct.
-    let (text, range) = extract_range_hint(&text);
-    let (label, unit) = match text.split_once(':') {
-        Some((label, unit)) => (label.trim().to_owned(), Some(unit.trim().to_owned())),
-        None => (text.trim().to_owned(), None),
-    };
+    // The engine owns the canonical field-name markup grammar (Foundation's
+    // `TagFieldNameInfo`). We map its decomposition onto Baboon's display meta.
+    // Note the Foundation marker semantics adopted here: `*` = read-only,
+    // `!` = hidden/expert-only (Baboon's `advanced` gate). See
+    // `blam_tags::field_name`.
+    let info = blam_tags::parse_field_name(name);
     FieldDisplayMeta {
-        label: clean_field_name_basic(&label),
-        unit: unit.filter(|unit| !unit.is_empty()),
-        range,
-        help: help.filter(|help| !help.is_empty()),
+        label: info.clean_name.into_owned(),
+        unit: info.units.map(str::to_owned),
+        range: info.range.map(str::to_owned),
+        help: info.description.map(str::to_owned),
         tag_reference_allowed: Vec::new(),
-        read_only,
-
-        advanced,
-    }
-}
-
-/// Split a `[ … ]` range hint out of `text`, returning `(remainder, range)`.
-/// The range keeps its brackets (e.g. `[0,+inf]`).
-fn extract_range_hint(text: &str) -> (String, Option<String>) {
-    match (text.find('['), text.rfind(']')) {
-        (Some(open), Some(close)) if open < close => {
-            let range = text[open..=close].to_owned();
-            let mut rest = text[..open].to_owned();
-            rest.push_str(&text[close + 1..]);
-            (rest, Some(range))
-        }
-        _ => (text.to_owned(), None),
+        read_only: info.read_only,
+        advanced: info.hidden,
     }
 }
 

--- a/src/app/find.rs
+++ b/src/app/find.rs
@@ -103,7 +103,7 @@ fn collect_find_struct(
             && field.as_struct().is_some()
             && is_inherited_parent_name(field.name());
         let path = if inherited_wrapper {
-            append_field_path(prefix, field.name())
+            append_field_path(prefix, field.clean_name().as_ref())
         } else {
             append_field_path_for(prefix, &field)
         };

--- a/src/app/foundation/containers.rs
+++ b/src/app/foundation/containers.rs
@@ -97,7 +97,7 @@ pub(in crate::app) fn inherited_struct_chain(
         let Some(parent_struct) = parent_field.as_struct() else {
             break;
         };
-        path_prefix = append_field_path(&path_prefix, parent_field.name());
+        path_prefix = append_field_path(&path_prefix, parent_field.clean_name().as_ref());
         chain.push((parent_struct, path_prefix.clone()));
         current = parent_struct;
     }
@@ -1380,17 +1380,11 @@ pub(in crate::app) fn parent_block_path(path: &str) -> Option<String> {
     Some(parent)
 }
 
-/// A readable breadcrumb for a block path: cleaned segments (index suffixes
-/// dropped) joined with ` › `, e.g. `regions[0]/permutations` → `regions › permutations`.
+/// A readable breadcrumb for a block path: cleaned segments (index/ordinal
+/// suffixes dropped) joined with ` › `, e.g. `regions[0]/permutations` →
+/// `regions › permutations`. Backed by the engine's `TagFieldPath`.
 pub(super) fn breadcrumb_for_path(path: &str) -> String {
-    path.split('/')
-        .map(|segment| {
-            let base = segment.split('[').next().unwrap_or(segment);
-            clean_field_name(base.split('#').next().unwrap_or(base))
-        })
-        .filter(|segment| !segment.is_empty())
-        .collect::<Vec<_>>()
-        .join(" › ")
+    blam_tags::TagFieldPath::parse(path).breadcrumb()
 }
 
 /// egui-memory key holding the block path that a pending "jump to parent" should

--- a/src/app/foundation/functions.rs
+++ b/src/app/foundation/functions.rs
@@ -38,7 +38,7 @@ pub(in crate::app) fn draw_foundation_function_row(
                         if function_button {
                             *edit.function_request = Some(FunctionPopup::new(
                                 edit.tag_key.to_owned(),
-                                clean_field_name(path),
+                                canonical_field_path(path),
                                 FunctionView::from_function(function.clone())
                                     .with_edit(foundation_function_edit_paths(path)),
                                 true,

--- a/src/app/foundation/traversal.rs
+++ b/src/app/foundation/traversal.rs
@@ -106,14 +106,15 @@ fn collect_visible_paths(
 ) -> bool {
     let mut any = false;
     for field in tag_struct.fields() {
-        let name_matches = clean_field_name(field.name())
-            .to_ascii_lowercase()
-            .contains(query);
-        // Canonical path = raw field names joined by '/', no element indices.
+        let clean = clean_field_name(field.name());
+        let name_matches = clean.to_ascii_lowercase().contains(query);
+        // Canonical path = CLEAN field names joined by '/', no element indices or
+        // ordinals. Must match `strip_node_indices` of the render-walk paths,
+        // which are also built from clean names (see `append_field_path_for`).
         let canon = if canon_prefix.is_empty() {
-            field.name().to_owned()
+            clean.clone()
         } else {
-            format!("{canon_prefix}/{}", field.name())
+            format!("{canon_prefix}/{clean}")
         };
 
         let child_under = under_matched || name_matches;

--- a/src/app/material.rs
+++ b/src/app/material.rs
@@ -446,7 +446,7 @@ pub(super) fn material_section_text(text: String) -> RichText {
 }
 
 pub(super) fn clean_field_name(name: &str) -> String {
-    field_display_meta(name).label
+    blam_tags::clean_field_name(name).into_owned()
 }
 
 pub(super) fn clean_field_name_basic(name: &str) -> String {
@@ -457,11 +457,18 @@ pub(super) fn clean_field_name_basic(name: &str) -> String {
         .join(" ")
 }
 
+/// Canonical form of a field PATH (or a single field name): each `/`-segment
+/// has its markup stripped and its element index / ordinal dropped. Backed by
+/// the engine's `TagFieldPath`, so names and multi-segment paths normalize
+/// uniformly. Used for path/name comparison keys.
+pub(super) fn canonical_field_path(path: &str) -> String {
+    blam_tags::TagFieldPath::parse(path)
+        .strip_node_indices()
+        .to_string()
+}
+
 pub(super) fn clean_field_key(name: &str) -> String {
-    clean_field_name(name)
-        .replace('^', "")
-        .trim()
-        .to_ascii_lowercase()
+    canonical_field_path(name).to_ascii_lowercase()
 }
 
 pub(super) fn clean_type_name(type_name: &str) -> String {

--- a/src/app/tests/classic_h2.rs
+++ b/src/app/tests/classic_h2.rs
@@ -53,3 +53,106 @@ fn h2_particle_mapping_field_edit_targets_exact_field() {
         "Function Type not set via positional path: {value:?}"
     );
 }
+
+fn load_h2_tag(tag_path: &str, def_rel: &str) -> Option<blam_tags::TagFile> {
+    let def = test_definition_path(def_rel);
+    if !std::path::Path::new(tag_path).exists() || !std::path::Path::new(&def).exists() {
+        eprintln!("skipping: {tag_path} / {def_rel} not present");
+        return None;
+    }
+    let bytes = std::fs::read(tag_path).ok()?;
+    let layout = blam_tags::layout::TagLayout::from_json(&def).ok()?;
+    blam_tags::classic::read_classic_tag_file(&bytes, layout).ok()
+}
+
+/// A field inside a **versioned** classic block (H2 `bitmap_data`, on-disk 116
+/// bytes vs its base struct 140) must resolve and edit. The path descent used to
+/// bounds-check against the base size and reject the descent entirely.
+#[test]
+fn h2_bitmap_versioned_block_field_resolves_and_edits() {
+    let Some(mut tag) =
+        load_h2_tag("/Users/camden/Halo/halo2_mcc/tags/globals/loading_screen.bitmap", "halo2_mcc/bitmap.json")
+    else {
+        return;
+    };
+
+    let path = {
+        let root = tag.root();
+        let bitmaps = root
+            .fields_all()
+            .find(|f| f.clean_name() == "bitmaps" && f.as_block().is_some())
+            .expect("bitmaps block");
+        let block_path = format!("{}[0]", append_field_path_for("", &bitmaps));
+        let element = bitmaps.as_block().unwrap().element(0).expect("bitmaps[0]");
+        let depth = element
+            .fields_all()
+            .find(|f| f.clean_name() == "depth")
+            .expect("depth field inside bitmap_data");
+        append_field_path_for(&block_path, &depth)
+    };
+
+    // The fix: descent into the versioned block resolves.
+    assert!(
+        tag.root().field_path(&path).is_some(),
+        "versioned-block descent failed for {path}"
+    );
+    apply_field_edit(&mut tag, &path, "2").unwrap();
+    let value = tag.root().field_path(&path).and_then(|f| f.value());
+    assert!(
+        matches!(value, Some(TagFieldData::ShortInteger(2)) | Some(TagFieldData::CharInteger(2))),
+        "depth not written through versioned-block path: {value:?}"
+    );
+}
+
+/// Recursively find the first field whose RAW name carries the `|CODE` dumper
+/// artifact, returning (clean resolvable path, raw name). Descends struct/block/
+/// array via element 0.
+fn find_coded_field(st: &blam_tags::TagStruct<'_>, prefix: &str) -> Option<(String, String)> {
+    for field in st.fields_all() {
+        let path = append_field_path_for(prefix, &field);
+        if field.name().contains('|') {
+            return Some((path, field.name().to_owned()));
+        }
+        let nested = if let Some(inner) = field.as_struct() {
+            Some((inner, path.clone()))
+        } else if let Some(el) = field.as_block().and_then(|b| b.element(0)) {
+            Some((el, format!("{path}[0]")))
+        } else if let Some(el) = field.as_array().and_then(|a| a.element(0)) {
+            Some((el, format!("{path}[0]")))
+        } else {
+            None
+        };
+        if let Some((child, child_prefix)) = nested {
+            if let Some(found) = find_coded_field(&child, &child_prefix) {
+                return Some(found);
+            }
+        }
+    }
+    None
+}
+
+/// An H2 `model_animation_graph` block whose stored name carries the `|CODE`
+/// dumper artifact (e.g. `animations|ABCDCC`) must resolve. `clean_field_name`
+/// now strips the code, so the built path (`resources[0]/animations#N`) matches.
+#[test]
+fn h2_jmad_name_code_block_resolves() {
+    let Some(tag) = load_h2_tag(
+        "/Users/camden/Halo/halo2_mcc/tags/objects/cinematics/cigar/cigar.model_animation_graph",
+        "halo2_mcc/model_animation_graph.json",
+    ) else {
+        return;
+    };
+
+    let found = find_coded_field(&tag.root(), "");
+    let Some((path, raw_name)) = found else {
+        eprintln!("skipping: no populated |CODE block in this jmad fixture");
+        return;
+    };
+
+    assert!(raw_name.contains('|'), "expected a |CODE raw name, got {raw_name:?}");
+    assert!(!path.contains('|'), "built path must carry the CLEAN name: {path}");
+    assert!(
+        tag.root().field_path(&path).is_some(),
+        "jmad |CODE field {raw_name:?} did not resolve via clean path {path}"
+    );
+}


### PR DESCRIPTION
## Problem

Tag field names embed Guerilla markup — `:units`, `#help`, `[range]`, `{alias}`, `&display`, and `*`/`!`/`^` flags (plus the H2 jmad `|CODE` dumper artifact). Baboon's resolvable-path builder emitted the **raw** name, so a segment like `ambient color:[0,255]#5` collided with the path grammar's own tokens: the `[0,255]` range hint was parsed as an element index, the `:` as a type filter, and the `#5` ordinal was discarded — the field silently failed to resolve or edit. ~25% of modern field names carry such markup.

## Approach

Make **blam-tags** the single source of truth for the field-name grammar and field-path type, modeled on Foundation's `TagFieldNameInfo` / `TagFieldPath`, and repoint Baboon at it. (Engine changes are in the bumped rev `3dfe74f`.)

- `append_field_path_for` emits the **clean** name (`clean_name#ordinal`); the engine resolver is also tolerant (a bracket range is never read as an index, `:units` never as a type filter) and matches on the clean form of both sides, so legacy raw-name paths resolve too.
- `field_display_meta` maps from `blam_tags::parse_field_name`, adopting Foundation marker semantics: `*` = read-only, `!` = hidden/expert-only, presence-tested (so `angle*!` keeps both — the old `ends_with` parser silently dropped `*`).
- `clean_field_name` / `clean_field_key` delegate to the engine; new `canonical_field_path` normalizes names **and** multi-segment paths uniformly (fixes a latent conversion path-key bug the old range-hint strip had masked). `breadcrumb_for_path` → engine `TagFieldPath`.
- `collect_visible_paths` keys on clean names so the search-filter canonical flavor stays consistent with the now-clean resolvable paths.

## Two compatibility bugs found and fixed (engine side)

A full round-trip sweep over **all 5 MCC kits — 244,250 tags, 19.3M fields, 91k markup names** — surfaced two pre-existing H2 resolution bugs, now fixed:

1. **Versioned classic-block descent**: the path descent bounds-checked against the base struct size, not the version-aware element size, so descent into H2 versioned blocks (`bitmap_data` 116 vs 140, and `physics_model`/`model`/`particle_physics`/`weather_system`/`sound`/`vehicle_collection`) failed. Now uses `block_element_size`.
2. **jmad `|CODE` dumper artifact**: `clean_field_name` now strips the `|<code>` so `animations|ABCDCC` → `animations` everywhere.

Post-fix sweep: **0 resolve failures, 0 path round-trip drift across all 5 kits.**

## Tests

Unit tests for every markup form, canonical-path normalization, and the `*`/`!` semantics; gated real-H2 end-to-end tests for a versioned-block field edit and a jmad `|CODE` resolve. 267 Baboon tests + 220 engine tests green.