### PR TITLE
Add Halo: Campaign Evolved support (UE5 IoStore container VFS + mods)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,17 +455,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "blam-tags"
 version = "0.1.0"
-source = "git+https://github.com/camden-smallwood/blam-tags?rev=3dfe74f62f92dc6b576436070d232005ba8c312d#3dfe74f62f92dc6b576436070d232005ba8c312d"
+source = "git+https://github.com/camden-smallwood/blam-tags?rev=863c879d86db30ef297783e08b7b54288af24797#863c879d86db30ef297783e08b7b54288af24797"
 dependencies = [
+ "anyhow",
  "bcdec_rs",
+ "blake3",
+ "byteorder",
  "flate2",
  "half",
  "lewton",
  "log",
+ "memmap2",
  "num-derive",
  "num-traits",
+ "oozextract",
  "opus",
  "serde",
  "serde_json",
@@ -637,6 +706,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,6 +729,12 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "core-foundation"
@@ -753,6 +834,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1043,6 +1133,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "log",
+]
+
+[[package]]
 name = "epaint"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1078,7 +1190,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1206,12 +1318,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1219,6 +1347,17 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -1251,6 +1390,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-sink"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+
+[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1262,9 +1407,11 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -1628,6 +1775,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1760,6 +1913,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1861,6 +2020,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -1998,6 +2166,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2360,6 +2537,26 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oozextract"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0296c8b223f00ed2bc0556de95d20a20a536fd5b79a1b0b59ff579972a5577"
+dependencies = [
+ "bytemuck",
+ "bytes",
+ "futures",
+ "log",
+ "test-log",
+ "wide",
+]
 
 [[package]]
 name = "opus"
@@ -2898,7 +3095,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2906,6 +3103,15 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "same-file"
@@ -2996,8 +3202,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -3254,7 +3469,39 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "test-log"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b9c218384242b5c89b68303ab6f6fc53a312d923f0c14dc6bb860c6aeee40f1"
+dependencies = [
+ "env_logger",
+ "test-log-macros",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "test-log-core"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c26ef8b00e4d382e59f6a8ddb3cd790b3a5bb29f21a358a9a69ea2f29f13f27b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "944ad38adcbb71eaa682c56bceeb079e4ca82b4b3edc2a0fde5cb297b77dac8d"
+dependencies = [
+ "syn",
+ "test-log-core",
 ]
 
 [[package]]
@@ -3295,6 +3542,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -3419,6 +3675,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -3441,7 +3726,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3538,6 +3823,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3547,6 +3838,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -3875,6 +4172,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3896,7 +4203,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1"
-blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "3dfe74f62f92dc6b576436070d232005ba8c312d", features = ["audio"] }
+blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "863c879d86db30ef297783e08b7b54288af24797", features = ["audio", "iostore"] }
 eframe = { version = "0.29", default-features = false, features = ["default_fonts", "glow"] }
 egui_extras = { version = "0.29", features = ["svg"] }
 flate2 = "1"

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ The game is also detected from a folder literally named after the game id (e.g.
 `halo3_mcc`), and **custom editing-kit folder names** can be mapped to a game in
 *File → Settings* for non-standard layouts.
 
+Beyond the MCC editing kits, Baboon also mounts **Halo: Campaign Evolved**
+(`haloce_evolved`) — the UE5 remake of Halo 1 on a modified Reach engine, whose
+Reach-format tags are cooked into UE5 IoStore paks. It's loaded from its game
+folder rather than a `tags/` directory; see *Campaign Evolved mods* below.
+
 Per-game group-name tables and schemas are loaded from
 `definitions/<game>/*.json`. Release builds place the `definitions/` folder next
 to `Baboon.exe`, which keeps the schemas inspectable and editable without
@@ -58,6 +63,12 @@ never blocks:
   directories only as you open them, so even a full kit opens instantly.
 - **Monolithic cache** — open a Halo 4 `blob_index.dat` monolithic tag cache and
   browse its contents as if they were loose files (read-only).
+- **Campaign Evolved container** — point **Load Folder** at the Halo: Campaign
+  Evolved game directory (or its `Meteorite/Content/Paks`). Baboon auto-detects
+  the UE5 IoStore paks, mounts them as one read-only virtual filesystem, and
+  presents the Reach tags exactly like loose files. Every pack (the shared base
+  chunk plus the per-level chunks that carry each mission's scenario and BSPs) is
+  merged into a single lowercase tag tree. See *Campaign Evolved mods* below.
 
 Tag files are identified by probing their 64-byte header for the `BLAM`
 (big-endian) / `MALB` (little-endian) magic, so non-tag files in the tree are
@@ -277,6 +288,41 @@ All extraction runs on background threads and reports progress to the status bar
     render + collision JMS for Halo CE).
 - **Import info** and **animation extraction**, all run in-process via the
   `blam-tags` library.
+
+### Halo: Campaign Evolved mods
+
+Campaign Evolved's tags live inside UE5 IoStore paks. Baboon edits them **in
+memory** and offers two ways to commit changes — overwrite the game directly, or
+package your changes as a separate, reversible mod:
+
+- **Save** (Ctrl+S) — **overwrites the tag inside the game's own pak, in place.**
+  The edited chunk is appended to the container's `.ucas` and its `.utoc` is
+  rewritten to point at it (preserving the container's perfect-hash seeds), with
+  the paired `.uasset`'s bulk-data size patched when an edit changes the tag's
+  byte length. This modifies the shipped game files, so Baboon **always confirms
+  first** — the dialog offers *Export Mod* as the non-destructive alternative, and
+  has a *Don't ask again* option (also under **Settings → Startup → Saving**).
+  There is no undo without a backup of the paks. *(Loose-folder MCC tags save
+  normally and never prompt.)*
+- **Export Mod…** (File menu) — bundle **every open, modified tag** into one
+  portable, higher-priority **overlay container** without touching the base game.
+  Mods are fully reversible (delete the overlay to uninstall).
+- **Save As** — *duplicate* the tag under a new name into an overlay container (a
+  new UE package with its own identity, `.uasset`, and container-header entry).
+- **Rename** (right-click) — the same as Save As, plus a package **redirect** so
+  existing tags that reference the old name resolve to the renamed one.
+
+Export Mod / Save As / Rename each produce a `<name>-WinGDK_P.utoc` / `.ucas`
+pair. Drop **both** files into the game's `Meteorite/Content/Paks/` folder
+alongside the base paks; the `_P` suffix gives the overlay patch priority and
+UE's loader serves your chunks on top of the base (last-mounted-wins).
+
+Tag identity (`FPackageId` / export hashes), UE5 Zen-package `.uasset`
+(de)serialization, and override-container writing are all implemented natively in
+`blam-tags` with no external UE tooling — references resolve by the same
+`CityHash64` package-path hashing the game itself uses. Output containers are
+validated structurally against an independent packer; loading them in the
+shipping game is the one step that requires a Windows/Xbox run to confirm.
 
 ### Geometry import & integrated terminal
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -40,7 +40,8 @@ use crate::format::{TagNameIndex, format_value, group_label};
 use crate::source::{
     DependencyRef, EkFolderAlias, EntryIndexRefresh, LoadedSourceData, ReverseDependencyIndex,
     SUPPORTED_EK_GAMES, TagEntry, TagEntryLocation, TagSource, TagTree, TagTreeNode, load_folder,
-    load_folder_node_entries, load_monolithic_blob_index, load_single_file, loose_file_entry,
+    load_folder_node_entries, load_iostore_container, load_iostore_container_set,
+    load_monolithic_blob_index, load_single_file, loose_file_entry,
     read_entry, resolve_folder_root, scan_folder_subtree_entries,
     scan_folder_subtree_entries_with_progress, supported_ek_game_id,
 };
@@ -175,6 +176,8 @@ pub struct Baboon {
     session_restore: SessionRestore,
     show_block_sizes: bool,
     scroll_to_cycle_dropdowns: bool,
+    /// Warn before Save overwrites Campaign Evolved pak files in place.
+    confirm_container_overwrite: bool,
     expert_mode: bool,
     dark_mode: bool,
     ui_scale: f32,
@@ -189,6 +192,8 @@ pub struct Baboon {
     settings_tab: SettingsTab,
     new_tag_open: bool,
     new_tag_dialog: NewTagDialog,
+    /// Pending in-place overwrite confirmation (the tag key) for a container tag.
+    overwrite_confirm: Option<String>,
     about_open: bool,
     help_panel_tab: HelpPanelTab,
     help_docs: HelpDocsState,
@@ -371,6 +376,7 @@ impl Baboon {
             session_restore: prefs.session_restore,
             show_block_sizes: prefs.show_block_sizes,
             scroll_to_cycle_dropdowns: prefs.scroll_to_cycle_dropdowns,
+            confirm_container_overwrite: prefs.confirm_container_overwrite,
             expert_mode: prefs.expert_mode,
             dark_mode: prefs.dark_mode,
             ui_scale: prefs.ui_scale,
@@ -385,6 +391,7 @@ impl Baboon {
             settings_tab: SettingsTab::Startup,
             new_tag_open: false,
             new_tag_dialog: NewTagDialog::default(),
+            overwrite_confirm: None,
             about_open: false,
             help_panel_tab: HelpPanelTab::About,
             help_docs: HelpDocsState::load(),

--- a/src/app/browser/tree.rs
+++ b/src/app/browser/tree.rs
@@ -1011,7 +1011,10 @@ pub(in crate::app) fn draw_entry(
     response.context_menu(|ui| {
         style_tag_context_menu(ui);
 
-        let rename_enabled = matches!(entry.location, TagEntryLocation::LooseFile(_));
+        let rename_enabled = matches!(
+            entry.location,
+            TagEntryLocation::LooseFile(_) | TagEntryLocation::Container { .. }
+        );
         let extract_enabled = supports_tag_extract_menu(entry.group_tag);
         ui.horizontal(|ui| {
             if context_menu_primary_button(ui, "Rename", rename_enabled).clicked() {

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -39,6 +39,27 @@ const TERMINAL_VISIBLE_LINE_LIMIT: usize = 20_000;
 const TERMINAL_VISIBLE_LINE_TRIM_TARGET: usize = 18_000;
 const ENTRY_INDEX_REFRESH_INTERVAL_SECS: f64 = 30.0;
 
+/// Map a container `.ubulk` path to the UE package path the runtime hashes.
+/// `Meteorite/Content/Tags/objects/.../foo-biped.ubulk` → `/Game/Tags/objects/.../foo-biped`.
+fn container_rel_to_package_path(rel: &str) -> Option<String> {
+    let no_ext = rel.strip_suffix(".ubulk").unwrap_or(rel);
+    let after = no_ext.strip_prefix("Meteorite/Content/").unwrap_or(no_ext);
+    Some(format!("/Game/{after}"))
+}
+
+/// Prompt for an override `.utoc` output path, defaulting to `default_name`.
+fn pick_override_utoc(default_name: &str) -> Option<PathBuf> {
+    let mut output = rfd::FileDialog::new()
+        .set_title("Export Override Container")
+        .set_file_name(default_name)
+        .add_filter("IoStore TOC", &["utoc"])
+        .save_file()?;
+    if output.extension().is_none() {
+        output.set_extension("utoc");
+    }
+    Some(output)
+}
+
 #[cfg(any(windows, test))]
 fn explorer_select_args(path: &Path) -> [std::ffi::OsString; 2] {
     [
@@ -190,6 +211,12 @@ impl Baboon {
     /// Starts source work off the UI thread and reports completion through `WorkerMessage`.
     /// Captured source identity prevents stale results from replacing newer state.
     pub(super) fn begin_load_folder_path(&mut self, path: PathBuf, ctx: egui::Context) {
+        // A UE5 `Paks` directory (Halo: Campaign Evolved) is mounted as a
+        // container set rather than walked as loose files.
+        if let Some(paks) = crate::source::find_paks_dir(&path) {
+            self.begin_load_iostore_container_set_path(paks, ctx);
+            return;
+        }
         let tx = self.tx.clone();
         let names = self.default_names.clone();
         let definitions_root = locate_definitions_root();
@@ -237,6 +264,58 @@ impl Baboon {
         let recent_path = clean_recent_path(path.clone());
         thread::spawn(move || {
             let result = load_monolithic_blob_index(path, &names).map_err(|e| e.to_string());
+            let _ = tx.send(WorkerMessage::SourceLoaded {
+                result,
+                recent_path: Some(recent_path),
+            });
+            ctx.request_repaint();
+        });
+    }
+
+    pub(super) fn begin_load_iostore_container(&mut self, ctx: egui::Context) {
+        let Some(path) = rfd::FileDialog::new()
+            .set_title("Open Halo: Campaign Evolved container (.utoc)")
+            .add_filter("IoStore TOC", &["utoc"])
+            .pick_file()
+        else {
+            return;
+        };
+        self.begin_load_iostore_container_path(path, ctx);
+    }
+
+    /// Mounts a single IoStore container (`.utoc`) off the UI thread; completion
+    /// is reported through `WorkerMessage::SourceLoaded` like the other loaders.
+    pub(super) fn begin_load_iostore_container_path(&mut self, path: PathBuf, ctx: egui::Context) {
+        let tx = self.tx.clone();
+        let names = self.default_names.clone();
+        let definitions_root = locate_definitions_root();
+        self.status = format!("Mounting {}", path.display());
+        let recent_path = clean_recent_path(path.clone());
+        thread::spawn(move || {
+            let result =
+                load_iostore_container(path, &names, &definitions_root).map_err(|e| e.to_string());
+            let _ = tx.send(WorkerMessage::SourceLoaded {
+                result,
+                recent_path: Some(recent_path),
+            });
+            ctx.request_repaint();
+        });
+    }
+
+    /// Mounts every container in a `Paks` directory as one merged set.
+    pub(super) fn begin_load_iostore_container_set_path(
+        &mut self,
+        paks_dir: PathBuf,
+        ctx: egui::Context,
+    ) {
+        let tx = self.tx.clone();
+        let names = self.default_names.clone();
+        let definitions_root = locate_definitions_root();
+        self.status = format!("Mounting containers in {}", paks_dir.display());
+        let recent_path = clean_recent_path(paks_dir.clone());
+        thread::spawn(move || {
+            let result = load_iostore_container_set(paks_dir, &names, &definitions_root)
+                .map_err(|e| e.to_string());
             let _ = tx.send(WorkerMessage::SourceLoaded {
                 result,
                 recent_path: Some(recent_path),
@@ -1303,7 +1382,9 @@ impl Baboon {
         };
         match &entry.location {
             TagEntryLocation::LooseFile(path) => path.display().to_string(),
-            TagEntryLocation::Monolithic { .. } => entry.display_path.clone(),
+            TagEntryLocation::Monolithic { .. } | TagEntryLocation::Container { .. } => {
+                entry.display_path.clone()
+            }
         }
     }
 
@@ -1334,6 +1415,8 @@ impl Baboon {
             TagSource::MonolithicCache { root, .. } => {
                 (LastSessionSourceKind::MonolithicCache, root.clone())
             }
+            // Container mounts are not persisted across sessions yet.
+            TagSource::IoStoreContainerSet { .. } => return None,
         };
         let mut tags = Vec::new();
         for key in ordered_unique_keys(self.open_tabs.iter().chain(self.floating_tabs.iter())) {
@@ -1342,7 +1425,7 @@ impl Baboon {
             };
             let path = match &entry.location {
                 TagEntryLocation::LooseFile(path) => Some(path.clone()),
-                TagEntryLocation::Monolithic { .. } => None,
+                TagEntryLocation::Monolithic { .. } | TagEntryLocation::Container { .. } => None,
             };
             tags.push(LastSessionTag {
                 key: entry.key.clone(),
@@ -1667,6 +1750,10 @@ impl Baboon {
             }
             (TagEntryLocation::Monolithic { .. }, _) => {
                 self.status = "Monolithic tag has no loose file to show".to_owned();
+                return;
+            }
+            (TagEntryLocation::Container { .. }, _) => {
+                self.status = "Container tag has no loose file to show".to_owned();
                 return;
             }
         };
@@ -2172,6 +2259,17 @@ impl Baboon {
             self.status = "No tag selected".to_owned();
             return;
         };
+        // For a container tag, "Save" overwrites the tag inside the game's pak
+        // in place (destructive). Confirm first unless the user opted out (loose
+        // builds never prompt).
+        if self.current_source_is_container() {
+            if self.confirm_container_overwrite {
+                self.overwrite_confirm = Some(key);
+            } else {
+                self.overwrite_current_tag_in_place(&key);
+            }
+            return;
+        }
         match self.save_tag_by_key(&key) {
             Ok(path) => self.status = format!("Saved {}", path.display()),
             Err(error) => self.status = format!("Save failed: {error}"),
@@ -2201,11 +2299,230 @@ impl Baboon {
         Ok(output)
     }
 
+    pub(super) fn current_source_is_container(&self) -> bool {
+        matches!(
+            self.source.as_ref().map(|s| &s.source),
+            Some(TagSource::IoStoreContainerSet { .. })
+        )
+    }
+
+    /// Export a container tag as a higher-priority override container. The base
+    /// game is never modified.
+    /// - `rename_to == None`: same-name override (Save) — replaces this tag's
+    ///   chunk(s), with the `.uasset` SerialSize patched on a size change.
+    /// - `Some((new_rel, redirect))`: a new tag at `/Game/Tags/<new_rel>-<group>`
+    ///   (Save As / Rename); `redirect` adds an old→new package redirect so
+    ///   existing references resolve to the renamed tag.
+    /// Returns the output path, or `None` if the save dialog was cancelled.
+    fn export_container_override(
+        &mut self,
+        key: &str,
+        rename_to: Option<(String, bool)>,
+    ) -> Result<Option<PathBuf>, String> {
+        let Some(entry) = self.entry_for_key(key).cloned() else {
+            return Err("Tag is no longer in the source".to_owned());
+        };
+        let TagEntryLocation::Container { container, rel_path } = &entry.location else {
+            return Err("Not a Campaign Evolved container tag".to_owned());
+        };
+        let Some(source) = self.source.as_ref() else {
+            return Err("No source loaded".to_owned());
+        };
+        let TagSource::IoStoreContainerSet { containers, .. } = &source.source else {
+            return Err("Source is not a container".to_owned());
+        };
+        let archive = containers
+            .get(*container)
+            .ok_or("container provenance is stale")?
+            .archive
+            .clone();
+        let rel_path = rel_path.clone();
+        let group = entry.group_name.clone().unwrap_or_default();
+
+        // Tag content: current edited bytes if the tag is loaded, else the
+        // original `.ubulk`.
+        let tag_bytes = if let Some(doc) = self.parsed_tags.get(key) {
+            doc.tag.write_to_bytes().map_err(|e| format!("serialize tag: {e}"))?
+        } else {
+            archive.read(&rel_path).map_err(|e| format!("read tag: {e}"))?
+        };
+
+        match rename_to {
+            None => {
+                let stem = rel_path
+                    .rsplit('/')
+                    .next()
+                    .and_then(|f| f.strip_suffix(".ubulk"))
+                    .unwrap_or("tag");
+                let Some(output) = pick_override_utoc(&format!("{stem}-WinGDK_P.utoc")) else {
+                    return Ok(None);
+                };
+                blam_tags::iostore::writer::write_tag_override(
+                    &archive, &rel_path, &tag_bytes, &output,
+                )
+                .map_err(|e| format!("write override: {e}"))?;
+                Ok(Some(output))
+            }
+            Some((new_rel, redirect)) => {
+                let ua_path = rel_path
+                    .strip_suffix(".ubulk")
+                    .map(|s| format!("{s}.uasset"))
+                    .ok_or("source is not a .ubulk")?;
+                let template = archive
+                    .read(&ua_path)
+                    .map_err(|e| format!("read template .uasset: {e}"))?;
+                let old_pkg = container_rel_to_package_path(&rel_path)
+                    .ok_or("could not derive source package path")?;
+                let new_pkg = format!("/Game/Tags/{new_rel}-{group}");
+                let leaf = new_rel.rsplit('/').next().unwrap_or("tag");
+                let Some(output) = pick_override_utoc(&format!("{leaf}-{group}-WinGDK_P.utoc"))
+                else {
+                    return Ok(None);
+                };
+                blam_tags::iostore::writer::write_new_tag_container(
+                    &template,
+                    &tag_bytes,
+                    &new_pkg,
+                    if redirect { Some(old_pkg.as_str()) } else { None },
+                    &output,
+                )
+                .map_err(|e| format!("write container: {e}"))?;
+                Ok(Some(output))
+            }
+        }
+    }
+
+    /// Overwrite the current container tag inside its own pak, in place.
+    /// **Destructive** — modifies the shipped game files. Only reached after the
+    /// user confirms the overwrite dialog.
+    pub(super) fn overwrite_current_tag_in_place(&mut self, key: &str) {
+        let Some(entry) = self.entry_for_key(key).cloned() else {
+            self.status = "Tag is no longer in the source".to_owned();
+            return;
+        };
+        let TagEntryLocation::Container { container, rel_path } = &entry.location else {
+            self.status = "Not a Campaign Evolved container tag".to_owned();
+            return;
+        };
+        let container_idx = *container;
+        let rel_path = rel_path.clone();
+        let Some(doc) = self.parsed_tags.get(key) else {
+            self.status = "Load the tag before saving".to_owned();
+            return;
+        };
+        let bytes = match doc.tag.write_to_bytes() {
+            Ok(b) => b,
+            Err(e) => {
+                self.status = format!("Failed to serialize tag: {e}");
+                return;
+            }
+        };
+        let utoc_path = {
+            let Some(source) = self.source.as_ref() else {
+                self.status = "No source loaded".to_owned();
+                return;
+            };
+            let TagSource::IoStoreContainerSet { containers, .. } = &source.source else {
+                self.status = "Source is not a container".to_owned();
+                return;
+            };
+            let Some(m) = containers.get(container_idx) else {
+                self.status = "Container provenance is stale".to_owned();
+                return;
+            };
+            m.utoc_path.clone()
+        };
+        if let Err(e) =
+            blam_tags::iostore::writer::overwrite_tag_in_place(&utoc_path, &rel_path, &bytes)
+        {
+            self.status = format!("Overwrite failed: {e}");
+            return;
+        }
+        // Hot-swap the pak's archive so subsequent reads see the new bytes.
+        match blam_tags::iostore::IoStoreArchive::open(&utoc_path) {
+            Ok(a) => {
+                if let Some(source) = self.source.as_mut()
+                    && let TagSource::IoStoreContainerSet { containers, .. } = &mut source.source
+                    && let Some(m) = containers.get_mut(container_idx)
+                {
+                    m.archive = std::sync::Arc::new(a);
+                }
+            }
+            Err(e) => self.status = format!("Saved, but reloading the pak failed: {e}"),
+        }
+        if let Some(doc) = self.parsed_tags.get_mut(key) {
+            doc.dirty = false;
+        }
+        self.status = format!("Saved into {} (game files modified)", utoc_path.display());
+    }
+
+    /// Bundle every open, modified container tag into one portable `_P` overlay
+    /// mod — the base game is left untouched.
+    pub(super) fn export_mod(&mut self) {
+        let Some(source) = self.source.as_ref() else {
+            self.status = "No source loaded".to_owned();
+            return;
+        };
+        let TagSource::IoStoreContainerSet { containers, .. } = &source.source else {
+            self.status = "Export Mod is only for Campaign Evolved containers".to_owned();
+            return;
+        };
+        // (archive, rel_path, edited bytes) for each loaded + dirty container tag.
+        let mut collected: Vec<(std::sync::Arc<blam_tags::iostore::IoStoreArchive>, String, Vec<u8>)> =
+            Vec::new();
+        for (k, doc) in self.parsed_tags.iter() {
+            if !doc.dirty {
+                continue;
+            }
+            let Some(entry) = self.entry_for_key(k) else {
+                continue;
+            };
+            let TagEntryLocation::Container { container, rel_path } = &entry.location else {
+                continue;
+            };
+            let Some(m) = containers.get(*container) else {
+                continue;
+            };
+            let Ok(bytes) = doc.tag.write_to_bytes() else {
+                continue;
+            };
+            collected.push((m.archive.clone(), rel_path.clone(), bytes));
+        }
+        if collected.is_empty() {
+            self.status = "No modified tags to export — edit a tag first".to_owned();
+            return;
+        }
+        let count = collected.len();
+        let Some(mut output) = pick_override_utoc("mymod-WinGDK_P.utoc") else {
+            return;
+        };
+        if output.extension().is_none() {
+            output.set_extension("utoc");
+        }
+        let refs: Vec<(&blam_tags::iostore::IoStoreArchive, &str, &[u8])> = collected
+            .iter()
+            .map(|(a, p, b)| (a.as_ref(), p.as_str(), b.as_slice()))
+            .collect();
+        match blam_tags::iostore::writer::write_mod_container(&refs, &output) {
+            Ok(()) => {
+                self.status =
+                    format!("Exported {count} tag(s) to {} (base game unchanged)", output.display())
+            }
+            Err(e) => self.status = format!("Export Mod failed: {e}"),
+        }
+    }
+
     pub(super) fn save_current_tag_as(&mut self) {
         let Some(key) = self.selected_key.clone() else {
             self.status = "No tag selected".to_owned();
             return;
         };
+        // For a container tag, "Save As" opens the rename dialog in duplicate
+        // mode (new name, no reference redirect) and writes an override.
+        if self.current_source_is_container() {
+            self.open_container_duplicate(&key);
+            return;
+        }
         let Some(entry) = self.entry_for_key(&key).cloned() else {
             self.status = "Selected tag is no longer in the source".to_owned();
             return;
@@ -2324,11 +2641,22 @@ impl Baboon {
     /// Open the rename/move dialog for a tag, pre-listing the tags that
     /// reference it (which will be rewritten on apply).
     pub(super) fn open_rename_tag(&mut self, key: &str) {
+        self.open_rename_or_duplicate(key, true);
+    }
+
+    /// Open the rename dialog in "duplicate" mode (Save As for a container tag —
+    /// writes a new tag with no redirect).
+    pub(super) fn open_container_duplicate(&mut self, key: &str) {
+        self.open_rename_or_duplicate(key, false);
+    }
+
+    fn open_rename_or_duplicate(&mut self, key: &str, redirect: bool) {
         let Some(entry) = self.entry_for_key(key).cloned() else {
             return;
         };
-        if !matches!(entry.location, TagEntryLocation::LooseFile(_)) {
-            self.status = "Only loose-folder tags can be renamed/moved".to_owned();
+        let is_container = matches!(entry.location, TagEntryLocation::Container { .. });
+        if !is_container && !matches!(entry.location, TagEntryLocation::LooseFile(_)) {
+            self.status = "Only loose-folder or container tags can be renamed".to_owned();
             return;
         }
         let display = entry.display_path.replace('\\', "/");
@@ -2353,15 +2681,67 @@ impl Baboon {
             new_path_input: name,
             referrers,
             referrers_unavailable,
+            is_container,
+            redirect,
         });
     }
 
     /// Apply the rename/move: move the file on disk and rewrite every
     /// referencing tag, in the background (reuses the folder-refactor pipeline).
     pub(super) fn begin_rename_tag(&mut self) {
-        let Some(state) = self.rename_tag.as_ref() else {
+        let Some((key, old_display, new_name_raw, is_container, redirect)) =
+            self.rename_tag.as_ref().map(|s| {
+                (
+                    s.key.clone(),
+                    s.old_display.clone(),
+                    s.new_path_input.clone(),
+                    s.is_container,
+                    s.redirect,
+                )
+            })
+        else {
             return;
         };
+        let new_name = new_name_raw.trim().to_owned();
+        if new_name.is_empty() {
+            self.status = "Enter a new tag name".to_owned();
+            return;
+        }
+        if new_name.contains(['/', '\\']) {
+            self.status = "Enter a name only; use Move to choose a folder".to_owned();
+            return;
+        }
+        if new_name.contains('.') {
+            self.status = "Enter a name without an extension".to_owned();
+            return;
+        }
+        let parent = old_display
+            .rsplit_once('/')
+            .map(|(parent, _)| parent)
+            .unwrap_or("");
+        let new_rel = if parent.is_empty() {
+            new_name
+        } else {
+            format!("{parent}/{new_name}")
+        };
+
+        // Container tags: write an override container (rename adds a redirect,
+        // duplicate does not) instead of moving a loose file.
+        if is_container {
+            self.rename_tag = None;
+            match self.export_container_override(&key, Some((new_rel, redirect))) {
+                Ok(Some(path)) => {
+                    let what = if redirect { "renamed tag" } else { "tag copy" };
+                    self.status =
+                        format!("Exported {what} to {} (base game unchanged)", path.display());
+                }
+                Ok(None) => {}
+                Err(e) => self.status = format!("Export failed: {e}"),
+            }
+            return;
+        }
+
+        // Loose folder: move the file on disk + rewrite references.
         if self.folder_refactor.is_some() {
             self.status = "A move/rename is already running".to_owned();
             return;
@@ -2374,30 +2754,7 @@ impl Baboon {
             self.status = "Rename requires a loaded tags folder".to_owned();
             return;
         };
-        let new_name = state.new_path_input.trim().to_owned();
-        if new_name.is_empty() {
-            self.status = "Enter a new tag name".to_owned();
-            return;
-        }
-        if new_name.contains(['/', '\\']) {
-            self.status = "Rename accepts a name only; use Move to choose a folder".to_owned();
-            return;
-        }
-        if new_name.contains('.') {
-            self.status = "Enter a name without an extension".to_owned();
-            return;
-        }
-        let parent = state
-            .old_display
-            .rsplit_once('/')
-            .map(|(parent, _)| parent)
-            .unwrap_or("");
-        let new_rel = if parent.is_empty() {
-            new_name
-        } else {
-            format!("{parent}/{new_name}")
-        };
-        let Some(entry) = self.entry_for_key(&state.key).cloned() else {
+        let Some(entry) = self.entry_for_key(&key).cloned() else {
             self.status = "Tag no longer exists".to_owned();
             return;
         };
@@ -3541,6 +3898,7 @@ impl Baboon {
             session_restore: self.session_restore,
             show_block_sizes: self.show_block_sizes,
             scroll_to_cycle_dropdowns: self.scroll_to_cycle_dropdowns,
+            confirm_container_overwrite: self.confirm_container_overwrite,
             expert_mode: self.expert_mode,
             dark_mode: self.dark_mode,
             ui_scale: self.ui_scale,

--- a/src/app/controller/saving.rs
+++ b/src/app/controller/saving.rs
@@ -107,7 +107,9 @@ pub(super) fn register_saved_copy_in_loaded_source(
 pub(super) fn save_as_file_name(entry: &TagEntry, extension: Option<&str>) -> String {
     let path = match &entry.location {
         TagEntryLocation::LooseFile(path) => path,
-        TagEntryLocation::Monolithic { .. } => Path::new(&entry.display_path),
+        TagEntryLocation::Monolithic { .. } | TagEntryLocation::Container { .. } => {
+            Path::new(&entry.display_path)
+        }
     };
     let mut file_name = path
         .file_name()
@@ -132,7 +134,7 @@ pub(super) fn save_as_file_name(entry: &TagEntry, extension: Option<&str>) -> St
 pub(super) fn save_as_start_dir(entry: &TagEntry) -> Option<PathBuf> {
     match &entry.location {
         TagEntryLocation::LooseFile(path) => path.parent().map(Path::to_path_buf),
-        TagEntryLocation::Monolithic { .. } => None,
+        TagEntryLocation::Monolithic { .. } | TagEntryLocation::Container { .. } => None,
     }
 }
 

--- a/src/app/editor/value_parser.rs
+++ b/src/app/editor/value_parser.rs
@@ -4,8 +4,12 @@
 use super::*;
 
 pub(in crate::app) fn is_editable_tag(entry: &TagEntry, tag: &TagFile) -> bool {
-    matches!(entry.location, TagEntryLocation::LooseFile(_))
-        && (tag.classic_engine().is_some() || tag.endian == Endian::Le)
+    // Loose tags are edited in place; container (Campaign Evolved) tags are
+    // edited in memory and written out as an override on Save/Save As/Rename.
+    matches!(
+        entry.location,
+        TagEntryLocation::LooseFile(_) | TagEntryLocation::Container { .. }
+    ) && (tag.classic_engine().is_some() || tag.endian == Endian::Le)
 }
 
 pub(in crate::app) fn append_field_path(prefix: &str, field_name: &str) -> String {

--- a/src/app/export/geometry.rs
+++ b/src/app/export/geometry.rs
@@ -228,6 +228,9 @@ pub(in crate::app) fn load_referenced_tag_from_source(
         TagSource::MonolithicCache { cache, .. } => cache
             .read_tag_by_name(group_tag, reference)
             .map_err(|error| anyhow::anyhow!("read {reference}.{extension} failed: {error}")),
+        TagSource::IoStoreContainerSet { .. } => anyhow::bail!(
+            "resolving tag references for geometry export is not yet supported for Campaign Evolved containers"
+        ),
     }
 }
 

--- a/src/app/game_assets.rs
+++ b/src/app/game_assets.rs
@@ -10,6 +10,7 @@ pub(super) fn get_game_banner_bytes(game: &str) -> &'static [u8] {
         "halo3odst_mcc" => include_bytes!("../../assets/Game Icons/h3odst.png"),
         "haloreach_mcc" => include_bytes!("../../assets/Game Icons/reach.png"),
         "halo4_mcc" => include_bytes!("../../assets/Game Icons/h4.png"),
+        "haloce_evolved" => include_bytes!("../../assets/Game Icons/ce.png"),
         _ => include_bytes!("../../assets/Game Icons/ce.png"),
     }
 }
@@ -25,6 +26,7 @@ pub(super) fn get_game_emblem_bytes(game: &str) -> Option<&'static [u8]> {
         "halo3odst_mcc" => Some(include_bytes!("../../assets/Game Icons/emblems/h3odst.png")),
         "haloreach_mcc" => Some(include_bytes!("../../assets/Game Icons/emblems/hreach.png")),
         "halo4_mcc" => Some(include_bytes!("../../assets/Game Icons/emblems/h4.png")),
+        "haloce_evolved" => Some(include_bytes!("../../assets/Game Icons/emblems/h1.png")),
         _ => None,
     }
 }
@@ -38,6 +40,15 @@ pub(super) fn game_display_name(game: &str) -> &'static str {
         "halo3odst_mcc" => "Halo 3: ODST",
         "haloreach_mcc" => "Halo: Reach",
         "halo4_mcc" => "Halo 4",
+        "haloce_evolved" => "Halo: Campaign Evolved",
         _ => "Unknown Game",
+    }
+}
+
+/// Platform/edition suffix shown after the game name (e.g. "MCC", "PC").
+pub(super) fn game_platform_label(game: &str) -> &'static str {
+    match game {
+        "haloce_evolved" => "PC",
+        _ => "MCC",
     }
 }

--- a/src/app/prefs.rs
+++ b/src/app/prefs.rs
@@ -101,6 +101,10 @@ pub(super) fn load_gui_prefs() -> GuiPrefs {
             .get("scroll_to_cycle_dropdowns")
             .and_then(Value::as_bool)
             .unwrap_or(true),
+        confirm_container_overwrite: value
+            .get("confirm_container_overwrite")
+            .and_then(Value::as_bool)
+            .unwrap_or(true),
         expert_mode: value
             .get("expert_mode")
             .and_then(Value::as_bool)
@@ -408,6 +412,7 @@ pub(super) fn save_gui_prefs(
         "session_restore": prefs.session_restore.as_str(),
         "show_block_sizes": prefs.show_block_sizes,
         "scroll_to_cycle_dropdowns": prefs.scroll_to_cycle_dropdowns,
+        "confirm_container_overwrite": prefs.confirm_container_overwrite,
         "expert_mode": prefs.expert_mode,
         "dark_mode": prefs.dark_mode,
         "ui_scale": prefs.ui_scale,

--- a/src/app/state/browser.rs
+++ b/src/app/state/browser.rs
@@ -45,6 +45,12 @@ pub(in crate::app) struct RenameTagState {
     pub(in crate::app) referrers: Vec<String>,
     /// True when no reverse-dependency index was available to list referrers.
     pub(in crate::app) referrers_unavailable: bool,
+    /// Source is a Campaign Evolved container: apply writes an override
+    /// container instead of moving a loose file + rewriting references.
+    pub(in crate::app) is_container: bool,
+    /// Container-only: rename (redirect old references to the new tag) vs.
+    /// duplicate (Save As — no redirect). Ignored for loose sources.
+    pub(in crate::app) redirect: bool,
 }
 
 /// Results of a tag query (find-references / unreferenced), shown in a floating

--- a/src/app/state/prefs.rs
+++ b/src/app/state/prefs.rs
@@ -156,6 +156,8 @@ pub(in crate::app) struct GuiPrefs {
     pub(in crate::app) session_restore: SessionRestore,
     pub(in crate::app) show_block_sizes: bool,
     pub(in crate::app) scroll_to_cycle_dropdowns: bool,
+    /// Warn before Save overwrites Campaign Evolved pak files in place.
+    pub(in crate::app) confirm_container_overwrite: bool,
     pub(in crate::app) expert_mode: bool,
     pub(in crate::app) dark_mode: bool,
     pub(in crate::app) ui_scale: f32,
@@ -183,6 +185,7 @@ impl Default for GuiPrefs {
             double_click_to_open_tags: false,
             show_block_sizes: false,
             scroll_to_cycle_dropdowns: true,
+            confirm_container_overwrite: true,
             expert_mode: false,
             dark_mode: false,
             ui_scale: DEFAULT_UI_SCALE,

--- a/src/app/ui.rs
+++ b/src/app/ui.rs
@@ -137,9 +137,13 @@ fn draw_game_banner_header(ui: &mut Ui, app: &mut Baboon, game: &str, path_label
                 ui.vertical(|ui| {
                     ui.add_space(8.0);
                     ui.label(
-                        RichText::new(format!("Tags - {} (MCC)", game_display_name(game)))
-                            .color(text_dark())
-                            .strong(),
+                        RichText::new(format!(
+                            "Tags - {} ({})",
+                            game_display_name(game),
+                            game_platform_label(game)
+                        ))
+                        .color(text_dark())
+                        .strong(),
                     );
                     ui.add(
                         egui::Label::new(RichText::new(path_label).color(subtle_dark()).small())
@@ -155,6 +159,7 @@ fn sidebar_source_path_label(source: &TagSource) -> String {
         TagSource::SingleFile { path } => path.display().to_string(),
         TagSource::LooseFolder { root, .. } => root.display().to_string(),
         TagSource::MonolithicCache { root, .. } => root.display().to_string(),
+        TagSource::IoStoreContainerSet { root, .. } => root.display().to_string(),
     }
 }
 

--- a/src/app/ui/dialogs.rs
+++ b/src/app/ui/dialogs.rs
@@ -445,6 +445,81 @@ impl Baboon {
         }
     }
 
+    /// Destructive-save confirmation for Campaign Evolved container tags. Save
+    /// overwrites the shipped pak files in place, so we always confirm and point
+    /// the user at Export Mod as the non-destructive alternative.
+    pub(super) fn draw_overwrite_confirm_window(&mut self, ctx: &egui::Context) {
+        let Some(key) = self.overwrite_confirm.clone() else {
+            return;
+        };
+        let mut open = true;
+        let mut do_overwrite = false;
+        let mut do_export = false;
+        let mut cancel = false;
+        let mut dont_ask = !self.confirm_container_overwrite;
+        egui::Window::new("Overwrite game files?")
+            .id(egui::Id::new("overwrite_confirm"))
+            .open(&mut open)
+            .collapsible(false)
+            .resizable(false)
+            .default_width(520.0)
+            .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
+            .show(ctx, |ui| {
+                ui.label(
+                    RichText::new("Save will overwrite this tag inside the game's shipped pak files, in place:")
+                        .color(text_dark()),
+                );
+                ui.add_space(5.0);
+                ui.label(RichText::new(&key).color(text_dark()).monospace());
+                ui.add_space(9.0);
+                ui.label(
+                    RichText::new(
+                        "This modifies the original game content and cannot be undone without a backup of the pak files.",
+                    )
+                    .color(egui::Color32::from_rgb(210, 120, 90)),
+                );
+                ui.add_space(5.0);
+                ui.label(
+                    RichText::new(
+                        "To keep the base game untouched, cancel and use File \u{2192} Export Mod\u{2026} instead — it bundles your changes into a separate mod overlay.",
+                    )
+                    .color(subtle_dark())
+                    .small(),
+                );
+                ui.add_space(8.0);
+                ui.checkbox(
+                    &mut dont_ask,
+                    "Don't ask again (changeable in Settings)",
+                );
+                ui.add_space(10.0);
+                ui.horizontal(|ui| {
+                    if ui.button("Overwrite Game Files").clicked() {
+                        do_overwrite = true;
+                    }
+                    if ui.button("Export Mod Instead\u{2026}").clicked() {
+                        do_export = true;
+                    }
+                    if ui.button("Cancel").clicked() {
+                        cancel = true;
+                    }
+                });
+            });
+        if !open || cancel {
+            self.overwrite_confirm = None;
+        } else if do_overwrite {
+            self.overwrite_confirm = None;
+            // Apply the opt-out only when the user commits to the overwrite.
+            if dont_ask && self.confirm_container_overwrite {
+                self.confirm_container_overwrite = false;
+                self.persist_prefs_if_changed();
+            }
+            self.overwrite_current_tag_in_place(&key);
+        } else if do_export {
+            self.overwrite_confirm = None;
+            self.export_mod();
+        }
+    }
+
     pub(super) fn draw_rename_tag_window(&mut self, ctx: &egui::Context) {
         if self.rename_tag.is_none() {
             return;
@@ -454,7 +529,12 @@ impl Baboon {
         let mut cancel = false;
         {
             let state = self.rename_tag.as_mut().expect("checked above");
-            egui::Window::new("Rename Tag")
+            let title = if state.is_container && !state.redirect {
+                "Save Tag As (New Copy)"
+            } else {
+                "Rename Tag"
+            };
+            egui::Window::new(title)
                 .id(egui::Id::new("rename_tag"))
                 .open(&mut open)
                 .default_width(560.0)
@@ -503,7 +583,33 @@ impl Baboon {
                             .small(),
                     );
                     ui.add_space(8.0);
-                    if state.referrers_unavailable {
+                    if state.is_container {
+                        if state.redirect {
+                            ui.label(
+                                RichText::new(
+                                    "Existing references will be redirected to the new tag via the \
+                                     overlay container.",
+                                )
+                                .color(text_dark()),
+                            );
+                        } else {
+                            ui.label(
+                                RichText::new(
+                                    "Writes an independent new tag; existing references are \
+                                     unchanged.",
+                                )
+                                .color(text_dark()),
+                            );
+                        }
+                        ui.label(
+                            RichText::new(
+                                "A higher-priority overlay container is written; base game files \
+                                 are never modified.",
+                            )
+                            .color(subtle_dark())
+                            .small(),
+                        );
+                    } else if state.referrers_unavailable {
                         ui.label(
                             RichText::new(
                                 "Reference index unavailable — references are still rewritten on \
@@ -539,7 +645,11 @@ impl Baboon {
                                 !state.new_path_input.trim().is_empty(),
                                 egui::Button::new("Apply"),
                             )
-                            .on_hover_text("Move the file on disk and rewrite all references")
+                            .on_hover_text(if state.is_container {
+                                "Write a higher-priority overlay container (base game unchanged)"
+                            } else {
+                                "Move the file on disk and rewrite all references"
+                            })
                             .clicked()
                         {
                             do_apply = true;

--- a/src/app/ui/settings.rs
+++ b/src/app/ui/settings.rs
@@ -96,6 +96,22 @@ impl Baboon {
             SessionRestore::Never,
             "Start fresh (never reopen)",
         );
+
+        ui.add_space(10.0);
+        ui.separator();
+        ui.label(RichText::new("Saving").color(text_dark()).strong());
+        ui.add_space(4.0);
+        ui.checkbox(
+            &mut self.confirm_container_overwrite,
+            "Confirm before Save overwrites Campaign Evolved game files",
+        );
+        ui.label(
+            RichText::new(
+                "Saving a tag loaded from a Campaign Evolved container overwrites the game's pak files in place. Use File \u{2192} Export Mod\u{2026} to bundle changes into a separate mod instead.",
+            )
+            .color(subtle_dark())
+            .small(),
+        );
     }
 
     pub(super) fn draw_settings_browser_tab(&mut self, ui: &mut Ui) {

--- a/src/app/ui/shell.rs
+++ b/src/app/ui/shell.rs
@@ -41,6 +41,13 @@ impl Baboon {
                             ui.close_menu();
                             self.begin_load_monolithic(ctx.clone());
                         }
+                        if ui
+                            .button("Open Campaign Evolved container (.utoc)...")
+                            .clicked()
+                        {
+                            ui.close_menu();
+                            self.begin_load_iostore_container(ctx.clone());
+                        }
                         ui.separator();
                         let has_loaded_folder = self.loaded_tags_root().is_some();
                         if ui
@@ -97,6 +104,21 @@ impl Baboon {
                         {
                             ui.close_menu();
                             self.save_current_tag_as();
+                        }
+                        if self.current_source_is_container() {
+                            if ui
+                                .add_enabled(
+                                    self.parsed_tags.values().any(|d| d.dirty),
+                                    egui::Button::new("Export Mod..."),
+                                )
+                                .on_hover_text(
+                                    "Bundle every open, modified tag into one portable mod overlay (the base game is left untouched)",
+                                )
+                                .clicked()
+                            {
+                                ui.close_menu();
+                                self.export_mod();
+                            }
                         }
                         if self.expert_mode {
                             if ui
@@ -1675,6 +1697,7 @@ impl Baboon {
         self.draw_settings_window(ctx);
         self.draw_tool_commands_window(ctx);
         self.draw_new_tag_window(ctx);
+        self.draw_overwrite_confirm_window(ctx);
         self.draw_tag_conversion_window(ctx);
         self.draw_folder_conversion_window(ctx);
         self.draw_about_window(ctx);

--- a/src/source/index.rs
+++ b/src/source/index.rs
@@ -258,7 +258,7 @@ fn refresh_entry_index_from_cache(
 fn entry_file_path(entry: &TagEntry) -> Option<&Path> {
     match &entry.location {
         TagEntryLocation::LooseFile(path) => Some(path.as_path()),
-        TagEntryLocation::Monolithic { .. } => None,
+        TagEntryLocation::Monolithic { .. } | TagEntryLocation::Container { .. } => None,
     }
 }
 

--- a/src/source/loading.rs
+++ b/src/source/loading.rs
@@ -139,6 +139,228 @@ pub fn load_monolithic_blob_index(
     })
 }
 
+const CAMPAIGN_EVOLVED_GAME: &str = "haloce_evolved";
+
+/// Mounts every IoStore container in a `Paks` directory as one merged read-only
+/// source of Reach tags (Halo: Campaign Evolved). Shared tags live in
+/// `pakchunk0`; each level chunk carries that mission's scenario + BSPs, so all
+/// packs must be mounted to see the whole tag tree.
+pub fn load_iostore_container_set(
+    paks_dir: PathBuf,
+    fallback_names: &TagNameIndex,
+    definitions_root: &Path,
+) -> Result<LoadedSourceData> {
+    let mut utocs: Vec<PathBuf> = std::fs::read_dir(&paks_dir)
+        .with_context(|| format!("failed to read {}", paks_dir.display()))?
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.extension().is_some_and(|x| x.eq_ignore_ascii_case("utoc")))
+        // `global.utoc` has no directory index; it would fail to open anyway.
+        .filter(|p| !p.file_name().is_some_and(|n| n.eq_ignore_ascii_case("global.utoc")))
+        .collect();
+    // Mount base chunk first, then level chunks by number, so higher/patch
+    // chunks win on any collision (mirrors UE's FIoDispatcher last-wins).
+    utocs.sort_by_key(|p| (chunk_number(p), p.clone()));
+    build_container_set(paks_dir, utocs, fallback_names, definitions_root)
+}
+
+/// Mounts a single IoStore container (`.utoc`) — the "open one chunk" path. The
+/// resulting source is still a set (of one).
+pub fn load_iostore_container(
+    utoc: PathBuf,
+    fallback_names: &TagNameIndex,
+    definitions_root: &Path,
+) -> Result<LoadedSourceData> {
+    let root = utoc.parent().map(Path::to_path_buf).unwrap_or_else(|| utoc.clone());
+    build_container_set(root, vec![utoc], fallback_names, definitions_root)
+}
+
+fn build_container_set(
+    root: PathBuf,
+    utocs: Vec<PathBuf>,
+    fallback_names: &TagNameIndex,
+    definitions_root: &Path,
+) -> Result<LoadedSourceData> {
+    let names = TagNameIndex::load_game(definitions_root, CAMPAIGN_EVOLVED_GAME)
+        .unwrap_or_else(|_| fallback_names.clone());
+
+    let mut containers: Vec<MountedContainer> = Vec::new();
+    let mut entries: Vec<TagEntry> = Vec::new();
+    // Dedup/layer by lowercase logical key; later packs (higher chunk) win.
+    let mut seen: HashMap<String, usize> = HashMap::new();
+    let mut opened_any = false;
+
+    for utoc in utocs {
+        let archive = match IoStoreArchive::open(&utoc) {
+            Ok(a) => a,
+            // Skip containers we can't parse (e.g. index-less globals).
+            Err(_) => continue,
+        };
+        opened_any = true;
+        let chunk_label = utoc
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("container")
+            .to_string();
+        let container_index = containers.len();
+        let archive = Arc::new(archive);
+        let mut contributed = false;
+
+        for e in archive.ublock_entries() {
+            let Some((tag_name, group_longname)) = parse_ublock_stem(&e.path) else {
+                continue;
+            };
+            // A known group long-name yields the FOURCC and also filters out
+            // non-tag `.ubulk` bulk data whose fake "group" isn't a real group.
+            let Some(group_tag) = names.group_tag_for(group_longname) else {
+                continue;
+            };
+
+            // Strip the `Tags/` root (that folder IS the Halo tags root, so the
+            // remainder is tag-reference-relative), then lowercase folders/name
+            // for consistency with lowercase tag references. `rel_path` keeps
+            // ORIGINAL case for the case-sensitive container read.
+            let after = strip_tags_root(&e.path);
+            let dir = after.rsplit_once('/').map(|(d, _)| d).unwrap_or("");
+            let logical = if dir.is_empty() {
+                tag_name.to_ascii_lowercase()
+            } else {
+                format!("{}/{}", dir.to_ascii_lowercase(), tag_name.to_ascii_lowercase())
+            };
+            let display_path = display_str_with_friendly_extension(&logical, group_tag, &names);
+
+            let entry = TagEntry {
+                key: format!("ublock:{chunk_label}:{}", e.path),
+                display_path,
+                group_tag,
+                group_name: names.name_for(group_tag).map(str::to_owned),
+                location: TagEntryLocation::Container {
+                    container: container_index,
+                    rel_path: e.path.clone(),
+                },
+            };
+            contributed = true;
+
+            let dedup_key = format!("{group_tag:08x}:{logical}");
+            match seen.get(&dedup_key) {
+                Some(&existing) => {
+                    // Overlap should be near-zero; note it rather than hide it.
+                    eprintln!(
+                        "container tag collision on {}: {} overrides earlier pack",
+                        entry.display_path, chunk_label
+                    );
+                    entries[existing] = entry;
+                }
+                None => {
+                    seen.insert(dedup_key, entries.len());
+                    entries.push(entry);
+                }
+            }
+        }
+
+        // Only keep packs that actually contributed tags (drops empty stubs).
+        if contributed {
+            containers.push(MountedContainer {
+                utoc_path: utoc,
+                chunk_label,
+                archive,
+            });
+        }
+    }
+
+    if !opened_any {
+        anyhow::bail!("no readable IoStore containers found in {}", root.display());
+    }
+
+    entries.sort_by(|a, b| natural_key(&a.display_path).cmp(&natural_key(&b.display_path)));
+    let label = format!(
+        "{} ({} packs)",
+        root.file_name().and_then(|s| s.to_str()).unwrap_or("Campaign Evolved"),
+        containers.len()
+    );
+    let tree = build_tree(&entries);
+    let group_tree = build_group_tree(&entries);
+    Ok(LoadedSourceData {
+        label,
+        source: TagSource::IoStoreContainerSet { root, containers },
+        names,
+        game: Some(CAMPAIGN_EVOLVED_GAME.to_string()),
+        all_entries: Vec::new(),
+        entries,
+        tree,
+        group_tree,
+        initial_tag: None,
+        reverse_dependencies: None,
+    })
+}
+
+/// Locate a UE5 `Paks` directory at or beneath `root` (any folder containing a
+/// `.utoc`), so "Load Folder" can auto-detect a Campaign Evolved install. Checks
+/// the folder itself, the common UE layout, then a shallow walk.
+pub fn find_paks_dir(root: &Path) -> Option<PathBuf> {
+    if dir_has_utoc(root) {
+        return Some(root.to_path_buf());
+    }
+    for cand in [
+        root.join("Meteorite").join("Content").join("Paks"),
+        root.join("Content").join("Paks"),
+    ] {
+        if dir_has_utoc(&cand) {
+            return Some(cand);
+        }
+    }
+    for entry in WalkDir::new(root)
+        .max_depth(4)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        if entry.file_type().is_dir()
+            && entry.file_name().eq_ignore_ascii_case("Paks")
+            && dir_has_utoc(entry.path())
+        {
+            return Some(entry.path().to_path_buf());
+        }
+    }
+    None
+}
+
+fn dir_has_utoc(dir: &Path) -> bool {
+    std::fs::read_dir(dir)
+        .into_iter()
+        .flatten()
+        .filter_map(|e| e.ok())
+        .any(|e| {
+            e.path()
+                .extension()
+                .is_some_and(|x| x.eq_ignore_ascii_case("utoc"))
+        })
+}
+
+/// Strip the leading `Tags/` root (optionally under `Meteorite/Content/`),
+/// case-insensitively. The remainder is relative to the Halo tags root.
+fn strip_tags_root(path: &str) -> &str {
+    for prefix in ["Meteorite/Content/Tags/", "Tags/"] {
+        if path.len() >= prefix.len() && path[..prefix.len()].eq_ignore_ascii_case(prefix) {
+            return &path[prefix.len()..];
+        }
+    }
+    let mc = "Meteorite/Content/";
+    if path.len() >= mc.len() && path[..mc.len()].eq_ignore_ascii_case(mc) {
+        return &path[mc.len()..];
+    }
+    path
+}
+
+/// Parse the chunk id from a `pakchunk<N>-...utoc` filename (u32::MAX if none),
+/// so `pakchunk0` sorts first as the base.
+fn chunk_number(utoc: &Path) -> u32 {
+    utoc.file_stem()
+        .and_then(|s| s.to_str())
+        .and_then(|s| s.strip_prefix("pakchunk"))
+        .and_then(|s| s.split(|c: char| !c.is_ascii_digit()).next())
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(u32::MAX)
+}
+
 /// Reads an entry using the storage and parsing rules of its owning source.
 /// Mismatched source/location pairs are rejected rather than guessed.
 pub fn read_entry(source: &TagSource, entry: &TagEntry) -> Result<TagFile> {
@@ -166,6 +388,28 @@ pub fn read_entry(source: &TagSource, entry: &TagEntry) -> Result<TagFile> {
         }),
         (TagEntryLocation::Monolithic { .. }, _) => {
             anyhow::bail!("monolithic entry selected outside a monolithic source")
+        }
+        (
+            TagEntryLocation::Container {
+                container,
+                rel_path,
+            },
+            TagSource::IoStoreContainerSet { containers, .. },
+        ) => {
+            let mounted = containers
+                .get(*container)
+                .context("container index out of range")?;
+            // The `.ubulk` payload is a byte-complete self-describing Reach MCC
+            // tag — no external layout needed.
+            let bytes = mounted
+                .archive
+                .read(rel_path)
+                .map_err(|e| anyhow!("failed to read {rel_path} from container: {e}"))?;
+            TagFile::read_from_bytes(&bytes)
+                .map_err(|e| anyhow!("failed to parse {}: {e}", entry.display_path))
+        }
+        (TagEntryLocation::Container { .. }, _) => {
+            anyhow::bail!("container entry selected outside a container source")
         }
     }
 }
@@ -279,6 +523,79 @@ fn read_non_classic_tag(path: &Path) -> Result<TagFile> {
         }
     }
     TagFile::read(path).map_err(Into::into)
+}
+
+#[cfg(test)]
+mod container_tests {
+    use super::*;
+
+    const PAKS: &str = "/Users/camden/Halo/halo-campaign-evolved_pc/Meteorite/Content/Paks";
+
+    /// Mount the whole `Paks` directory through Baboon's set loader and read a
+    /// sample of tags via `read_entry`. Asserts scenarios (only in level chunks)
+    /// show up alongside pak0's shared tags. Skipped when the game isn't present.
+    #[test]
+    fn mount_container_set_and_read_tags() {
+        if !Path::new(PAKS).exists() {
+            eprintln!("skipping: {PAKS} not present");
+            return;
+        }
+        let defs = Path::new(env!("CARGO_MANIFEST_DIR")).join("definitions");
+        let names = TagNameIndex::load_from_definitions(&defs);
+        let loaded = load_iostore_container_set(PathBuf::from(PAKS), &names, &defs)
+            .expect("mount container set");
+
+        assert!(
+            loaded.entries.len() > 5000,
+            "expected thousands of tags, got {}",
+            loaded.entries.len()
+        );
+        assert_eq!(loaded.game.as_deref(), Some("haloce_evolved"));
+        let TagSource::IoStoreContainerSet { ref containers, .. } = loaded.source else {
+            panic!("expected a container set");
+        };
+        assert!(containers.len() > 10, "expected base + level chunks, got {}", containers.len());
+
+        // Scenarios live only in level chunks — proves multi-container merge.
+        let scnr = u32::from_be_bytes(*b"scnr");
+        let scenarios: Vec<&TagEntry> =
+            loaded.entries.iter().filter(|e| e.group_tag == scnr).collect();
+        eprintln!(
+            "mounted {} packs, {} tags, {} scenarios",
+            containers.len(),
+            loaded.entries.len(),
+            scenarios.len()
+        );
+        for s in scenarios.iter().take(3) {
+            eprintln!("  scenario: {}", s.display_path);
+        }
+        assert!(
+            scenarios.len() >= 10,
+            "expected ~13 scenarios across level chunks, got {}",
+            scenarios.len()
+        );
+        // Display paths are lowercased and Tags/-stripped.
+        for s in &scenarios {
+            assert!(
+                s.display_path == s.display_path.to_ascii_lowercase(),
+                "display path not lowercased: {}",
+                s.display_path
+            );
+            assert!(!s.display_path.to_ascii_lowercase().contains("/tags/"));
+        }
+
+        // Read a sample (including every scenario) via the source-aware path.
+        let mut sample: Vec<&TagEntry> = scenarios.clone();
+        sample.extend(loaded.entries.iter().take(300));
+        for entry in sample {
+            let tag = read_entry(&loaded.source, entry)
+                .unwrap_or_else(|e| panic!("read_entry failed for {}: {e}", entry.display_path));
+            assert_eq!(
+                tag.group().tag, entry.group_tag,
+                "group mismatch for {}", entry.display_path
+            );
+        }
+    }
 }
 
 /// Validates a selected `blob_index.dat` and returns its cache directory.

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -13,6 +13,7 @@ use std::time::UNIX_EPOCH;
 
 use anyhow::{Context, Result, anyhow};
 use blam_tags::classic::{ClassicHeader, read_classic_tag_file};
+use blam_tags::iostore::{IoStoreArchive, parse_ublock_stem};
 use blam_tags::monolithic::MonolithicCache;
 use blam_tags::paths::group_tag_to_extension;
 use blam_tags::{TagFile, TagLayout, format_group_tag};
@@ -53,6 +54,13 @@ pub struct TagEntry {
 pub enum TagEntryLocation {
     LooseFile(PathBuf),
     Monolithic { name: String, group_tag: u32 },
+    /// A tag inside a mounted UE5 IoStore container (Halo: Campaign Evolved).
+    /// `container` indexes the owning [`TagSource::IoStoreContainerSet`]'s
+    /// `containers` (its provenance — which pak the tag came from, needed by the
+    /// write/repack path). `rel_path` is the container-relative path of the
+    /// `.ubulk` payload in its **original case** (the IoStore directory index is
+    /// case-sensitive), whose bytes are a self-describing Reach MCC tag.
+    Container { container: usize, rel_path: String },
 }
 
 #[derive(Clone)]
@@ -75,6 +83,25 @@ pub enum TagSource {
         root: PathBuf,
         cache: Arc<MonolithicCache>,
     },
+    /// One or more mounted UE5 IoStore containers (`.utoc`/`.ucas`) presented as
+    /// a single read-only virtual filesystem of Reach tags. `root` is the `Paks`
+    /// directory; `containers` are the individual mounted packs (base + level
+    /// chunks), each shared behind an `Arc` so reads don't reopen or re-mmap.
+    IoStoreContainerSet {
+        root: PathBuf,
+        containers: Vec<MountedContainer>,
+    },
+}
+
+/// One mounted IoStore pack within a [`TagSource::IoStoreContainerSet`]. Carries
+/// provenance (`utoc_path`, `chunk_label`) so the write/repack path knows
+/// exactly which container/chunk a tag belongs to.
+#[derive(Clone)]
+pub struct MountedContainer {
+    pub utoc_path: PathBuf,
+    /// e.g. `pakchunk240-WinGDK` — the pak this tag was read from.
+    pub chunk_label: String,
+    pub archive: Arc<IoStoreArchive>,
 }
 
 impl TagSource {
@@ -84,6 +111,9 @@ impl TagSource {
             TagSource::LooseFolder { root, .. } => format!("Folder: {}", root.display()),
             TagSource::MonolithicCache { root, .. } => {
                 format!("Monolithic cache: {}", root.display())
+            }
+            TagSource::IoStoreContainerSet { root, containers } => {
+                format!("Containers ({}): {}", containers.len(), root.display())
             }
         }
     }
@@ -228,6 +258,7 @@ pub(crate) const SUPPORTED_EK_GAMES: &[(&str, &str)] = &[
     ("Halo 3 ODST", "halo3odst_mcc"),
     ("Halo Reach", "haloreach_mcc"),
     ("Halo 4", "halo4_mcc"),
+    ("Halo: Campaign Evolved", "haloce_evolved"),
 ];
 
 #[derive(Default)]


### PR DESCRIPTION
Adds first-class support for **Halo: Campaign Evolved** — the UE5 remake of Halo 1 built on a modified Reach engine, which cooks its Reach-format tags into UE5 IoStore paks.

## Loading
Point **Load Folder** at the game's `Meteorite/Content/Paks/` directory. Baboon mounts every container (`.utoc`/`.ucas`, TOC v8, Oodle-compressed) as one virtual tag filesystem: the `.ubulk` payloads across all paks are merged into a single lowercase tag tree (top-level `Tags/` folder flattened into the root), each read as a normal Reach-format MCC tag. The game registers as **Halo: Campaign Evolved (PC)**.

New source plumbing: `TagSource::IoStoreContainerSet`, `TagEntryLocation::Container`, and the `haloce_evolved` editing-kit registration.

## Editing & mods
For a mounted container tag:

- **Save (Ctrl+S)** overwrites the tag **inside the game's own pak, in place** — the edited chunk is appended to the container's `.ucas` and its `.utoc` is repointed (perfect-hash seeds preserved), with the paired `.uasset`'s bulk size patched on a length change. Because this modifies shipped game files, Save **always confirms first**; the dialog offers **Export Mod** as the non-destructive alternative and has a **Don't ask again** opt-out (also under **Settings → Startup → Saving**). Loose-folder MCC tags save normally and never prompt.
- **Export Mod…** (File menu) bundles **every open, modified tag** into one portable, higher-priority `_P` overlay container, leaving the base game untouched.
- **Save As / Rename** write new/renamed tags into an overlay container (new UE package identity + `.uasset` + container-header entry; Rename adds a package redirect so existing references resolve).

## Engine
Bumps `blam-tags` to `863c879` (the `iostore` VFS + Zen `.uasset` (de)serializer + override/in-place writers, all native — no external UE tooling) and the `definitions` submodule to `732263c` (haloce_evolved definitions).

Identity/reference resolution uses the game's own `CityHash64` package-path hashing, validated against real chunk ids; the Zen serializer round-trips byte-exact on real packages; written containers verify against an independent packer. **In-game loading of an edited pak is the one step still unverified** — it needs a Windows/Xbox run to confirm.