### PR TITLE
Campaign Evolved: export mods as a .utoc/.ucas/.pak triplet so the game loads them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,7 +471,7 @@ dependencies = [
 [[package]]
 name = "blam-tags"
 version = "0.1.0"
-source = "git+https://github.com/camden-smallwood/blam-tags?rev=863c879d86db30ef297783e08b7b54288af24797#863c879d86db30ef297783e08b7b54288af24797"
+source = "git+https://github.com/camden-smallwood/blam-tags?rev=64bdc76366b2ac613cf28c6d0ab29648354c26fe#64bdc76366b2ac613cf28c6d0ab29648354c26fe"
 dependencies = [
  "anyhow",
  "bcdec_rs",
@@ -488,6 +488,7 @@ dependencies = [
  "opus",
  "serde",
  "serde_json",
+ "sha1",
  "strum",
  "tiff",
  "vorbis_rs",
@@ -3193,6 +3194,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1"
-blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "863c879d86db30ef297783e08b7b54288af24797", features = ["audio", "iostore"] }
+blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "64bdc76366b2ac613cf28c6d0ab29648354c26fe", features = ["audio", "iostore"] }
 eframe = { version = "0.29", default-features = false, features = ["default_fonts", "glow"] }
 egui_extras = { version = "0.29", features = ["svg"] }
 flate2 = "1"

--- a/README.md
+++ b/README.md
@@ -20,27 +20,30 @@ animations — all from one application.
 
 ## Supported games
 
-Baboon recognises and auto-configures itself for the following MCC editing
-kits, detected from the kit's root folder name:
+Baboon recognises and auto-configures itself for the following games. The MCC
+editing kits are detected from the kit's root folder name; Halo: Campaign
+Evolved is mounted from its game install (see the footnote and *Campaign Evolved
+mods* below):
 
-| Editing kit              | Folder              | Game identifier |
-| ------------------------ | ------------------- | --------------- |
-| Halo CE                  | `HCEEK` / `H1EK`    | `haloce_mcc`    |
-| Halo 2                   | `H2EK`              | `halo2_mcc`     |
-| Halo 3                   | `H3EK`              | `halo3_mcc`     |
-| Halo 3: ODST             | `H3ODSTEK`          | `halo3odst_mcc` |
-| Halo: Reach              | `HREK`              | `haloreach_mcc` |
-| Halo 4                   | `H4EK`              | `halo4_mcc`     |
-| Halo 2: Anniversary (MP) | `H2AMPEK` / `H2AEK` | `halo2amp_mcc`  |
+| Game                     | Folder                        | Game identifier  |
+| ------------------------ | ----------------------------- | ---------------- |
+| Halo CE                  | `HCEEK` / `H1EK`              | `haloce_mcc`     |
+| Halo 2                   | `H2EK`                        | `halo2_mcc`      |
+| Halo 3                   | `H3EK`                        | `halo3_mcc`      |
+| Halo 3: ODST             | `H3ODSTEK`                    | `halo3odst_mcc`  |
+| Halo: Reach              | `HREK`                        | `haloreach_mcc`  |
+| Halo 4                   | `H4EK`                        | `halo4_mcc`      |
+| Halo 2: Anniversary (MP) | `H2AMPEK` / `H2AEK`          | `halo2amp_mcc`   |
+| Halo: Campaign Evolved † | game install (IoStore paks)   | `haloce_evolved` |
 
-The game is also detected from a folder literally named after the game id (e.g.
-`halo3_mcc`), and **custom editing-kit folder names** can be mapped to a game in
-*File → Settings* for non-standard layouts.
+The MCC game is also detected from a folder literally named after the game id
+(e.g. `halo3_mcc`), and **custom editing-kit folder names** can be mapped to a
+game in *File → Settings* for non-standard layouts.
 
-Beyond the MCC editing kits, Baboon also mounts **Halo: Campaign Evolved**
-(`haloce_evolved`) — the UE5 remake of Halo 1 on a modified Reach engine, whose
-Reach-format tags are cooked into UE5 IoStore paks. It's loaded from its game
-folder rather than a `tags/` directory; see *Campaign Evolved mods* below.
+† **Halo: Campaign Evolved** is not an MCC editing kit — it's the UE5 remake of
+Halo 1 on a modified Reach engine, whose Reach-format tags are cooked into UE5
+IoStore paks. It's mounted from its game folder via **Load Folder** rather than a
+`tags/` directory; see *Campaign Evolved mods* below.
 
 Per-game group-name tables and schemas are loaded from
 `definitions/<game>/*.json`. Release builds place the `definitions/` folder next
@@ -312,10 +315,13 @@ package your changes as a separate, reversible mod:
 - **Rename** (right-click) — the same as Save As, plus a package **redirect** so
   existing tags that reference the old name resolve to the renamed one.
 
-Export Mod / Save As / Rename each produce a `<name>-WinGDK_P.utoc` / `.ucas`
-pair. Drop **both** files into the game's `Meteorite/Content/Paks/` folder
-alongside the base paks; the `_P` suffix gives the overlay patch priority and
-UE's loader serves your chunks on top of the base (last-mounted-wins).
+Export Mod / Save As / Rename each produce a `<name>-WinGDK_P` IoStore
+**triplet** — `.utoc`, `.ucas`, and a small `.pak` stub. Drop **all three**
+files into the game's `Meteorite/Content/Paks/` folder alongside the base paks.
+The `.pak` is required: UE's loader discovers containers by scanning that folder
+for `.pak` files and derives the matching `.utoc`/`.ucas` from each — an overlay
+with no `.pak` is never mounted. The `_P` suffix then gives the overlay patch
+priority so UE serves your chunks on top of the base (last-mounted-wins).
 
 Tag identity (`FPackageId` / export hashes), UE5 Zen-package `.uasset`
 (de)serialization, and override-container writing are all implemented natively in

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -2505,8 +2505,11 @@ impl Baboon {
             .collect();
         match blam_tags::iostore::writer::write_mod_container(&refs, &output) {
             Ok(()) => {
-                self.status =
-                    format!("Exported {count} tag(s) to {} (base game unchanged)", output.display())
+                let stem = output.file_stem().and_then(|s| s.to_str()).unwrap_or("mod");
+                self.status = format!(
+                    "Exported {count} tag(s) → {stem}.utoc/.ucas/.pak — copy all three into \
+                     Meteorite/Content/Paks/ (base game unchanged)"
+                )
             }
             Err(e) => self.status = format!("Export Mod failed: {e}"),
         }
@@ -2732,8 +2735,11 @@ impl Baboon {
             match self.export_container_override(&key, Some((new_rel, redirect))) {
                 Ok(Some(path)) => {
                     let what = if redirect { "renamed tag" } else { "tag copy" };
-                    self.status =
-                        format!("Exported {what} to {} (base game unchanged)", path.display());
+                    let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("mod");
+                    self.status = format!(
+                        "Exported {what} → {stem}.utoc/.ucas/.pak — copy all three into \
+                         Meteorite/Content/Paks/ (base game unchanged)"
+                    );
                 }
                 Ok(None) => {}
                 Err(e) => self.status = format!("Export failed: {e}"),


### PR DESCRIPTION
## Problem

Exported Campaign Evolved overlay mods never loaded in-game. Saving over the game's own pak (in place) worked, but **Export Mod / Save As / Rename** produced overlays the game ignored — reported by a Reach modder testing on real hardware.

## Root cause (reverse-engineered from `HaloCampaignEvolved.exe`)

The stock UE5 loader (`FPakPlatformFile`) discovers IoStore containers by **scanning `Paks/` for `*.pak`** and derives each sibling `.utoc`/`.ucas` from the `.pak` path. Confirmed in the binary: the *only* container-discovery glob is `*.pak` (there is no `*.utoc`/`*.ucas` scan), every shipped container is a `.pak`/`.ucas`/`.utoc` triple, and the one `.pak`-less container (`global.utoc`) is mounted by hardcoded name. Baboon wrote only `.utoc`/`.ucas`, so the overlay was **never discovered, never mounted**.

Everything else was already correct: `Mount` computes `Order = DirOrder + 100 × PatchVersion`, so the `_P` suffix already gives the overlay +100 over the base (~3), and the IoDispatcher resolves duplicate chunk ids to the highest-order container — the header-less id-override shadows the base as intended. The missing `.pak` stub was the entire gap.

## Fix

Bump `blam-tags` to `64bdc76`, whose `OverrideContainerWriter::write` now also emits a `<stem>.pak` stub beside the `.utoc`/`.ucas`, so all three overlay producers (`write_mod_container`, `write_tag_override`, `write_new_tag_container`) write the full triplet. The in-place overwrite path is untouched (the base already has its pak). The stub is a 339-byte empty UE5 pak generated clean-room (`PakFileVersion 11`, unencrypted, mount `/`, zero entries, present-but-empty PathHash + FullDirectory sub-indexes, `FPakInfo` footer) — matching the game's own IoStore-only level stubs.

Baboon side:
- Export Mod / Save As / Rename status messages now name all three files and tell the user to copy the whole triplet into `Meteorite/Content/Paks/`.
- README: add Campaign Evolved to the supported-games table, and correct the mod file set (pair → triplet, with why the `.pak` is required).

## Validation

Engine tests assert the stub's 339-byte layout and that its sub-index hashes equal the game's shipped stubs, and that every override write drops the `.pak` sibling; all 10 `iostore::writer` tests pass. Baboon builds against the bumped rev.

**In-game load of the triplet is the one step still unverified** — it needs a Windows/Xbox run to confirm.