### PR TITLE
Stop the release workflow overwriting hand-written release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,12 +103,16 @@ jobs:
           path: artifacts
           merge-multiple: true
 
+      # Attaches the built archives and nothing else. `generate_release_notes`
+      # is deliberately absent: a tagged release is usually published from a
+      # draft whose notes were written by hand, and generating them here would
+      # replace those with a commit list at the moment the tag is pushed.
+      # Passing no body leaves whatever the release already has.
       - name: Tagged release
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
           files: artifacts/*
-          generate_release_notes: true
           fail_on_unmatched_files: true
 
       - name: Dev rolling release


### PR DESCRIPTION
A tagged release is normally published from a draft whose notes were written by hand. Publishing that draft creates the tag, which runs this workflow, which passed `generate_release_notes: true` — so the notes were replaced by a commit list at the moment the tag went up, every time.

Dropping that input leaves the body alone. With no `body` input the action resolves `workflowBody || existingReleaseBody`, so an existing release keeps its notes and a release created by a bare tag push starts empty.

Artifact upload is unchanged, and the rolling `dev` release does not go through this step — it uses `gh release create` directly with its own `--notes`.

Needed before publishing the [v0.2.0 draft](https://github.com/Zoephie/Baboon/releases), whose notes would otherwise be discarded the moment it is published.