### PR TITLE
Per-workspace browser view, middle-click tab close, and a cross-workspace routing sweep

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -181,7 +181,7 @@ pub struct Baboon {
     /// Pending "discard unsaved edits and replace with the imported tag?" prompt.
     import_discard_confirm: Option<PendingImport>,
     /// Pending in-place overwrite confirmation (the tag key) for a container tag.
-    overwrite_confirm: Option<String>,
+    overwrite_confirm: Option<OverwriteConfirm>,
     about_open: bool,
     help_panel_tab: HelpPanelTab,
     help_docs: HelpDocsState,

--- a/src/app.rs
+++ b/src/app.rs
@@ -147,8 +147,11 @@ pub struct Baboon {
     folder_conversion_dialog: Option<FolderConversionDialog>,
     /// Modeless find-in-tag dialog and its exact occurrence list.
     find: FindDialogState,
-    browser_mode: BrowserMode,
-    browser_sort: BrowserSort,
+    /// Browser view a newly opened workspace starts in. The live setting is
+    /// [`Kit::browser_mode`] — each workspace keeps its own — and this is the
+    /// saved default they are seeded from.
+    default_browser_mode: BrowserMode,
+    default_browser_sort: BrowserSort,
     show_browser_prefixes: bool,
     folders_before_tags: bool,
     double_click_to_open_tags: bool,
@@ -335,15 +338,21 @@ impl Baboon {
             default_names: names.clone(),
             tx,
             rx,
-            kits: vec![Kit::empty(KitId(0), names.clone())],
+            // The startup workspace is seeded like any other new kit; every
+            // later one goes through `Baboon::empty_kit`.
+            kits: vec![Kit {
+                browser_mode: prefs.browser_mode,
+                browser_sort: prefs.browser_sort,
+                ..Kit::empty(KitId(0), names.clone())
+            }],
             kit_tree: egui_tiles::Tree::empty(egui::Id::new("kit_tree")),
             active: 0,
             next_kit_id: 1,
             tag_conversion_dialog: None,
             folder_conversion_dialog: None,
             find: FindDialogState::default(),
-            browser_mode: prefs.browser_mode,
-            browser_sort: prefs.browser_sort,
+            default_browser_mode: prefs.browser_mode,
+            default_browser_sort: prefs.browser_sort,
             show_browser_prefixes: prefs.show_browser_prefixes,
             folders_before_tags: prefs.folders_before_tags,
             double_click_to_open_tags: prefs.double_click_to_open_tags,

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -4853,8 +4853,8 @@ impl Baboon {
         self.launch_kit_tool_clearing_startup("tag_test", self.tag_test_executable(), "init.txt");
     }
 
-    pub(super) fn can_launch_scenario_in_sapien(&self, entry: &TagEntry) -> bool {
-        let Some(source) = self.source() else {
+    pub(super) fn can_launch_scenario_in_sapien(&self, kit: usize, entry: &TagEntry) -> bool {
+        let Some(source) = self.kits.get(kit).and_then(|kit| kit.source.as_ref()) else {
             return false;
         };
         let Ok(context) = scenario_launch_context(source, entry) else {
@@ -4919,8 +4919,8 @@ impl Baboon {
         }
     }
 
-    pub(super) fn can_launch_scenario_in_tag_test(&self, entry: &TagEntry) -> bool {
-        let Some(source) = self.source() else {
+    pub(super) fn can_launch_scenario_in_tag_test(&self, kit: usize, entry: &TagEntry) -> bool {
+        let Some(source) = self.kits.get(kit).and_then(|kit| kit.source.as_ref()) else {
             return false;
         };
         let Ok(context) = scenario_launch_context(source, entry) else {

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -2033,6 +2033,8 @@ impl Baboon {
             source_path,
             game: source.game.clone(),
             project_path: kit.campaign_project.as_ref().map(|project| project.path.clone()),
+            browser_mode: Some(kit.browser_mode),
+            browser_sort: Some(kit.browser_sort),
             tags,
         })
     }
@@ -2049,6 +2051,8 @@ impl Baboon {
             source_kind,
             source_path,
             project_path,
+            browser_mode,
+            browser_sort,
             tags,
         } in kits
         {
@@ -2079,6 +2083,15 @@ impl Baboon {
             // The loaders route to a kit and leave it active, so this stages
             // the tags on the kit the load will land in.
             self.kits[self.active].pending_restore_tags = tags;
+            // Its browser view is staged the same way: `install_loaded_source`
+            // carries it across the load rather than resetting it, so each
+            // workspace comes back in the view it was left in.
+            if let Some(mode) = browser_mode {
+                self.kits[self.active].browser_mode = mode;
+            }
+            if let Some(sort) = browser_sort {
+                self.kits[self.active].browser_sort = sort;
+            }
             // Its project is queued the same way, and opens once the source
             // this session recorded has finished mounting.
             if let Some(project_path) = project_path {
@@ -4136,7 +4149,7 @@ impl Baboon {
             return;
         };
         self.kits[self.active].filter.clear();
-        self.browser_mode = BrowserMode::Folders;
+        self.kits[self.active].browser_mode = BrowserMode::Folders;
         self.kits[self.active].selected_key = Some(entry.key.clone());
         self.reveal_target = Some(RevealRequest {
             kit: self.active_kit_id(),
@@ -4655,8 +4668,10 @@ impl Baboon {
 
     pub(super) fn current_prefs(&self) -> GuiPrefs {
         GuiPrefs {
-            browser_mode: self.browser_mode,
-            browser_sort: self.browser_sort,
+            // The focused workspace's view is what a new one is seeded with,
+            // so a single-workspace session remembers its choice as before.
+            browser_mode: self.kits[self.active].browser_mode,
+            browser_sort: self.kits[self.active].browser_sort,
             show_browser_prefixes: self.show_browser_prefixes,
             folders_before_tags: self.folders_before_tags,
             double_click_to_open_tags: self.double_click_to_open_tags,

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -490,6 +490,7 @@ impl Baboon {
             .unwrap_or("halo3_mcc")
             .to_owned();
         self.new_tag_dialog = NewTagDialog {
+            kit: Some(self.active_kit_id()),
             game: default_game,
             rel_path: String::new(),
             output_path: None,
@@ -588,6 +589,16 @@ impl Baboon {
     }
 
     pub(super) fn create_new_tag(&mut self) {
+        // The tag is written into the active kit's source, and nothing below
+        // names a workspace, so without this the tag is created in whichever
+        // game was focused when Create was pressed rather than the one the
+        // dialog was opened for.
+        let dialog_kit = self.new_tag_dialog.kit;
+        if !dialog_kit.is_some_and(|kit| self.focus_navigation_kit(kit)) {
+            self.new_tag_dialog.error =
+                Some("The workspace this tag was being created in is closed".to_owned());
+            return;
+        }
         // Campaign Evolved containers have no loose tags folder to write into —
         // create the tag purely in memory and let Save / Export Mod write it.
         if self.current_source_is_container() {
@@ -806,6 +817,7 @@ impl Baboon {
             .unwrap_or("imported")
             .to_owned();
         self.import_tag_dialog = Some(ImportTagDialog {
+            kit: self.active_kit_id(),
             source_path: picked,
             folder_rel: folder_rel.unwrap_or_default(),
             name,
@@ -842,6 +854,16 @@ impl Baboon {
     /// document (dirty, with a discard prompt if it has unsaved edits) or add a
     /// brand-new container tag.
     pub(super) fn confirm_import_tag(&mut self) {
+        // The import is resolved and registered against the active kit's
+        // source, so return to the workspace the dialog was opened for.
+        let Some(kit) = self.import_tag_dialog.as_ref().map(|dialog| dialog.kit) else {
+            return;
+        };
+        if !self.focus_navigation_kit(kit) {
+            self.import_tag_dialog = None;
+            self.status = "The workspace this import came from is closed".to_owned();
+            return;
+        }
         let Some(dialog) = self.import_tag_dialog.as_mut() else {
             return;
         };
@@ -909,6 +931,7 @@ impl Baboon {
             // Already open with unsaved edits → confirm discard first.
             if self.kits[self.active].parsed_tags.get(&key).map(|d| d.dirty).unwrap_or(false) {
                 self.import_discard_confirm = Some(PendingImport {
+                    kit: self.active_kit_id(),
                     tag,
                     target_key: key,
                 });
@@ -975,6 +998,10 @@ impl Baboon {
         let Some(pending) = self.import_discard_confirm.take() else {
             return;
         };
+        if !self.focus_navigation_kit(pending.kit) {
+            self.status = "The workspace this import came from is closed".to_owned();
+            return;
+        }
         self.apply_import_over_existing(&pending.target_key, pending.tag);
     }
 
@@ -2822,7 +2849,10 @@ impl Baboon {
         // builds never prompt).
         if self.current_source_is_container() {
             if self.confirm_container_overwrite {
-                self.overwrite_confirm = Some(key);
+                self.overwrite_confirm = Some(OverwriteConfirm {
+                    kit: self.active_kit_id(),
+                    key,
+                });
             } else {
                 self.overwrite_current_tag_in_place(&key);
             }
@@ -3400,6 +3430,7 @@ impl Baboon {
             None => (Vec::new(), true),
         };
         self.rename_tag = Some(RenameTagState {
+            kit: self.active_kit_id(),
             key: entry.key.clone(),
             old_display: display,
             extension,
@@ -3414,6 +3445,18 @@ impl Baboon {
     /// Apply the rename/move: move the file on disk and rewrite every
     /// referencing tag, in the background (reuses the folder-refactor pipeline).
     pub(super) fn begin_rename_tag(&mut self) {
+        // Everything below resolves against the active kit's tags root or
+        // container set, so return to the workspace the dialog was opened for.
+        // A closed workspace drops the rename rather than moving a file in
+        // whichever game is focused now.
+        let Some(kit) = self.rename_tag.as_ref().map(|state| state.kit) else {
+            return;
+        };
+        if !self.focus_navigation_kit(kit) {
+            self.rename_tag = None;
+            self.status = "The workspace this rename came from is closed".to_owned();
+            return;
+        }
         let Some((key, old_display, new_name_raw, is_container, redirect)) =
             self.rename_tag.as_ref().map(|s| {
                 (
@@ -4436,6 +4479,16 @@ impl Baboon {
     /// Rows beyond the current element count are reported and ignored (no
     /// structural changes — fully covered by undo). Returns a status summary.
     pub(super) fn apply_tsv_paste(&mut self) {
+        // The document is looked up in the active kit below, and two workspaces
+        // of the same game share a key space, so a paste answered after a
+        // switch could land in the wrong game's tag rather than simply missing.
+        let Some(kit) = self.tsv_paste.as_ref().map(|paste| paste.kit) else {
+            return;
+        };
+        if !self.focus_navigation_kit(kit) {
+            self.set_tsv_paste_status("The workspace this paste came from is closed.");
+            return;
+        }
         let Some(paste) = self.tsv_paste.as_ref() else {
             return;
         };
@@ -5263,6 +5316,10 @@ impl Baboon {
         let Some(confirm) = self.block_confirm.as_ref() else {
             return;
         };
+        // The op is applied to the active kit's document, and two workspaces of
+        // the same game share a key space, so a confirmation answered after a
+        // switch could delete from the wrong game's tag.
+        let confirm_kit = confirm.kit;
         let message = confirm.message.clone();
         let confirm_label = confirm.confirm_label.clone();
         let mut do_apply = false;
@@ -5297,7 +5354,10 @@ impl Baboon {
                 });
             });
         if do_apply {
-            if let Some(confirm) = self.block_confirm.take() {
+            let routed = confirm_kit.is_some_and(|kit| self.focus_navigation_kit(kit));
+            if let Some(confirm) = self.block_confirm.take()
+                && routed
+            {
                 if let Some(doc) = self.kits[self.active].parsed_tags.get_mut(&confirm.tag_key) {
                     let op = BlockOp {
                         path: confirm.path,

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -1048,7 +1048,14 @@ impl Baboon {
     }
 
     pub(super) fn loaded_tags_root(&self) -> Option<PathBuf> {
-        let TagSource::LooseFolder { root, .. } = &self.source()?.source else {
+        self.loaded_tags_root_for(self.active)
+    }
+
+    /// A specific kit's loose tags root. Background work has to name its kit:
+    /// the one it started in may no longer be the focused one when it lands.
+    pub(super) fn loaded_tags_root_for(&self, kit: usize) -> Option<PathBuf> {
+        let TagSource::LooseFolder { root, .. } = &self.kits.get(kit)?.source.as_ref()?.source
+        else {
             return None;
         };
         Some(root.clone())
@@ -1060,17 +1067,22 @@ impl Baboon {
             .position(|kit| same_recent_path(&kit.tags_root, root))
     }
 
-    fn refresh_active_favorite_entries(&mut self) {
-        self.kits[self.active].active_favorite_entries.clear();
-        let Some(root) = self.loaded_tags_root() else {
+    /// Rebuild `kit`'s resolved favorite entries from the saved paths for its
+    /// tags root. Kit-scoped because a finished background refactor refreshes
+    /// the workspace it belonged to, which need not be the focused one.
+    fn refresh_favorite_entries_for(&mut self, kit: usize) {
+        self.kits[kit].active_favorite_entries.clear();
+        let Some(root) = self.loaded_tags_root_for(kit) else {
             return;
         };
         let Some(index) = self.favorite_kit_index(&root) else {
             return;
         };
-        let names = self.source()
+        let names = self.kits[kit]
+            .source
+            .as_ref()
             .map(|source| source.names.clone())
-            .unwrap_or_else(|| self.names().clone());
+            .unwrap_or_else(|| self.kits[kit].names.clone());
         let saved_paths = self.editing_kit_favorites[index].tags.clone();
         let mut missing = Vec::new();
         for relative_path in saved_paths {
@@ -1080,7 +1092,7 @@ impl Baboon {
                 continue;
             }
             if let Ok(Some(entry)) = loose_file_entry(&root, &path, &names) {
-                self.kits[self.active].active_favorite_entries.push(entry);
+                self.kits[kit].active_favorite_entries.push(entry);
             }
         }
         if !missing.is_empty() {
@@ -1144,8 +1156,18 @@ impl Baboon {
         }
     }
 
-    fn remap_current_favorites(&mut self, old_to_new_keys: &HashMap<String, String>) {
-        let Some(root) = self.loaded_tags_root() else {
+    /// Rewrite `kit`'s favorites after a move or rename changed its tag paths.
+    ///
+    /// Takes the kit rather than reading the active one: this runs from a
+    /// finished background refactor, which may well land while the user is in
+    /// another workspace — and then it resolved the wrong root and remapped the
+    /// wrong workspace's favorites with this one's rename map.
+    fn remap_favorites_for_kit(
+        &mut self,
+        kit: usize,
+        old_to_new_keys: &HashMap<String, String>,
+    ) {
+        let Some(root) = self.loaded_tags_root_for(kit) else {
             return;
         };
         let Some(index) = self.favorite_kit_index(&root) else {
@@ -1168,7 +1190,7 @@ impl Baboon {
                 true
             }
         });
-        self.refresh_active_favorite_entries();
+        self.refresh_favorite_entries_for(kit);
     }
 
     pub(super) fn open_dropped_files(&mut self, paths: Vec<PathBuf>, ctx: egui::Context) {

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -238,8 +238,8 @@ impl Baboon {
                 WorkerMessage::FolderRefactorProgress(progress) => {
                     self.handle_folder_refactor_progress(progress)
                 }
-                WorkerMessage::FolderRefactorFinished(result) => {
-                    self.handle_folder_refactor_finished(result)
+                WorkerMessage::FolderRefactorFinished { stamp, result } => {
+                    self.handle_folder_refactor_finished(stamp, result)
                 }
                 WorkerMessage::FolderConversionProgress(progress) => {
                     self.handle_folder_conversion_progress(progress)
@@ -2501,6 +2501,9 @@ impl Baboon {
         let existing_reverse_dependencies = self.source()
             .and_then(|source| source.reverse_dependencies.clone());
         let game = self.source().and_then(|source| source.game.clone());
+        // Routed back to the kit the refactor was started in, not
+        // whichever one is focused when it lands.
+        let stamp = self.kit_stamp();
         let tx = self.tx.clone();
         let job_label = if move_folder {
             format!("Moving {label}")
@@ -2529,7 +2532,7 @@ impl Baboon {
                 )
             }))
             .unwrap_or_else(|_| Err("Folder move/copy worker crashed".to_owned()));
-            let _ = tx.send(WorkerMessage::FolderRefactorFinished(result));
+            let _ = tx.send(WorkerMessage::FolderRefactorFinished { stamp, result });
         });
     }
 
@@ -3558,6 +3561,9 @@ impl Baboon {
             .unwrap_or_default();
         let reverse_dependencies = self.source()
             .and_then(|source| source.reverse_dependencies.clone());
+        // Routed back to the kit the refactor was started in, not
+        // whichever one is focused when it lands.
+        let stamp = self.kit_stamp();
         let tx = self.tx.clone();
         let job_label = job_label.to_owned();
         self.folder_refactor = Some(FolderRefactorUiState {
@@ -3581,7 +3587,7 @@ impl Baboon {
                 )
             }))
             .unwrap_or_else(|_| Err("Tag move worker crashed".to_owned()));
-            let _ = tx.send(WorkerMessage::FolderRefactorFinished(result));
+            let _ = tx.send(WorkerMessage::FolderRefactorFinished { stamp, result });
         });
     }
 
@@ -7484,16 +7490,6 @@ fn moved_key_map(
         }
     }
     map
-}
-
-fn remap_open_tag_keys(keys: &mut Vec<String>, map: &HashMap<String, String>) {
-    for key in keys.iter_mut() {
-        if let Some(new_key) = map.get(key) {
-            *key = new_key.clone();
-        }
-    }
-    let mut seen = HashSet::new();
-    keys.retain(|key| seen.insert(key.clone()));
 }
 
 fn same_entry_key(a: &str, b: &str) -> bool {

--- a/src/app/controller/loading.rs
+++ b/src/app/controller/loading.rs
@@ -60,7 +60,7 @@ impl Baboon {
         }
         let installed = self.active;
         self.apply_pending_campaign_project(installed, ctx.input(|input| input.time), ctx);
-        self.refresh_active_favorite_entries();
+        self.refresh_favorite_entries_for(installed);
         self.kits[self.active].generation = self.kits[self.active].generation.wrapping_add(1);
         self.refreshing_entry_index = false;
         self.building_reverse_dependencies = false;

--- a/src/app/controller/references.rs
+++ b/src/app/controller/references.rs
@@ -127,7 +127,7 @@ impl Baboon {
             }
         }
         if done.moved {
-            self.remap_current_favorites(&done.old_to_new_keys);
+            self.remap_favorites_for_kit(kit_index, &done.old_to_new_keys);
             self.kits[kit_index].remap_tag_keys(&done.old_to_new_keys);
         }
         let kit = &mut self.kits[kit_index];

--- a/src/app/controller/references.rs
+++ b/src/app/controller/references.rs
@@ -79,8 +79,14 @@ impl Baboon {
     }
 
     /// Applies `WorkerMessage::FolderRefactorFinished` and remaps open state after moves.
+    ///
+    /// Everything here lands on the kit the refactor was started in. It used to
+    /// land on the active kit, so a move that finished after the user switched
+    /// workspaces rebuilt the *other* game's browser from these results and
+    /// dropped its open documents and unsaved edit buffers along the way.
     pub(super) fn handle_folder_refactor_finished(
         &mut self,
+        stamp: KitStamp,
         result: Result<FolderRefactorFinished, String>,
     ) -> bool {
         self.folder_refactor = None;
@@ -91,7 +97,13 @@ impl Baboon {
                 return false;
             }
         };
-        if let Some(source) = self.source_mut() {
+        // The kit was closed or reloaded while the job ran: the work on disk is
+        // done, but there is no longer anything here to apply it to.
+        let Some(kit_index) = self.resolve_stamp(stamp) else {
+            self.status = done.status;
+            return false;
+        };
+        if let Some(source) = self.kits[kit_index].source.as_mut() {
             source.entries.clear();
             source.all_entries = done.all_entries;
             source.tree = done.tree;
@@ -116,21 +128,17 @@ impl Baboon {
         }
         if done.moved {
             self.remap_current_favorites(&done.old_to_new_keys);
-            remap_open_tag_keys(&mut self.kits[self.active].open_tabs, &done.old_to_new_keys);
-            if let Some(selected) = self.kits[self.active].selected_key.clone()
-                && let Some(new_key) = done.old_to_new_keys.get(&selected)
-            {
-                self.kits[self.active].selected_key = Some(new_key.clone());
-            }
+            self.kits[kit_index].remap_tag_keys(&done.old_to_new_keys);
         }
-        self.kits[self.active].parsed_tags.clear();
-        self.kits[self.active].loading_tags.clear();
-        self.kits[self.active].bitmap_previews.clear();
-        self.kits[self.active].model_previews.clear();
-        self.kits[self.active].edit_buffers.clear();
-        self.kits[self.active].field_search.clear();
-        self.kits[self.active].field_search_applied.clear();
-        self.kits[self.active].generation = self.kits[self.active].generation.wrapping_add(1);
+        let kit = &mut self.kits[kit_index];
+        kit.parsed_tags.clear();
+        kit.loading_tags.clear();
+        kit.bitmap_previews.clear();
+        kit.model_previews.clear();
+        kit.edit_buffers.clear();
+        kit.field_search.clear();
+        kit.field_search_applied.clear();
+        kit.generation = kit.generation.wrapping_add(1);
         self.terminal
             .lines
             .extend(done.lines.into_iter().map(TerminalLineEntry::new));

--- a/src/app/foundation/containers.rs
+++ b/src/app/foundation/containers.rs
@@ -956,6 +956,9 @@ pub(in crate::app) fn draw_foundation_block(
         if actions.replace_block {
             // Destructive (clears the block) — route through the confirm modal.
             *edit.block_confirm = Some(BlockConfirm {
+            // Stamped by the pane once this render returns; the field
+            // renderers are shared and have no kit of their own.
+            kit: None,
                 tag_key: edit.tag_key.to_owned(),
                 path: path_prefix.to_owned(),
                 kind: BlockOpKind::ReplaceBlock { elements },
@@ -1033,6 +1036,9 @@ pub(in crate::app) fn handle_block_actions(
             set_block_selected_index(ui, edit, path, sel.saturating_sub(1));
         } else {
             *edit.block_confirm = Some(BlockConfirm {
+            // Stamped by the pane once this render returns; the field
+            // renderers are shared and have no kit of their own.
+            kit: None,
                 tag_key: edit.tag_key.to_owned(),
                 path: path.to_owned(),
                 kind: BlockOpKind::Delete(sel),
@@ -1043,6 +1049,9 @@ pub(in crate::app) fn handle_block_actions(
     }
     if actions.delete_all && count > 0 {
         *edit.block_confirm = Some(BlockConfirm {
+            // Stamped by the pane once this render returns; the field
+            // renderers are shared and have no kit of their own.
+            kit: None,
             tag_key: edit.tag_key.to_owned(),
 
             path: path.to_owned(),

--- a/src/app/kit.rs
+++ b/src/app/kit.rs
@@ -411,7 +411,39 @@ fn active_after_removal(active: usize, removed: usize, new_len: usize) -> usize 
 
 #[cfg(test)]
 mod tests {
-    use super::active_after_removal;
+    use super::{active_after_removal, Kit, KitId};
+    use std::collections::HashMap;
+
+    /// A folder move rewrites tag keys underneath the open tabs. The tree is
+    /// what has to be rewritten: `open_tabs` is re-derived from it every frame,
+    /// so a remap that touched only the list was overwritten immediately and
+    /// left the panes pointing at keys the source no longer had.
+    #[test]
+    fn remapping_tag_keys_rewrites_the_layout_tree_itself() {
+        let mut kit = Kit::empty(KitId(0), Default::default());
+        kit.open_tag_pane("file:/tags/objects/a.weapon");
+        kit.open_tag_pane("file:/tags/objects/b.weapon");
+        kit.selected_key = Some("file:/tags/objects/a.weapon".to_owned());
+
+        let mut map = HashMap::new();
+        map.insert(
+            "file:/tags/objects/a.weapon".to_owned(),
+            "file:/tags/moved/a.weapon".to_owned(),
+        );
+        kit.remap_tag_keys(&map);
+
+        // Read back through the tree, not the cached list, so the assertion
+        // fails if only the list was rewritten.
+        let panes = kit.tabs_from_tree();
+        assert!(panes.contains(&"file:/tags/moved/a.weapon".to_owned()));
+        assert!(!panes.contains(&"file:/tags/objects/a.weapon".to_owned()));
+        assert!(panes.contains(&"file:/tags/objects/b.weapon".to_owned()));
+        assert_eq!(kit.open_tabs, panes);
+        assert_eq!(
+            kit.selected_key.as_deref(),
+            Some("file:/tags/moved/a.weapon")
+        );
+    }
 
     #[test]
     fn removing_a_kit_before_the_active_one_shifts_the_selection_down() {
@@ -461,6 +493,28 @@ impl Kit {
                 egui_tiles::Tile::Container(_) => None,
             })
             .collect()
+    }
+
+    /// Rewrite every open tag key through `map`, after a move or rename has
+    /// changed the keys underneath them.
+    ///
+    /// The tree is where this has to land: `open_tabs` is re-derived from it
+    /// every frame, so remapping only the list is overwritten immediately and
+    /// the panes keep pointing at keys their source no longer has.
+    pub(super) fn remap_tag_keys(&mut self, map: &HashMap<String, String>) {
+        for (_, tile) in self.tag_tree.tiles.iter_mut() {
+            if let egui_tiles::Tile::Pane(key) = tile
+                && let Some(new_key) = map.get(key)
+            {
+                *key = new_key.clone();
+            }
+        }
+        if let Some(selected) = self.selected_key.as_ref()
+            && let Some(new_key) = map.get(selected)
+        {
+            self.selected_key = Some(new_key.clone());
+        }
+        self.sync_open_tabs();
     }
 
     /// Re-derive `open_tabs` from the tree. Called after anything that can

--- a/src/app/kit.rs
+++ b/src/app/kit.rs
@@ -243,6 +243,15 @@ impl Baboon {
         match self.kit_index(kit) {
             Some(index) => {
                 self.active = index;
+                // Bring its workspace tab to the front too. `active` alone only
+                // decides where the action lands; if that workspace is a
+                // background tab the user is still looking at another game, and
+                // a jump or a confirmed dialog reads as having done nothing.
+                // A split needs no help here — both panes are already visible,
+                // and `make_active` leaves a pane that is not in a tab group
+                // alone.
+                self.kit_tree
+                    .make_active(|_, tile| matches!(tile, egui_tiles::Tile::Pane(id) if *id == kit));
                 true
             }
             None => false,

--- a/src/app/kit.rs
+++ b/src/app/kit.rs
@@ -87,6 +87,14 @@ pub(super) struct Kit {
     pub(super) field_search_applied: HashMap<String, String>,
 
     // --- Browser and index state ---
+    /// How this kit's browser lists tags, and in what order. Per kit because
+    /// the useful view differs by game — a folder-organized editing kit reads
+    /// best as Folders while a container source reads best as Groups — and two
+    /// browsers are on screen at once in a split. New kits start from the
+    /// saved [`Baboon::default_browser_mode`], so a single workspace behaves
+    /// exactly as it did when this was one application-wide setting.
+    pub(super) browser_mode: BrowserMode,
+    pub(super) browser_sort: BrowserSort,
     pub(super) filter: String,
     pub(super) filter_cache: FilterCache,
     /// Bumped whenever this kit's source or its `all_entries` set is replaced,
@@ -145,6 +153,8 @@ impl Kit {
             ce_sound_bindings: HashMap::new(),
             field_search: HashMap::new(),
             field_search_applied: HashMap::new(),
+            browser_mode: BrowserMode::default(),
+            browser_sort: BrowserSort::default(),
             filter: String::new(),
             filter_cache: FilterCache::default(),
             generation: 0,
@@ -266,12 +276,24 @@ impl Baboon {
         id
     }
 
+    /// Build an empty kit carrying a fresh id and the application defaults,
+    /// including the browser view a new workspace opens in. Every kit is made
+    /// here so no path can miss the seeding and open in the wrong view.
+    fn empty_kit(&mut self) -> Kit {
+        let id = self.next_kit_id();
+        Kit {
+            browser_mode: self.default_browser_mode,
+            browser_sort: self.default_browser_sort,
+            ..Kit::empty(id, self.default_names.clone())
+        }
+    }
+
     /// Add an empty kit and make it active. The next load installs into it,
     /// so "open another game" is add-then-load rather than a separate path.
     pub(super) fn add_kit(&mut self) -> KitId {
-        let id = self.next_kit_id();
-        let names = self.default_names.clone();
-        self.kits.push(Kit::empty(id, names));
+        let kit = self.empty_kit();
+        let id = kit.id;
+        self.kits.push(kit);
         self.active = self.kits.len() - 1;
         id
     }
@@ -285,9 +307,8 @@ impl Baboon {
         };
         self.kits.remove(index);
         if self.kits.is_empty() {
-            let id = self.next_kit_id();
-            let names = self.default_names.clone();
-            self.kits.push(Kit::empty(id, names));
+            let kit = self.empty_kit();
+            self.kits.push(kit);
         }
         self.active = active_after_removal(self.active, index, self.kits.len());
     }
@@ -342,10 +363,17 @@ impl Baboon {
         let pending_restore_tags = std::mem::take(&mut self.kits[index].pending_restore_tags);
         let pending_campaign_project =
             std::mem::take(&mut self.kits[index].pending_campaign_project);
+        // The browser view belongs to the workspace, not to the source in it:
+        // reloading a kit — or restoring one, which stages the saved view
+        // before the load lands — must not snap it back to the default.
+        let browser_mode = self.kits[index].browser_mode;
+        let browser_sort = self.kits[index].browser_sort;
         self.kits[index] = Kit {
             source: Some(source),
             names,
             requested_path,
+            browser_mode,
+            browser_sort,
             pending_restore_tags,
             pending_campaign_project,
             ..Kit::empty(id, self.default_names.clone())

--- a/src/app/prefs.rs
+++ b/src/app/prefs.rs
@@ -55,15 +55,10 @@ pub(super) fn load_gui_prefs() -> GuiPrefs {
     let Ok(value) = serde_json::from_str::<Value>(&text) else {
         return GuiPrefs::default();
     };
-    let browser_mode = match value.get("browser_mode").and_then(Value::as_str) {
-        Some("groups") => BrowserMode::Groups,
-        _ => BrowserMode::Folders,
-    };
-    let browser_sort = match value.get("browser_sort").and_then(Value::as_str) {
-        Some("name") => BrowserSort::Name,
-        Some("type") => BrowserSort::Type,
-        _ => BrowserSort::Natural,
-    };
+    let browser_mode =
+        browser_mode_from_str(value.get("browser_mode").and_then(Value::as_str)).unwrap_or_default();
+    let browser_sort =
+        browser_sort_from_str(value.get("browser_sort").and_then(Value::as_str)).unwrap_or_default();
     GuiPrefs {
         browser_mode,
         browser_sort,
@@ -397,15 +392,8 @@ pub(super) fn save_gui_prefs(
         }
     }
     let value = json!({
-        "browser_mode": match prefs.browser_mode {
-            BrowserMode::Folders => "folders",
-            BrowserMode::Groups => "groups",
-        },
-        "browser_sort": match prefs.browser_sort {
-            BrowserSort::Natural => "natural",
-            BrowserSort::Name => "name",
-            BrowserSort::Type => "type",
-        },
+        "browser_mode": browser_mode_str(prefs.browser_mode),
+        "browser_sort": browser_sort_str(prefs.browser_sort),
         "show_browser_prefixes": prefs.show_browser_prefixes,
         "folders_before_tags": prefs.folders_before_tags,
         "double_click_to_open_tags": prefs.double_click_to_open_tags,
@@ -483,6 +471,40 @@ pub(super) fn load_terminal_open_games() -> HashSet<String> {
 /// Version 3 stores an array of kits. Versions 1 and 2 stored a single source
 /// and are upgraded in place to a one-kit session, so a session file written
 /// by any earlier build still restores rather than being silently dropped.
+/// The browser view enums travel as strings in both `prefs.json` and
+/// `last_session.json`. Mapped in one place so the two files cannot drift.
+fn browser_mode_from_str(text: Option<&str>) -> Option<BrowserMode> {
+    match text? {
+        "folders" => Some(BrowserMode::Folders),
+        "groups" => Some(BrowserMode::Groups),
+        _ => None,
+    }
+}
+
+fn browser_mode_str(mode: BrowserMode) -> &'static str {
+    match mode {
+        BrowserMode::Folders => "folders",
+        BrowserMode::Groups => "groups",
+    }
+}
+
+fn browser_sort_from_str(text: Option<&str>) -> Option<BrowserSort> {
+    match text? {
+        "natural" => Some(BrowserSort::Natural),
+        "name" => Some(BrowserSort::Name),
+        "type" => Some(BrowserSort::Type),
+        _ => None,
+    }
+}
+
+fn browser_sort_str(sort: BrowserSort) -> &'static str {
+    match sort {
+        BrowserSort::Natural => "natural",
+        BrowserSort::Name => "name",
+        BrowserSort::Type => "type",
+    }
+}
+
 pub(super) fn load_last_session() -> Option<LastSessionState> {
     let text = fs::read_to_string(last_session_path()).ok()?;
     let value = serde_json::from_str::<Value>(&text).ok()?;
@@ -535,6 +557,10 @@ fn parse_session_kit(value: &Value) -> Option<LastSessionKit> {
         .map(str::trim)
         .filter(|path| !path.is_empty())
         .map(PathBuf::from);
+    // Absent in sessions written before the browser view became per-kit, and
+    // in every version-1 and version-2 file. `None` means "use the default".
+    let browser_mode = browser_mode_from_str(value.get("browser_mode").and_then(Value::as_str));
+    let browser_sort = browser_sort_from_str(value.get("browser_sort").and_then(Value::as_str));
     let mut tags = Vec::new();
     for item in value.get("tags")?.as_array()? {
         let Some(key) = item
@@ -574,6 +600,8 @@ fn parse_session_kit(value: &Value) -> Option<LastSessionKit> {
         source_path,
         game,
         project_path,
+        browser_mode,
+        browser_sort,
         tags,
     })
 }
@@ -587,6 +615,14 @@ pub(super) fn save_last_session(session: &LastSessionState) -> Result<(), String
         fs::create_dir_all(parent)
             .map_err(|error| format!("Could not create session folder: {error}"))?;
     }
+    let text = serde_json::to_string_pretty(&session_value(session))
+        .map_err(|error| format!("Could not encode session: {error}"))?;
+    fs::write(path, text).map_err(|error| format!("Could not save session: {error}"))
+}
+
+/// Pure encode of a session document, split out from the file write so the
+/// round trip through [`parse_last_session`] is covered by tests.
+fn session_value(session: &LastSessionState) -> Value {
     let kits = session
         .kits
         .iter()
@@ -608,18 +644,18 @@ pub(super) fn save_last_session(session: &LastSessionState) -> Result<(), String
                     "kind": kit.source_kind.as_str(),
                     "path": kit.source_path.display().to_string(),
                     "game": kit.game,
+                    "project_path": kit.project_path.as_ref().map(|path| path.display().to_string()),
                 },
+                "browser_mode": kit.browser_mode.map(browser_mode_str),
+                "browser_sort": kit.browser_sort.map(browser_sort_str),
                 "tags": tags,
             })
         })
         .collect::<Vec<_>>();
-    let value = json!({
+    json!({
         "version": 3,
         "kits": kits,
-    });
-    let text = serde_json::to_string_pretty(&value)
-        .map_err(|error| format!("Could not encode session: {error}"))?;
-    fs::write(path, text).map_err(|error| format!("Could not save session: {error}"))
+    })
 }
 
 pub(super) fn clear_last_session() {
@@ -845,5 +881,73 @@ mod session_tests {
     fn unknown_versions_are_ignored() {
         let value = serde_json::json!({ "version": 99, "kits": [] });
         assert!(parse_last_session(&value).is_none());
+    }
+
+    fn kit(path: &str, mode: Option<BrowserMode>) -> LastSessionKit {
+        LastSessionKit {
+            source_kind: LastSessionSourceKind::LooseFolder,
+            source_path: PathBuf::from(path),
+            game: None,
+            project_path: None,
+            browser_mode: mode,
+            browser_sort: Some(BrowserSort::Name),
+            tags: vec![LastSessionTag {
+                key: format!("file:{path}/a.weapon"),
+                label: "a".to_owned(),
+                group_tag: 1,
+                path: None,
+            }],
+        }
+    }
+
+    /// Each workspace keeps its own browser view, so a session holding a kit
+    /// in Folders and one in Groups must bring both back as they were — not
+    /// collapse them onto one setting.
+    #[test]
+    fn each_kit_restores_its_own_browser_view() {
+        let session = LastSessionState {
+            kits: vec![
+                kit("/evolved", Some(BrowserMode::Folders)),
+                kit("/reach", Some(BrowserMode::Groups)),
+            ],
+        };
+        let restored = parse_last_session(&session_value(&session)).expect("round trip");
+        assert_eq!(restored.kits[0].browser_mode, Some(BrowserMode::Folders));
+        assert_eq!(restored.kits[1].browser_mode, Some(BrowserMode::Groups));
+        assert_eq!(restored.kits[0].browser_sort, Some(BrowserSort::Name));
+    }
+
+    /// Sessions written before the view was saved carry none, which has to
+    /// stay distinguishable from a saved Folders so the restore can fall back
+    /// to the user's default instead of overriding it.
+    #[test]
+    fn sessions_without_a_saved_view_restore_none() {
+        let value = serde_json::json!({
+            "version": 3,
+            "kits": [{
+                "source": { "kind": "loose_folder", "path": "/h3" },
+                "tags": [{ "key": "file:/h3/a.weapon", "label": "a", "group_tag": 1 }],
+            }],
+        });
+        let session = parse_last_session(&value).expect("session parses");
+        assert_eq!(session.kits[0].browser_mode, None);
+        assert_eq!(session.kits[0].browser_sort, None);
+    }
+
+    /// A kit whose session is its project has no tags to save, so dropping the
+    /// project path on write left nothing to restore it from.
+    #[test]
+    fn a_projects_path_survives_the_round_trip() {
+        let mut project_kit = kit("/evolved", None);
+        project_kit.project_path = Some(PathBuf::from("/evolved/work.baboon"));
+        project_kit.tags.clear();
+        let session = LastSessionState {
+            kits: vec![project_kit],
+        };
+        let restored = parse_last_session(&session_value(&session)).expect("round trip");
+        assert_eq!(
+            restored.kits[0].project_path,
+            Some(PathBuf::from("/evolved/work.baboon"))
+        );
     }
 }

--- a/src/app/shader/editing.rs
+++ b/src/app/shader/editing.rs
@@ -895,7 +895,11 @@ fn shader_bitmap_thumbnail(
     group_tag: u32,
     open_ref: &str,
 ) -> Option<egui::TextureHandle> {
-    let cache_id = egui::Id::new(("shader_bitmap_thumb", group_tag, open_ref));
+    // Keyed by the source too: the decode resolves `open_ref` against this
+    // kit's tags root, and a relative tag path means different bitmaps in
+    // different games. Without the root, whichever workspace decoded first won
+    // and the other showed its thumbnail.
+    let cache_id = egui::Id::new(("shader_bitmap_thumb", edit.tags_root, group_tag, open_ref));
     if let Some(cached) = ui.data(|d| d.get_temp::<Option<egui::TextureHandle>>(cache_id)) {
         return cached;
     }

--- a/src/app/state/browser.rs
+++ b/src/app/state/browser.rs
@@ -39,6 +39,11 @@ pub(in crate::app) enum BrowserAction {
 /// will be rewritten (preview) and an editable destination path; applying moves
 /// the file on disk and rewrites every referencing tag.
 pub(in crate::app) struct RenameTagState {
+    /// Workspace this was raised from. The confirm applies against the active
+    /// kit, and a modeless dialog outlives the frame that opened it, so the
+    /// user can focus another game in between; resolving this first is what
+    /// keeps the action on the workspace it was started in.
+    pub(in crate::app) kit: KitId,
     pub(in crate::app) key: String,
     /// Current display path (forward slashes, with extension) — shown read-only.
     pub(in crate::app) old_display: String,

--- a/src/app/state/browser.rs
+++ b/src/app/state/browser.rs
@@ -150,16 +150,18 @@ pub(in crate::app) struct ContentExplorer {
     pub(in crate::app) forward: Vec<TagEntry>,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Default, Debug)]
 pub(in crate::app) enum BrowserMode {
+    #[default]
     Folders,
     Groups,
 }
 
 /// Ordering of tags within a browser folder/group node.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Default, Debug)]
 pub(in crate::app) enum BrowserSort {
     /// Filesystem / natural order (as built).
+    #[default]
     Natural,
     /// By filename, A→Z.
     Name,

--- a/src/app/state/documents.rs
+++ b/src/app/state/documents.rs
@@ -125,6 +125,10 @@ pub(in crate::app) struct LastSessionKit {
     pub(in crate::app) source_path: PathBuf,
     pub(in crate::app) game: Option<String>,
     pub(in crate::app) project_path: Option<PathBuf>,
+    /// The browser view this kit was in, or `None` when the session predates
+    /// per-kit views — the restored kit then falls back to the saved default.
+    pub(in crate::app) browser_mode: Option<BrowserMode>,
+    pub(in crate::app) browser_sort: Option<BrowserSort>,
     pub(in crate::app) tags: Vec<LastSessionTag>,
 }
 
@@ -138,6 +142,10 @@ pub(in crate::app) struct RestoreKit {
     pub(in crate::app) source_kind: LastSessionSourceKind,
     pub(in crate::app) source_path: PathBuf,
     pub(in crate::app) project_path: Option<PathBuf>,
+    /// The browser view this kit was in, or `None` when the session predates
+    /// per-kit views — the restored kit then falls back to the saved default.
+    pub(in crate::app) browser_mode: Option<BrowserMode>,
+    pub(in crate::app) browser_sort: Option<BrowserSort>,
     pub(in crate::app) tags: Vec<LastSessionTag>,
 }
 
@@ -154,6 +162,10 @@ pub(in crate::app) struct LastOpenedWindowsKit {
     pub(in crate::app) game: Option<String>,
     pub(in crate::app) source_available: bool,
     pub(in crate::app) project_path: Option<PathBuf>,
+    /// The browser view this kit was in, or `None` when the session predates
+    /// per-kit views — the restored kit then falls back to the saved default.
+    pub(in crate::app) browser_mode: Option<BrowserMode>,
+    pub(in crate::app) browser_sort: Option<BrowserSort>,
     pub(in crate::app) entries: Vec<LastOpenedWindowEntry>,
 }
 
@@ -210,6 +222,8 @@ impl LastOpenedWindowsKit {
             game: saved.game,
             source_available,
             project_path: saved.project_path,
+            browser_mode: saved.browser_mode,
+            browser_sort: saved.browser_sort,
             entries,
         })
     }
@@ -253,6 +267,8 @@ impl LastOpenedWindowsPrompt {
                     source_kind: kit.source_kind,
                     source_path: kit.source_path.clone(),
                     project_path: kit.project_path.clone(),
+                    browser_mode: kit.browser_mode,
+                    browser_sort: kit.browser_sort,
                     tags,
                 })
             })

--- a/src/app/state/documents.rs
+++ b/src/app/state/documents.rs
@@ -287,6 +287,11 @@ impl LastOpenedWindowsPrompt {
 /// parsed imported `TagFile` (moved out on confirm) and the schema-comparison
 /// result against our shipped JSON. Not `Clone` — `TagFile` isn't cloneable.
 pub(in crate::app) struct ImportTagDialog {
+    /// Workspace this was raised from. The confirm applies against the active
+    /// kit, and a modeless dialog outlives the frame that opened it, so the
+    /// user can focus another game in between; resolving this first is what
+    /// keeps the action on the workspace it was started in.
+    pub(in crate::app) kit: KitId,
     pub(in crate::app) source_path: PathBuf,
     /// Pre-filled container folder (empty for the root); the leaf name is `name`.
     pub(in crate::app) folder_rel: String,
@@ -305,7 +310,23 @@ pub(in crate::app) struct ImportTagDialog {
 
 /// A parsed imported tag awaiting a "discard unsaved edits?" confirmation before
 /// it overwrites an already-open, dirty document at `target_key`.
+/// Pending "Save will overwrite the game's paks in place" confirmation.
+///
+/// Carries its workspace for the same reason [`PendingImport`] does: the
+/// confirm is modeless, and an in-place container overwrite is the last thing
+/// that should land on whichever game happens to be focused when it is
+/// answered.
+pub(in crate::app) struct OverwriteConfirm {
+    pub(in crate::app) kit: KitId,
+    pub(in crate::app) key: String,
+}
+
 pub(in crate::app) struct PendingImport {
+    /// Workspace this was raised from. The confirm applies against the active
+    /// kit, and a modeless dialog outlives the frame that opened it, so the
+    /// user can focus another game in between; resolving this first is what
+    /// keeps the action on the workspace it was started in.
+    pub(in crate::app) kit: KitId,
     pub(in crate::app) tag: TagFile,
     pub(in crate::app) target_key: String,
 }
@@ -320,6 +341,9 @@ pub(in crate::app) struct NewTagGroup {
 
 #[derive(Clone, Debug)]
 pub(in crate::app) struct NewTagDialog {
+    /// Workspace the dialog was opened for. `None` before it is first
+    /// opened, since this dialog is always resident rather than optional.
+    pub(in crate::app) kit: Option<KitId>,
     pub(in crate::app) game: String,
     pub(in crate::app) rel_path: String,
     pub(in crate::app) output_path: Option<PathBuf>,
@@ -331,6 +355,7 @@ pub(in crate::app) struct NewTagDialog {
 impl Default for NewTagDialog {
     fn default() -> Self {
         Self {
+            kit: None,
             game: "halo3_mcc".to_owned(),
             rel_path: String::new(),
             output_path: None,

--- a/src/app/state/editing.rs
+++ b/src/app/state/editing.rs
@@ -212,6 +212,11 @@ pub(in crate::app) struct BlockClipboard {
 /// A pending destructive block op awaiting user confirmation. Lives on the
 /// app (persists across frames) and is shown as a modal.
 pub(in crate::app) struct BlockConfirm {
+    /// Workspace whose pane raised this, stamped by that pane after the
+    /// field render that created it — the field renderers are shared by
+    /// every pane and have no kit of their own. `None` only inside that one
+    /// render; the apply drops a confirm that somehow never got stamped.
+    pub(in crate::app) kit: Option<KitId>,
     pub(in crate::app) tag_key: String,
     pub(in crate::app) path: String,
     pub(in crate::app) kind: BlockOpKind,
@@ -359,6 +364,11 @@ pub(in crate::app) struct TsvPasteRequest {
 /// The open TSV-import window: the user pastes tab-separated rows and applies
 /// them to the target block's existing elements (per-cell, via `apply_field_edit`).
 pub(in crate::app) struct TsvPasteState {
+    /// Workspace this was raised from. The confirm applies against the active
+    /// kit, and a modeless dialog outlives the frame that opened it, so the
+    /// user can focus another game in between; resolving this first is what
+    /// keeps the action on the workspace it was started in.
+    pub(in crate::app) kit: KitId,
     pub(in crate::app) tag_key: String,
     pub(in crate::app) block_path: String,
     pub(in crate::app) block_label: String,

--- a/src/app/state/prefs.rs
+++ b/src/app/state/prefs.rs
@@ -184,8 +184,8 @@ pub(in crate::app) struct GuiPrefs {
 impl Default for GuiPrefs {
     fn default() -> Self {
         Self {
-            browser_mode: BrowserMode::Folders,
-            browser_sort: BrowserSort::Natural,
+            browser_mode: BrowserMode::default(),
+            browser_sort: BrowserSort::default(),
             show_browser_prefixes: false,
             folders_before_tags: false,
             double_click_to_open_tags: false,

--- a/src/app/state/worker.rs
+++ b/src/app/state/worker.rs
@@ -34,7 +34,13 @@ pub(in crate::app) enum WorkerMessage {
         result: Result<(), String>,
     },
     FolderRefactorProgress(FolderRefactorProgress),
-    FolderRefactorFinished(Result<FolderRefactorFinished, String>),
+    /// Stamped because the finish rewrites its kit's whole browser tree and
+    /// drops that kit's open documents: unrouted, a refactor that outlived a
+    /// workspace switch applied all of that to whichever kit was focused.
+    FolderRefactorFinished {
+        stamp: KitStamp,
+        result: Result<FolderRefactorFinished, String>,
+    },
     FolderConversionProgress(FolderConversionProgress),
     FolderConversionFinished(Result<FolderConversionReport, String>),
     // Full recursive entry scan finished for a loose-folder source.

--- a/src/app/ui.rs
+++ b/src/app/ui.rs
@@ -298,25 +298,36 @@ fn tint_toward(base: Color32, accent: Color32, t: f32) -> Color32 {
 
 
 impl Baboon {
-    pub(super) fn draw_scenario_launcher_buttons(&mut self, ui: &mut Ui, entry: &TagEntry) {
+    /// `kit_index` is the workspace whose pane is drawing this. Readiness is
+    /// resolved against that workspace's editing kit rather than the focused
+    /// one, and a launch makes it active first: it saves the tag and starts an
+    /// external editor, neither of which should follow the wrong game.
+    pub(super) fn draw_scenario_launcher_buttons(
+        &mut self,
+        ui: &mut Ui,
+        kit_index: usize,
+        entry: &TagEntry,
+    ) {
         if entry.group_tag != u32::from_be_bytes(*b"scnr") {
             return;
         }
         let key = entry.key.clone();
         ui.horizontal(|ui| {
             ui.label(RichText::new("Open scenario in:").color(subtle_dark()));
-            let sapien_ready = self.can_launch_scenario_in_sapien(entry);
+            let sapien_ready = self.can_launch_scenario_in_sapien(kit_index, entry);
             if launcher_button(ui, self.sapien_icon.as_ref(), "S", sapien_ready)
                 .on_hover_text("Save if needed, then launch this scenario in Sapien")
                 .clicked()
             {
+                self.active = kit_index;
                 self.launch_scenario_in_sapien(&key);
             }
-            let tag_test_ready = self.can_launch_scenario_in_tag_test(entry);
+            let tag_test_ready = self.can_launch_scenario_in_tag_test(kit_index, entry);
             if launcher_button(ui, self.tag_test_icon.as_ref(), "T", tag_test_ready)
                 .on_hover_text("Save if needed, then launch this scenario in tag_test")
                 .clicked()
             {
+                self.active = kit_index;
                 self.launch_scenario_in_tag_test(&key);
             }
         });

--- a/src/app/ui/browser_panel.rs
+++ b/src/app/ui/browser_panel.rs
@@ -103,20 +103,20 @@ impl Baboon {
                             button_icon_image(ui, ButtonIcon::FolderOpen, text_dark(), 16.0),
                             "Folders",
                         )
-                        .selected(self.browser_mode == BrowserMode::Folders),
+                        .selected(kit.browser_mode == BrowserMode::Folders),
                     );
                     if folders.clicked() {
-                        self.browser_mode = BrowserMode::Folders;
+                        kit.browser_mode = BrowserMode::Folders;
                     }
                     let groups = ui.add(
                         egui::Button::image_and_text(
                             button_icon_image(ui, ButtonIcon::Group, text_dark(), 16.0),
                             "Groups",
                         )
-                        .selected(self.browser_mode == BrowserMode::Groups),
+                        .selected(kit.browser_mode == BrowserMode::Groups),
                     );
                     if groups.clicked() {
-                        self.browser_mode = BrowserMode::Groups;
+                        kit.browser_mode = BrowserMode::Groups;
                     }
                     groups
                 };
@@ -132,10 +132,10 @@ impl Baboon {
                     |ui| {
                         for option in BrowserSort::ALL {
                             if ui
-                                .selectable_label(self.browser_sort == option, option.label())
+                                .selectable_label(kit.browser_sort == option, option.label())
                                 .clicked()
                             {
-                                self.browser_sort = option;
+                                kit.browser_sort = option;
                                 ui.close_menu();
                             }
                         }
@@ -171,7 +171,7 @@ impl Baboon {
             ui.add_space(4.0);
             let selected = kit.selected_key.clone();
             let filter = kit.filter.trim().to_owned();
-            let mode = self.browser_mode;
+            let mode = kit.browser_mode;
             let show_prefixes = self.show_browser_prefixes;
             let folders_before_tags = self.folders_before_tags;
             let double_click_to_open = self.double_click_to_open_tags;
@@ -196,7 +196,7 @@ impl Baboon {
                 key: request.key.as_str(),
                 remaining: request.ancestors.as_slice(),
             });
-            let sort = self.browser_sort;
+            let sort = kit.browser_sort;
             let action = if !filter.is_empty() {
                 // Active search: render a *pruned* tree containing only
                 // the matching tags, with folders collapsed so the user

--- a/src/app/ui/browser_panel.rs
+++ b/src/app/ui/browser_panel.rs
@@ -367,6 +367,16 @@ impl Baboon {
             if let Some(status) = status_update {
                 self.status = status;
             }
+            // Browser actions and the scan below all resolve against the active
+            // kit, and this browser is drawn inside the workspace-tree walk,
+            // where `active` is still whatever it was when the frame began.
+            // Press-activation usually beats the click by a frame, but a press
+            // and its release land in the same frame whenever one runs long --
+            // which is exactly what loading a large tag or indexing does. This
+            // browser's own kit is the right target either way.
+            if action.is_some() || need_scan {
+                self.active = kit_index;
+            }
             if let Some(action) = action {
                 self.handle_browser_action(action, ctx.clone());
             }

--- a/src/app/ui/dialogs.rs
+++ b/src/app/ui/dialogs.rs
@@ -449,7 +449,11 @@ impl Baboon {
     /// overwrites the shipped pak files in place, so we always confirm and point
     /// the user at Export Mod as the non-destructive alternative.
     pub(super) fn draw_overwrite_confirm_window(&mut self, ctx: &egui::Context) {
-        let Some(key) = self.overwrite_confirm.clone() else {
+        let Some((kit, key)) = self
+            .overwrite_confirm
+            .as_ref()
+            .map(|confirm| (confirm.kit, confirm.key.clone()))
+        else {
             return;
         };
         let mut open = true;
@@ -513,10 +517,18 @@ impl Baboon {
                 self.confirm_container_overwrite = false;
                 self.persist_prefs_if_changed();
             }
-            self.overwrite_current_tag_in_place(&key);
+            // Both actions write through the active kit's source. Return to the
+            // workspace this was raised from, and drop it if that workspace has
+            // been closed — overwriting the game's paks in place is the last
+            // thing that should land on whichever game is focused by now.
+            if self.focus_navigation_kit(kit) {
+                self.overwrite_current_tag_in_place(&key);
+            }
         } else if do_export {
             self.overwrite_confirm = None;
-            self.export_mod();
+            if self.focus_navigation_kit(kit) {
+                self.export_mod();
+            }
         }
     }
 

--- a/src/app/ui/kit_tiles.rs
+++ b/src/app/ui/kit_tiles.rs
@@ -50,7 +50,7 @@ impl egui_tiles::Behavior<KitId> for KitPaneBehavior<'_> {
         // An unloaded workspace has no tags to browse or edit, so it offers
         // ways to open one instead of an empty browser and an empty editor.
         if self.app.kits[kit_index].is_empty_workspace() {
-            self.app.draw_welcome_screen(ui, &self.ctx);
+            self.app.draw_welcome_screen(ui, &self.ctx, kit_index);
             return egui_tiles::UiResponse::None;
         }
         // Each workspace carries its own browser, so two games side by side can
@@ -216,7 +216,7 @@ impl Baboon {
         // zero-height tab bar still leaves the "+" and the bar's own painting
         // behind, so the tree is skipped outright.
         if self.kits.len() == 1 && self.kits[0].is_empty_workspace() {
-            self.draw_welcome_screen(ui, ctx);
+            self.draw_welcome_screen(ui, ctx, 0);
             return;
         }
         let placeholder = egui_tiles::Tree::empty(egui::Id::new("kit_tree_placeholder"));

--- a/src/app/ui/shell.rs
+++ b/src/app/ui/shell.rs
@@ -363,31 +363,32 @@ impl Baboon {
                         }
                     });
                     ui.menu_button("View", |ui| {
+                        // The browser view belongs to a workspace, so this
+                        // menu shows and sets the focused kit's — matching the
+                        // Folders/Groups buttons in that kit's own toolbar.
+                        let kit = &mut self.kits[self.active];
                         if ui
-                            .selectable_label(self.browser_mode == BrowserMode::Folders, "Folders")
+                            .selectable_label(kit.browser_mode == BrowserMode::Folders, "Folders")
                             .clicked()
                         {
-                            self.browser_mode = BrowserMode::Folders;
+                            kit.browser_mode = BrowserMode::Folders;
                             ui.close_menu();
                         }
                         if ui
-                            .selectable_label(
-                                self.browser_mode == BrowserMode::Groups,
-                                "Tag Groups",
-                            )
+                            .selectable_label(kit.browser_mode == BrowserMode::Groups, "Tag Groups")
                             .clicked()
                         {
-                            self.browser_mode = BrowserMode::Groups;
+                            kit.browser_mode = BrowserMode::Groups;
                             ui.close_menu();
                         }
                         ui.separator();
-                        ui.menu_button(format!("Sort by: {}", self.browser_sort.label()), |ui| {
+                        ui.menu_button(format!("Sort by: {}", kit.browser_sort.label()), |ui| {
                             for option in BrowserSort::ALL {
                                 if ui
-                                    .selectable_label(self.browser_sort == option, option.label())
+                                    .selectable_label(kit.browser_sort == option, option.label())
                                     .clicked()
                                 {
-                                    self.browser_sort = option;
+                                    kit.browser_sort = option;
                                     ui.close_menu();
                                 }
                             }

--- a/src/app/ui/tag_pane.rs
+++ b/src/app/ui/tag_pane.rs
@@ -29,7 +29,7 @@ impl Baboon {
     ) {
         let key = entry.key.clone();
         draw_entry_header(ui, entry, &self.kits[kit_index].names);
-        self.draw_scenario_launcher_buttons(ui, entry);
+        self.draw_scenario_launcher_buttons(ui, kit_index, entry);
         if show_keyword_bar {
             self.draw_keyword_bar(ui, kit_index, &key);
         }

--- a/src/app/ui/tag_pane.rs
+++ b/src/app/ui/tag_pane.rs
@@ -246,6 +246,11 @@ impl Baboon {
         if !picker_was_open && self.tag_reference_picker.is_some() {
             self.tag_reference_picker_kit = Some(kit_id);
         }
+        // And a block confirmation, raised the same way. Stamping only an
+        // unstamped one leaves a confirmation another pane raised alone.
+        if let Some(confirm) = self.block_confirm.as_mut() {
+            confirm.kit.get_or_insert(kit_id);
+        }
         // Element(s) were copied: stash them on the clipboard.
         if let Some(clip) = block_clip_request {
             self.status = format!(
@@ -258,6 +263,7 @@ impl Baboon {
         // "Paste TSV…" was chosen: open the import window.
         if let Some(req) = tsv_paste_request {
             self.tsv_paste = Some(TsvPasteState {
+                kit: kit_id,
                 tag_key: key.clone(),
                 block_path: req.block_path,
                 block_label: req.block_label,

--- a/src/app/ui/tag_pane.rs
+++ b/src/app/ui/tag_pane.rs
@@ -284,6 +284,11 @@ impl Baboon {
         kit.parsed_tags.insert(key, doc);
 
         if let Some(key) = bitmap_reimport {
+            // Resolves its source and entry against the active kit, and runs an
+            // external tool that rewrites the bitmap on disk. This pane's kit is
+            // the one being asked, so make it active first rather than trusting
+            // press-activation to have already landed this frame.
+            self.active = kit_index;
             self.begin_reimport_bitmap(key, ctx.clone());
         }
     }

--- a/src/app/ui/tag_pane.rs
+++ b/src/app/ui/tag_pane.rs
@@ -141,7 +141,15 @@ impl Baboon {
             block_clipboard: self.block_clipboard.as_ref(),
             block_clip_request: &mut block_clip_request,
             field_filter: field_filter.as_ref(),
-            field_nav: self.field_nav.as_ref(),
+            // Only the pane being navigated to sees the request. The scroll
+            // gate downstream matches on the field path alone, so an unfiltered
+            // nav scrolled every pane whose tag happened to have a field at the
+            // same path — which, between two tags of the same group, is most of
+            // them. Splitting a tag view is what exposed this.
+            field_nav: self
+                .field_nav
+                .as_ref()
+                .filter(|nav| nav.kit == kit_id && nav.tag_key == key),
         };
 
         if is_bitmap_tag(entry) {

--- a/src/app/ui/tag_tiles.rs
+++ b/src/app/ui/tag_tiles.rs
@@ -119,7 +119,9 @@ impl egui_tiles::Behavior<String> for TagPaneBehavior<'_> {
         false
     }
 
-    /// Restores the tab context menu the hand-rolled tab rack used to carry.
+    /// Restores the tab context menu and middle-click-to-close the hand-rolled
+    /// tab rack used to carry. Both hang off the tab's own response, which is
+    /// why they live here rather than in `tab_ui`.
     fn on_tab_button(
         &mut self,
         tiles: &egui_tiles::Tiles<String>,
@@ -130,6 +132,12 @@ impl egui_tiles::Behavior<String> for TagPaneBehavior<'_> {
             return button_response;
         };
         let key = key.clone();
+        // Queued exactly as the close button queues it, so a middle-click on a
+        // tab with unsaved edits still raises the prompt instead of discarding
+        // them. `tiles` is shared here, so the removal happens after the walk.
+        if button_response.middle_clicked() {
+            self.close_requests.push(key.clone());
+        }
         button_response.context_menu(|ui| {
             if ui.button("Reveal in browser").clicked() {
                 self.reveal = Some(key.clone());
@@ -332,6 +340,19 @@ impl Baboon {
         self.kits[kit_index].sync_open_tabs();
         if let Some(key) = focused {
             self.kits[kit_index].selected_key = Some(key);
+        }
+        // Everything below addresses the *active* kit: the close prompt and the
+        // save paths under it resolve documents there, and `reveal_in_browser`
+        // scrolls that kit's browser. These all answer a click on a tab in
+        // *this* pane, so the pane's kit has to be active before they run.
+        //
+        // Press-activation sets the same thing, but only after the whole kit
+        // tree has been walked — a frame too late for a close that executes
+        // immediately, which is what a Campaign Evolved kit's checkpointed
+        // close does. Without this, closing a tab in an unfocused pane of a
+        // split closes it in the other game.
+        if reveal.is_some() || close_all || close_all_but.is_some() || !close_requests.is_empty() {
+            self.active = kit_index;
         }
         if let Some(key) = reveal {
             self.reveal_in_browser(&key);

--- a/src/app/ui/welcome.rs
+++ b/src/app/ui/welcome.rs
@@ -26,7 +26,14 @@ impl Baboon {
     /// The previous empty state was an empty tag browser beside "No tag
     /// selected" — two panels, neither of which could do anything about it.
     /// Everything here is a way to open something.
-    pub(in crate::app) fn draw_welcome_screen(&mut self, ui: &mut Ui, ctx: &egui::Context) {
+    /// `kit_index` is the empty workspace this screen is filling. Its actions
+    /// load into the active kit, and this pane's kit is the one being asked.
+    pub(in crate::app) fn draw_welcome_screen(
+        &mut self,
+        ui: &mut Ui,
+        ctx: &egui::Context,
+        kit_index: usize,
+    ) {
         let mut action = None;
         let recents = self.recent_folders.clone();
         let configured: Vec<EditingKitShortcut> = EDITING_KIT_SHORTCUTS
@@ -165,6 +172,13 @@ impl Baboon {
                 });
             });
 
+        // `open_kit_for` reuses the active kit only when it is still an empty
+        // workspace; with another game active it would add a third kit and
+        // leave this pane empty. Press-activation normally beats the click by a
+        // frame, but not when a frame runs long.
+        if action.is_some() {
+            self.active = kit_index;
+        }
         match action {
             Some(WelcomeAction::LoadFolder) => self.begin_load_folder(ctx.clone()),
             Some(WelcomeAction::LoadTag) => self.begin_load_single(ctx.clone()),

--- a/src/source/ce_audio.rs
+++ b/src/source/ce_audio.rs
@@ -20,7 +20,7 @@
 
 use std::collections::{BTreeSet, VecDeque};
 use std::io::Cursor;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, anyhow};
 use blam_tags::iostore::container_header::EIoContainerHeaderVersion;
@@ -240,21 +240,26 @@ pub fn resolve_sound_binding(
 /// edited without ever touching audio.
 #[derive(Default)]
 pub struct CeMediaStore {
-    paks: Option<PakSet>,
+    /// The open set and the `Paks` directory it was opened from. The root is
+    /// held because this store is shared by every workspace: without it, a
+    /// second Campaign Evolved install reused the first one's containers and
+    /// played its audio, or reported the media missing.
+    paks: Option<(PathBuf, PakSet)>,
 }
 
 impl CeMediaStore {
-    /// Open the pak set rooted at the source's `Paks` directory, if not already.
+    /// Open the pak set rooted at the source's `Paks` directory, if the set
+    /// already open is not that one.
     fn paks(&mut self, paks_root: &Path) -> Result<&mut PakSet> {
-        if self.paks.is_none() {
+        if self.paks.as_ref().is_none_or(|(root, _)| root != paks_root) {
             let set = PakSet::open_dir(paks_root)
                 .with_context(|| format!("opening pak set at {}", paks_root.display()))?;
             if set.is_empty() {
                 return Err(anyhow!("no readable .pak containers in {}", paks_root.display()));
             }
-            self.paks = Some(set);
+            self.paks = Some((paks_root.to_path_buf(), set));
         }
-        Ok(self.paks.as_mut().expect("just populated"))
+        Ok(&mut self.paks.as_mut().expect("just populated").1)
     }
 
     /// Fetch and decode one media entry to PCM.


### PR DESCRIPTION
Two reports from cryo, and what came out of chasing them.

## The reports

**Middle-click closes a tag tab again.** The hand-rolled tab rack carried the gesture; the `egui_tiles` tab that replaced it in v0.2.0 did not, so it silently stopped working. It queues the same close request the `×` queues, so a middle click on a tag with unsaved edits still raises the prompt. (`clicked()` is primary-only in egui, so the `×` does not also fire on the same press.)

**Folders/Groups is per workspace.** It was one application-wide setting, so changing it in one workspace changed it everywhere — cryo wants Campaign Evolved in Folders while Reach is in Groups. `browser_mode` and `browser_sort` move onto `Kit`; the saved preference becomes the view a *new* workspace opens in, and is captured back from the focused kit, so a single workspace behaves exactly as before. The view is saved per kit in the session too, or two workspaces would come back sharing one setting again.

## What the sweep found

Chasing the first report led into the tab-action path, which led to a full sweep for state that belongs to one workspace but is reachable from another — every field on `Baboon`, and every `WorkerMessage` variant.

**A finished folder move/rename landed on the wrong workspace.** The finish handler wrote into whichever kit was active when the worker returned: it replaced that kit's browser tree with the other one's entries, dropped its open documents, and cleared its **unsaved edit buffers**, while the workspace the refactor belonged to was left stale. It was the only source-dependent worker result not carrying a `KitStamp`. Open tags were also remapped through `open_tabs`, which is re-derived from the tree every frame, so the remap was overwritten before anything read it.

**Actions raised inside a pane were dispatched against the previously-focused workspace.** The browser, the welcome screen, the bitmap reimport button and the scenario launcher all draw inside the workspace-tree walk, but `active` is only updated *after* that walk, from the press recorded during it. That holds until a frame runs long — loading a large tag, indexing a folder — at which point the press and its release arrive together, and the action targets whatever was focused when the frame began. Clicking a tag in a background pane's browser then opens it into the wrong game.

**Seven modeless dialogs** captured a target and applied it against `active` at confirm time. New Tag and Import check no tag key at all, so opening New Tag against one game, clicking into another and pressing Create wrote the tag into the second game. The others are guarded by a key lookup, but that guard assumes key uniqueness and container/monolithic keys are source-relative — two Campaign Evolved installs share a key space. Each now carries the `KitId` it was raised from.

**Four silent cross-workspace leaks.** Field navigation was handed to every pane, and the scroll gate matches on field path alone (only the glow checks the tag key), so a jump scrolled any pane whose tag had a field at the same path. `CeMediaStore` opened its pak set once and then ignored the `paks_root` it was passed, so a second Campaign Evolved install read its Wwise media out of the first one's containers. Shader bitmap thumbnails were cached under `(group_tag, ref_path)` but decoded against the kit's own tags root. Favorites remapping resolved the active kit's root while running from a background refactor.

**`focus_navigation_kit` didn't front the workspace tab**, so routed work landed correctly somewhere the user could not see.

Also fixes a session round trip that wrote no `project_path` though it read one, so a Campaign Evolved workspace whose session *was* its project came back without it.

## Checked and clean

Sound bank and Wwise caches are invalidated on root change. `handle_source_loaded` deliberately makes its kit active up front, so concurrent session restores are safe. Model previews carry no active-scoped reads. The bundled `ce_usmap` is install-independent. No positional kit index is stored across frames. Browser folder-collapse ids are salted by the `push_id` wrapper, and egui texture names are debug labels rather than keys. The `editor`, `foundation`, `shader`, `browser` and `material` modules contain no `Baboon` methods at all, which is what makes the in-pane class closed rather than sampled.

Two things left deliberately. You can still drag a tag from one game's browser onto another game's reference cell — the drop validates the group tag but not the source, and it is an explicit, visible gesture. And the global index/scan flags still get cleared by any workspace's load; every result is stamped so work lands correctly, but you can get duplicate concurrent index builds and a shared progress bar. That is the known gap from the v0.2.0 notes, now verified rather than assumed.

## Testing

`cargo test`: 325 passed, 0 failed. The remap fix has a test that asserts through the layout tree, so it fails if a remap only touches the cached list again.

These are UI-timing paths that can't be driven from a test, so the routing needs a human. The sharp cases:

- Click a tag in a background pane's browser while something large is loading.
- Open New Tag or Rename in one workspace, click into another, then confirm.
- Start a folder move, switch workspaces, and let it finish.
- Middle-click a tag tab, and middle-click one with unsaved edits.
- Set Folders in one workspace and Groups in another, then quit and reopen.
