### PR TITLE
Post-0.2.0 bug report fixes: block dropdowns, discarding edits, project persistence, font fallback

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -152,6 +152,8 @@ pub struct Baboon {
     /// saved default they are seeded from.
     default_browser_mode: BrowserMode,
     default_browser_sort: BrowserSort,
+    /// How nested groups, structs and blocks in the tag editor start out.
+    nested_default: NestedDefault,
     show_browser_prefixes: bool,
     folders_before_tags: bool,
     double_click_to_open_tags: bool,
@@ -356,6 +358,7 @@ impl Baboon {
             find: FindDialogState::default(),
             default_browser_mode: prefs.browser_mode,
             default_browser_sort: prefs.browser_sort,
+            nested_default: prefs.nested_default,
             show_browser_prefixes: prefs.show_browser_prefixes,
             folders_before_tags: prefs.folders_before_tags,
             double_click_to_open_tags: prefs.double_click_to_open_tags,

--- a/src/app.rs
+++ b/src/app.rs
@@ -179,6 +179,9 @@ pub struct Baboon {
     import_discard_confirm: Option<PendingImport>,
     /// Pending in-place overwrite confirmation (the tag key) for a container tag.
     overwrite_confirm: Option<String>,
+    /// Pending confirmation for the Campaign Evolved "clear modifications"
+    /// toolbar action, which is irreversible.
+    clear_stash_confirm: Option<ClearStashConfirm>,
     about_open: bool,
     help_panel_tab: HelpPanelTab,
     help_docs: HelpDocsState,
@@ -368,6 +371,7 @@ impl Baboon {
             import_tag_dialog: None,
             import_discard_confirm: None,
             overwrite_confirm: None,
+            clear_stash_confirm: None,
             about_open: false,
             help_panel_tab: HelpPanelTab::About,
             help_docs: HelpDocsState::load(),

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -8,3 +8,69 @@ mod tree;
 
 pub(super) use filter::*;
 pub(super) use tree::*;
+
+/// Which tags in a workspace carry edits that are not written into the game.
+///
+/// Resolved once per change rather than per frame: mapping a tag key to its
+/// entry is a linear scan of the source, so doing it for every modified tag
+/// every frame would cost far more than the handful of lookups it represents.
+#[derive(Default)]
+pub(in crate::app) struct ModifiedTags {
+    keys: HashSet<String>,
+}
+
+impl ModifiedTags {
+    pub(in crate::app) fn contains_key(&self, key: &str) -> bool {
+        self.keys.contains(key)
+    }
+
+    pub(in crate::app) fn insert(&mut self, entry: &TagEntry) {
+        self.keys.insert(entry.key.clone());
+    }
+
+    /// Whether anything under this folder is modified.
+    ///
+    /// Walks the subtree and stops at the first hit, so a folder that contains
+    /// an edit answers immediately; only clean folders pay for their whole
+    /// subtree, and an empty set skips the walk entirely.
+    pub(in crate::app) fn subtree_has_modified(
+        &self,
+        node: &TagTreeNode,
+        entries: &[TagEntry],
+    ) -> bool {
+        if self.keys.is_empty() {
+            return false;
+        }
+        node.entries.iter().any(|&index| {
+            entries
+                .get(index)
+                .is_some_and(|entry| self.keys.contains(&entry.key))
+        }) || node
+            .children
+            .iter()
+            .any(|child| self.subtree_has_modified(child, entries))
+    }
+}
+
+/// egui-memory slot holding the browser's modified set for the kit currently
+/// being drawn. Kept here rather than threaded through the tree's dozen
+/// drawing functions: the browsers draw one after another, so the value in
+/// memory while a kit's tree is drawn is that kit's own — the same mechanism
+/// the Find highlighter uses to reach individual field cells.
+pub(in crate::app) fn modified_tags_id() -> egui::Id {
+    egui::Id::new("browser_modified_tags")
+}
+
+pub(in crate::app) fn set_browser_modified_tags(ui: &Ui, modified: std::sync::Arc<ModifiedTags>) {
+    ui.data_mut(|data| data.insert_temp(modified_tags_id(), modified));
+}
+
+pub(in crate::app) fn browser_modified_tags(ui: &Ui) -> Option<std::sync::Arc<ModifiedTags>> {
+    ui.data(|data| data.get_temp::<std::sync::Arc<ModifiedTags>>(modified_tags_id()))
+}
+
+/// Colour for a tag or folder holding edits that are not written into the game.
+/// The same goldenrod the workspace tab is tinted with.
+pub(in crate::app) fn modified_text() -> Color32 {
+    Color32::from_rgb(214, 168, 46)
+}

--- a/src/app/browser/tree.rs
+++ b/src/app/browser/tree.rs
@@ -360,7 +360,9 @@ pub(in crate::app) fn draw_tree_node_lazy(
     } else {
         node.label.clone()
     };
-    let response = egui::CollapsingHeader::new(RichText::new(folder_label).color(text_dark()))
+    let response = egui::CollapsingHeader::new(
+        RichText::new(folder_label).color(folder_label_color(ui, node, entries)),
+    )
         .icon(folder_arrow_icon)
         .default_open(!filter.is_empty())
         .open(on_path.then_some(true))
@@ -648,6 +650,7 @@ pub(in crate::app) fn draw_tree_node(
         show_group_tree_header(
             ui,
             &node.label,
+            folder_label_color(ui, node, entries),
             show_prefixes,
             !filter.is_empty(),
             on_path,
@@ -659,7 +662,9 @@ pub(in crate::app) fn draw_tree_node(
         } else {
             node.label.clone()
         };
-        egui::CollapsingHeader::new(RichText::new(folder_label).color(text_dark()))
+        egui::CollapsingHeader::new(
+            RichText::new(folder_label).color(folder_label_color(ui, node, entries)),
+        )
             .icon(folder_arrow_icon)
             .default_open(!filter.is_empty())
             .open(on_path.then_some(true))
@@ -740,6 +745,16 @@ pub(in crate::app) fn draw_tree_node(
     clicked
 }
 
+/// Colour for a folder row: marked when anything beneath it carries edits that
+/// are not written into the game, so the workspace can be scanned top-down for
+/// where the modifications actually are.
+fn folder_label_color(ui: &Ui, node: &TagTreeNode, entries: &[TagEntry]) -> Color32 {
+    match browser_modified_tags(ui) {
+        Some(modified) if modified.subtree_has_modified(node, entries) => modified_text(),
+        _ => text_dark(),
+    }
+}
+
 fn group_tree_label_parts(label: &str) -> (&str, &str) {
     label
         .rsplit_once(' ')
@@ -749,6 +764,7 @@ fn group_tree_label_parts(label: &str) -> (&str, &str) {
 fn show_group_tree_header<R>(
     ui: &mut Ui,
     label: &str,
+    label_color: Color32,
     show_prefixes: bool,
     default_open: bool,
     force_open: bool,
@@ -776,7 +792,7 @@ fn show_group_tree_header<R>(
             name.to_owned()
         };
         if !display_name.is_empty() {
-            content = content.union(ui.label(RichText::new(display_name).color(text_dark())));
+            content = content.union(ui.label(RichText::new(display_name).color(label_color)));
         }
         let badge = Frame::none()
             .fill(Color32::from_rgb(48, 58, 66))
@@ -1011,7 +1027,12 @@ pub(in crate::app) fn draw_entry(
             Align2::LEFT_CENTER,
             label,
             FontId::proportional(12.5),
-            text_dark(),
+            // Marked when the tag has unsaved edits, or bytes stashed in the
+            // workspace's project from an earlier session.
+            match browser_modified_tags(ui) {
+                Some(modified) if modified.contains_key(&entry.key) => modified_text(),
+                _ => text_dark(),
+            },
         );
     }
     if response.dragged()

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -4820,6 +4820,7 @@ impl Baboon {
             // so a single-workspace session remembers its choice as before.
             browser_mode: self.kits[self.active].browser_mode,
             browser_sort: self.kits[self.active].browser_sort,
+            nested_default: self.nested_default,
             show_browser_prefixes: self.show_browser_prefixes,
             folders_before_tags: self.folders_before_tags,
             double_click_to_open_tags: self.double_click_to_open_tags,

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -3249,11 +3249,17 @@ impl Baboon {
                 let sidecar = output.with_extension("baboon");
                 match save_campaign_project(&sidecar, &snapshot) {
                     Ok(()) => {
-                        self.kits[exporting].campaign_project = Some(ActiveCampaignProject::from_snapshot(
-                            sidecar,
-                            &snapshot,
-                            0.0,
-                        ));
+                        // The sidecar is an export artifact: a copy that travels
+                        // with the mod so it can be resumed or shared. The
+                        // workspace keeps its own project.
+                        //
+                        // Repointing it here sent every later autosave to a file
+                        // beside the exported mod, wherever the user put that,
+                        // and the workspace's own recovery file stopped being
+                        // updated. The next launch then adopted the stale
+                        // recovery file and every tag opened as the game ships
+                        // it -- the edits read as never having been saved.
+                        let _ = self.checkpoint_campaign_project(exporting, 0.0);
                         self.status = if skipped == 0 {
                             format!(
                                 "Exported {count} tag(s) → {stem}.utoc/.ucas/.pak/.baboon \

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -1782,12 +1782,21 @@ impl Baboon {
     }
 
     pub(super) fn entry_for_key(&self, key: &str) -> Option<&TagEntry> {
-        let source = self.source()?;
+        self.entry_for_key_in(self.active, key)
+    }
+
+    /// Resolve a tag key against a specific kit. Anything that runs for a kit
+    /// other than the focused one has to use this: a key only means something
+    /// inside its own source, so resolving it against the active kit silently
+    /// finds nothing and the caller skips the tag.
+    pub(super) fn entry_for_key_in(&self, kit: usize, key: &str) -> Option<&TagEntry> {
+        let kit = self.kits.get(kit)?;
+        let source = kit.source.as_ref()?;
         source
             .entries
             .iter()
             .chain(source.all_entries.iter())
-            .chain(self.kits[self.active].active_favorite_entries.iter())
+            .chain(kit.active_favorite_entries.iter())
             .find(|entry| entry.key == key)
     }
 

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -1731,6 +1731,75 @@ impl Baboon {
         self.terminal.refocus_input = true;
     }
 
+    /// Throw away a tag's unsaved edits and put it back the way its source has
+    /// it: drop the parsed document and everything derived from it, forget any
+    /// stashed Campaign Evolved overlay, then reload the tag if it is open.
+    ///
+    /// Forgetting the overlay is the load-bearing half for a container source.
+    /// The project autosaves every dirty tag within a second of the edit, so
+    /// clearing the dirty flag alone leaves the edited bytes stashed and
+    /// reopening the tag restores them — the edit would be unremovable.
+    pub(super) fn discard_tag_changes(&mut self, kit: usize, key: &str, ctx: &egui::Context) {
+        // Reloading below goes through the active-kit path, and discarding is a
+        // user action on this kit either way.
+        self.active = kit;
+        let was_dirty = self.kits[kit]
+            .parsed_tags
+            .get(key)
+            .is_some_and(|document| document.dirty);
+        let had_overlay = self.forget_campaign_overlay(kit, key);
+        if !was_dirty && !had_overlay {
+            self.status = "That tag has no unsaved changes".to_owned();
+            return;
+        }
+        let label = self.tag_path_label(key);
+        let kit_state = &mut self.kits[kit];
+        kit_state.parsed_tags.remove(key);
+        kit_state.loading_tags.remove(key);
+        kit_state.bitmap_previews.remove(key);
+        kit_state.model_previews.remove(key);
+        kit_state.field_search.remove(key);
+        kit_state.field_search_applied.remove(key);
+        kit_state.edit_buffers.forget_tag(key);
+        // Persist the removal. The document is gone by now, so the capture
+        // below cannot put the overlay straight back.
+        if had_overlay {
+            let now = ctx.input(|input| input.time);
+            if let Err(error) = self.checkpoint_campaign_project(kit, now) {
+                self.status = format!("Could not update the Campaign Evolved project: {error}");
+                return;
+            }
+        }
+        // Still open: reload it as the source has it, rather than leaving an
+        // empty pane behind.
+        if self.kits[kit].open_tabs.iter().any(|open| open == key) {
+            self.select_entry(key.to_owned(), ctx.clone());
+        }
+        self.status = format!("Discarded unsaved changes to {label}");
+    }
+
+    /// Whether `key` has anything to discard — unsaved edits, or bytes stashed
+    /// in this kit's project from an earlier session.
+    pub(super) fn tag_has_discardable_changes(&self, kit: usize, key: &str) -> bool {
+        if self.kits[kit]
+            .parsed_tags
+            .get(key)
+            .is_some_and(|document| document.dirty)
+        {
+            return true;
+        }
+        let Some(entry) = self.entry_for_key_in(kit, key) else {
+            return false;
+        };
+        let Some((identity, ..)) = campaign_entry_project_parts(entry) else {
+            return false;
+        };
+        self.kits[kit]
+            .campaign_project
+            .as_ref()
+            .is_some_and(|project| project.overlays.contains_key(&identity))
+    }
+
     pub(super) fn select_entry(&mut self, key: String, ctx: egui::Context) {
         self.kits[self.active].open_tag_pane(&key);
         self.kits[self.active].selected_key = Some(key.clone());
@@ -1830,31 +1899,13 @@ impl Baboon {
             }
             _ => {}
         }
-        // A Campaign Evolved project retains edits, so upstream skips the
-        // unsaved-changes prompt once the checkpoint lands.
-        //
-        // CloseApp is deliberately excluded. It walks the dirty kits one at a
-        // time, and a checkpoint does not clear their dirty flags, so returning
-        // early here would re-enter this function with the same kit selected
-        // and never terminate. Exiting with a project therefore still prompts;
-        // that is one prompt too many, not one too few.
-        if !matches!(action, PendingCloseAction::CloseApp)
-            && self.current_source_is_campaign_project_capable(self.active)
-        {
-            let now = ctx.input(|input| input.time);
-            match self.checkpoint_campaign_project(self.active, now) {
-                Ok(_) => {
-                    self.execute_close_action(action, ctx);
-                    return;
-                }
-                Err(error) => {
-                    self.status = format!("Could not checkpoint Campaign Evolved project: {error}");
-                    self.project_checkpoint_prompt =
-                        Some(ProjectCheckpointPrompt { action, error });
-                    return;
-                }
-            }
-        }
+        // Upstream skipped the unsaved-changes prompt entirely for a container
+        // source, checkpointing the project instead on the grounds that the
+        // project retains the edits. It does — but silently, and there was no
+        // way to say no: overlays were only ever inserted, so an edit could not
+        // be taken back once stashed. The prompt is raised for these sources
+        // too, and offers stashing as a third, named choice.
+        let can_stash = self.current_source_is_campaign_project_capable(self.active);
         let dirty_tags = self.dirty_tags_for_close_action(&action);
         if dirty_tags.is_empty() {
             self.execute_close_action(action, ctx);
@@ -1862,6 +1913,7 @@ impl Baboon {
         }
         self.save_changes_prompt = SaveChangesPrompt {
             visible: true,
+            can_stash,
             dirty_tags,
             pending_action: action,
             error: None,
@@ -5312,15 +5364,60 @@ impl Baboon {
                 self.save_changes_prompt.dirty_tags.clear();
                 self.save_changes_prompt.error = None;
             }
+            SaveChangesPromptAction::StashForMod => {
+                let action = self.save_changes_prompt.pending_action.clone();
+                let now = ctx.input(|input| input.time);
+                match self.checkpoint_campaign_project(self.active, now) {
+                    Ok(_) => {
+                        // The project holds these bytes now, so they are no
+                        // longer unsaved work: leaving them dirty would prompt
+                        // again on the next close and, for a CloseApp walking
+                        // several kits, would never terminate.
+                        for entry in &self.save_changes_prompt.dirty_tags {
+                            if let Some(document) =
+                                self.kits[self.active].parsed_tags.get_mut(&entry.tag_id)
+                            {
+                                document.dirty = false;
+                            }
+                        }
+                        self.save_changes_prompt.visible = false;
+                        self.save_changes_prompt.dirty_tags.clear();
+                        self.save_changes_prompt.error = None;
+                        self.status = "Stashed for Export Mod".to_owned();
+                        self.execute_close_action(action, ctx);
+                    }
+                    Err(error) => {
+                        self.save_changes_prompt.error =
+                            Some(format!("Could not stash into the project: {error}"));
+                    }
+                }
+            }
             SaveChangesPromptAction::DontSave => {
                 let action = self.save_changes_prompt.pending_action.clone();
                 // Discarding is explicit, so drop the dirty flags the prompt
                 // listed. Without this, a CloseApp that spans several kits
                 // would see the same unsaved work again and re-prompt forever.
-                for entry in &self.save_changes_prompt.dirty_tags {
-                    if let Some(doc) = self.kits[self.active].parsed_tags.get_mut(&entry.tag_id) {
+                let kit = self.active;
+                let tag_ids: Vec<String> = self
+                    .save_changes_prompt
+                    .dirty_tags
+                    .iter()
+                    .map(|entry| entry.tag_id.clone())
+                    .collect();
+                for tag_id in &tag_ids {
+                    if let Some(doc) = self.kits[kit].parsed_tags.get_mut(tag_id) {
                         doc.dirty = false;
                     }
+                    // And forget anything the project stashed for it. Autosave
+                    // captures a dirty tag within a second of the edit, so
+                    // without this "Don't Save" cleared a flag while the edited
+                    // bytes stayed behind and came back on reopen.
+                    self.forget_campaign_overlay(kit, tag_id);
+                    self.kits[kit].edit_buffers.forget_tag(tag_id);
+                }
+                let now = ctx.input(|input| input.time);
+                if let Err(error) = self.checkpoint_campaign_project(kit, now) {
+                    self.status = format!("Could not update the Campaign Evolved project: {error}");
                 }
                 self.save_changes_prompt.visible = false;
                 self.save_changes_prompt.dirty_tags.clear();
@@ -5518,6 +5615,9 @@ mod browser_refresh_tests;
 enum SaveChangesPromptAction {
     None,
     Save(Vec<String>),
+    /// Keep the edits in this workspace's Baboon project, ready for Export
+    /// Mod, without writing anything into the game's own files.
+    StashForMod,
     DontSave,
     Cancel,
 }
@@ -5542,6 +5642,17 @@ fn render_save_changes_prompt(
                 RichText::new("The following files have been modified. Select the files to save.")
                     .color(text_dark()),
             );
+            if prompt.can_stash {
+                ui.add_space(4.0);
+                ui.label(
+                    RichText::new(
+                        "Save overwrites the game's own pak files in place. Stash for Mod keeps \
+                         the edits in this workspace's project instead, ready for Export Mod.",
+                    )
+                    .small()
+                    .color(subtle_dark()),
+                );
+            }
             ui.add_space(8.0);
             if let Some(error) = prompt.error.as_deref() {
                 ui.label(RichText::new(error).color(Color32::from_rgb(180, 48, 40)));
@@ -5568,6 +5679,19 @@ fn render_save_changes_prompt(
                     .clicked()
                 {
                     action = SaveChangesPromptAction::DontSave;
+                }
+                if prompt.can_stash
+                    && ui
+                        .add(
+                            egui::Button::new("Stash for Mod").min_size(Vec2::new(110.0, 24.0)),
+                        )
+                        .on_hover_text(
+                            "Keep these edits in this workspace's Baboon project, ready for \
+                             Export Mod. The game's own files are left untouched.",
+                        )
+                        .clicked()
+                {
+                    action = SaveChangesPromptAction::StashForMod;
                 }
                 if ui
                     .add(egui::Button::new("Save").min_size(Vec2::new(78.0, 24.0)))

--- a/src/app/foundation/containers.rs
+++ b/src/app/foundation/containers.rs
@@ -1659,12 +1659,25 @@ pub(in crate::app) fn draw_foundation_block_control(
                 if has_sel {
                     let (combo_response, wheel_delta) = combo_box_with_scroll(
                         ui,
+                        // The element count is part of the id on purpose. A
+                        // popup's `Area` and `ScrollArea` remember their size
+                        // in egui memory under this id, and the remembered
+                        // size becomes the space the content is laid out in --
+                        // so once the list grew past the size the popup had
+                        // when it was last open, it stayed at the old size and
+                        // scrolled instead of growing. Keying on the count
+                        // retires that memory the moment the list changes.
+                        //
+                        // This is also why closing and reopening the tag
+                        // "fixed" it: a reopened tag lands in a new tile, whose
+                        // `view_scope` is already part of this id.
                         egui::ComboBox::from_id_salt((
                             "block_instance",
                             view_scope,
                             tag_key,
                             path_salt,
                             depth,
+                            count,
                         ))
                         .selected_text(truncate_for_cell(selected_label, combo_width - 24.0))
                         .width(combo_width),
@@ -2397,7 +2410,10 @@ pub(in crate::app) fn draw_foundation_block_index_row(
             let mut new_index: Option<i64> = None;
             let (_, wheel_delta) = combo_box_with_scroll(
                 ui,
-                egui::ComboBox::from_id_salt(("block_index", path))
+                // Keyed on the option count for the same reason as the
+                // instance selector above: adding a palette entry must not
+                // leave the popup at the size it had before.
+                egui::ComboBox::from_id_salt(("block_index", path, labels.len()))
                     .selected_text(truncate_for_cell(&selected_text, 280.0))
                     .width(300.0),
                 |ui| {

--- a/src/app/foundation/containers.rs
+++ b/src/app/foundation/containers.rs
@@ -2655,4 +2655,88 @@ mod palette_repro_tests {
         eprintln!("checked {checked} block-index field(s)");
         assert!(failures.is_empty(), "{failures:#?}");
     }
+
+    /// Crisp's report, stated exactly: adding an element to a block must make
+    /// that block's own instance selector offer it, without a save and reopen.
+    /// The selector lists `0..block.len()`, so this checks the length the
+    /// renderer would read on the next frame.
+    #[test]
+    fn adding_an_element_grows_the_blocks_own_length() {
+        let defs = std::path::Path::new("definitions");
+        let cases = [
+            ("halo3_mcc", "levels/multi/riverworld/riverworld.scenario", *b"scnr"),
+            ("haloreach_mcc", "levels/multi/35_island/35_island.scenario", *b"scnr"),
+            ("halo2_mcc", "scenarios/solo/05a_deltaapproach/05a_deltaapproach.scenario", *b"scnr"),
+            ("haloce_mcc", "levels/d40/d40.scenario", *b"scnr"),
+        ];
+        let mut failures = Vec::new();
+
+        for (game, rel, group_bytes) in cases {
+            let tag_path = std::path::Path::new("/Users/camden/Halo")
+                .join(game)
+                .join("tags")
+                .join(rel);
+            if !tag_path.exists() {
+                eprintln!("skip {game}: missing");
+                continue;
+            }
+            let group = u32::from_be_bytes(group_bytes);
+            let Ok(tag) = crate::source::read_tag_at_path(&tag_path, Some(game), Some(defs), group)
+            else {
+                eprintln!("skip {game}: unreadable");
+                continue;
+            };
+            // Root-level blocks, split by whether they start empty: an
+            // empty-on-disk block is the case that has bitten before.
+            let mut blocks: Vec<(String, usize)> = Vec::new();
+            for field in tag.root().fields_all() {
+                if let Some(block) = field.as_block() {
+                    blocks.push((field.name().to_owned(), block.len()));
+                }
+            }
+            let empty = blocks.iter().filter(|(_, n)| *n == 0).count();
+            eprintln!("{game}: {} root block(s), {empty} empty", blocks.len());
+
+            let mut checked = 0usize;
+            let mut stale = 0usize;
+            for (name, before) in blocks {
+                let Ok(mut tag) =
+                    crate::source::read_tag_at_path(&tag_path, Some(game), Some(defs), group)
+                else {
+                    continue;
+                };
+                let mut dirty = false;
+                let status = crate::app::apply_block_ops(
+                    &mut tag,
+                    vec![BlockOp {
+                        path: name.clone(),
+                        kind: BlockOpKind::Add,
+                    }],
+                    &mut dirty,
+                );
+                if status.as_deref().is_some_and(|s| s.contains("failed")) {
+                    continue;
+                }
+                let after = tag
+                    .root()
+                    .fields_all()
+                    .find_map(|field| {
+                        (field.name() == name)
+                            .then(|| field.as_block().map(|block| block.len()))
+                            .flatten()
+                    })
+                    .unwrap_or(0);
+                checked += 1;
+                if after != before + 1 {
+                    stale += 1;
+                    failures.push(format!(
+                        "{game} block {name:?}: len {before} -> {after} after adding an element \
+                         (status {status:?})"
+                    ));
+                }
+            }
+            eprintln!("{game}: checked {checked} block(s), {stale} stale");
+        }
+        assert!(failures.is_empty(), "{} failure(s):\n{failures:#?}", failures.len());
+    }
 }

--- a/src/app/foundation/containers.rs
+++ b/src/app/foundation/containers.rs
@@ -2532,4 +2532,127 @@ mod palette_repro_tests {
         }
         assert!(failures.is_empty(), "{failures:#?}");
     }
+
+    /// Every block-index field in a tag, at every depth, with the struct path
+    /// the app itself would render it under (`name#ordinal` segments) -- so the
+    /// ancestor walk in `block_index_target_options` is exercised through
+    /// `root.descend`, not just the root-level shortcut.
+    fn collect_block_index_fields(
+        st: &blam_tags::TagStruct<'_>,
+        path: &str,
+        out: &mut Vec<String>,
+        depth: usize,
+    ) {
+        if depth > 6 || out.len() > 400 {
+            return;
+        }
+        for field in st.fields_all() {
+            let field_path = crate::app::append_field_path_for(path, &field);
+            if field.definition().block_index_target().is_some() {
+                out.push(path.to_owned());
+            }
+            if let Some(block) = field.as_block()
+                && block.len() > 0
+                && let Some(element) = block.element(0)
+            {
+                let element_path = format!("{field_path}[0]");
+                collect_block_index_fields(&element, &element_path, out, depth + 1);
+            }
+        }
+    }
+
+    /// The general form of Crisp's report: for a block-index field anywhere in
+    /// a tag, adding an element to the block it targets must be offered by the
+    /// dropdown immediately, with no save and reopen.
+    #[test]
+    fn adding_to_a_targeted_block_reaches_its_dropdown_at_every_depth() {
+        let defs = std::path::Path::new("definitions");
+        let names = crate::format::TagNameIndex::default();
+        let cases = [
+            ("halo3_mcc", "levels/multi/riverworld/riverworld.scenario", *b"scnr"),
+            ("haloreach_mcc", "levels/multi/35_island/35_island.scenario", *b"scnr"),
+        ];
+        let mut failures = Vec::new();
+        let mut checked = 0usize;
+
+        for (game, rel, group_bytes) in cases {
+            let tag_path = std::path::Path::new("/Users/camden/Halo")
+                .join(game)
+                .join("tags")
+                .join(rel);
+            if !tag_path.exists() {
+                eprintln!("skip {game}: {} missing", tag_path.display());
+                continue;
+            }
+            let group = u32::from_be_bytes(group_bytes);
+            let Ok(tag) = crate::source::read_tag_at_path(&tag_path, Some(game), Some(defs), group)
+            else {
+                eprintln!("skip {game}: unreadable");
+                continue;
+            };
+            let mut struct_paths = Vec::new();
+            collect_block_index_fields(&tag.root(), "", &mut struct_paths, 0);
+            struct_paths.sort();
+            struct_paths.dedup();
+            eprintln!("{game}: {} struct(s) holding block-index fields", struct_paths.len());
+
+            for struct_path in struct_paths.iter().take(40) {
+                // Re-read per case: each one mutates the tag.
+                let Ok(mut tag) =
+                    crate::source::read_tag_at_path(&tag_path, Some(game), Some(defs), group)
+                else {
+                    continue;
+                };
+                let resolve = |tag: &blam_tags::TagFile| -> Option<(String, usize)> {
+                    let root = tag.root();
+                    let st = if struct_path.is_empty() {
+                        root
+                    } else {
+                        root.descend(struct_path)?
+                    };
+                    for field in st.fields_all() {
+                        if field.definition().block_index_target().is_some()
+                            && let Some((labels, target)) = block_index_target_options(
+                                &st,
+                                &field,
+                                &names,
+                                Some(root),
+                                struct_path,
+                            )
+                        {
+                            return Some((target, labels.len()));
+                        }
+                    }
+                    None
+                };
+                let Some((target, before)) = resolve(&tag) else {
+                    continue;
+                };
+                let mut dirty = false;
+                let status = crate::app::apply_block_ops(
+                    &mut tag,
+                    vec![BlockOp {
+                        path: target.clone(),
+                        kind: BlockOpKind::Add,
+                    }],
+                    &mut dirty,
+                );
+                if status.as_deref().is_some_and(|s| s.contains("failed")) {
+                    eprintln!("  {struct_path:?} -> {target:?}: add failed: {status:?}");
+                    continue;
+                }
+                let after = resolve(&tag).map(|(_, n)| n).unwrap_or(0);
+                checked += 1;
+                if after != before + 1 {
+                    failures.push(format!(
+                        "{game} {struct_path:?} -> target {target:?}: {before} option(s) before, \
+                         {after} after adding an element (expected {})",
+                        before + 1
+                    ));
+                }
+            }
+        }
+        eprintln!("checked {checked} block-index field(s)");
+        assert!(failures.is_empty(), "{failures:#?}");
+    }
 }

--- a/src/app/foundation/containers.rs
+++ b/src/app/foundation/containers.rs
@@ -22,7 +22,8 @@ pub(in crate::app) fn draw_struct_fields(
     } else {
         clean_field_name(tag_struct.name())
     };
-    let open_override = edit.resolve_open(path_prefix, depth <= 1);
+    let group_default_open = edit.default_open(depth <= 1);
+    let open_override = edit.resolve_open(path_prefix, group_default_open);
     draw_foundation_group(
         ui,
         title,
@@ -62,7 +63,8 @@ pub(in crate::app) fn draw_inherited_object_fields(
 
     for (struct_value, path_prefix) in chain.iter().rev() {
         let title = clean_field_name(struct_value.name()).to_ascii_uppercase();
-        let open_override = edit.resolve_open(path_prefix, true);
+        let inherited_default_open = edit.default_open(true);
+        let open_override = edit.resolve_open(path_prefix, inherited_default_open);
         draw_foundation_group(
             ui,
             title,
@@ -408,7 +410,7 @@ pub(in crate::app) fn draw_field(
         // Foundation/Guerilla. The user can still collapse it, and that choice
         // persists (collapse state is keyed index-free; see `strip_node_indices`).
 
-        let nested_default_open = true;
+        let nested_default_open = edit.default_open(true);
         let open_override = edit.resolve_open(&field_path, nested_default_open);
         draw_foundation_group(
             ui,
@@ -817,7 +819,7 @@ pub(in crate::app) fn draw_foundation_block(
         block_element_dropdown_label(block.element(sel), names, sel)
     };
 
-    let block_default_open = depth == 0 || is_priority_section(name);
+    let block_default_open = edit.default_open(depth == 0 || is_priority_section(name));
     let open_override = edit.resolve_open(path_prefix, block_default_open);
     // A clipboard is compatible when it came from the same group + block schema
     // position AND holds elements of the same on-disk size. Element subscripts
@@ -1272,7 +1274,8 @@ pub(in crate::app) fn draw_foundation_array(
     } else {
         block_element_dropdown_label(array.element(sel), names, sel)
     };
-    let open_override = edit.resolve_open(path_prefix, depth == 0);
+    let array_default_open = edit.default_open(depth == 0);
+    let open_override = edit.resolve_open(path_prefix, array_default_open);
     // A clipboard is compatible when it came from this same array schema
     // position. Element subscripts are stripped so which parent block element is
     // selected doesn't matter — the array's shape is identical across siblings.

--- a/src/app/foundation/containers.rs
+++ b/src/app/foundation/containers.rs
@@ -1670,11 +1670,17 @@ pub(in crate::app) fn draw_foundation_block_control(
                         .width(combo_width),
                         |ui| {
                             selector_active |= ui.rect_contains_pointer(ui.max_rect());
+                            // Adding an element selects it, so opening the list
+                            // scrolled to the top hid the very entry that was
+                            // just added when the list outgrew the popup.
+                            let just_opened = combo_popup_just_opened(ui);
                             for i in 0..count {
-                                if ui
-                                    .selectable_label(i == selected_index, element_label(i))
-                                    .clicked()
-                                {
+                                let row =
+                                    ui.selectable_label(i == selected_index, element_label(i));
+                                if just_opened && i == selected_index {
+                                    row.scroll_to_me(Some(egui::Align::Center));
+                                }
+                                if row.clicked() {
                                     actions.new_selection = Some(i);
                                 }
                             }
@@ -1846,6 +1852,27 @@ fn combo_scroll_cycle_enabled(ui: &Ui) -> bool {
     })
 }
 
+/// How tall a combo popup may grow before it scrolls. Generous enough that
+/// ordinary lists size to their contents, while a block with hundreds of
+/// elements still gets a scrollable popup rather than a full-screen one.
+pub(in crate::app) const COMBO_POPUP_MAX_HEIGHT: f32 = 420.0;
+
+/// True on the first frame a combo popup is drawn, so a caller can reveal the
+/// selected row exactly once. Scrolling on every frame would fight the user's
+/// own scrolling and the wheel-cycling above.
+///
+/// The popup's `Ui` id is stable while it stays open, and the popup only draws
+/// while open, so a gap in the pass counter means it was closed in between.
+/// That distinguishes "just opened" from "still open" without threading state
+/// through any of the call sites.
+pub(in crate::app) fn combo_popup_just_opened(ui: &Ui) -> bool {
+    let id = ui.id().with("combo_popup_last_pass");
+    let now = ui.ctx().cumulative_pass_nr();
+    let last = ui.data(|data| data.get_temp::<u64>(id));
+    ui.data_mut(|data| data.insert_temp(id, now));
+    !matches!(last, Some(previous) if previous + 1 >= now)
+}
+
 pub(in crate::app) fn combo_box_with_scroll<R>(
     ui: &mut Ui,
     combo: egui::ComboBox,
@@ -1855,6 +1882,13 @@ pub(in crate::app) fn combo_box_with_scroll<R>(
         .scope(|ui| {
             ui.spacing_mut().interact_size.y = 20.0;
             ui.spacing_mut().button_padding.y = 2.0;
+            // egui sizes a combo popup to its contents and only scrolls once
+            // they exceed `combo_height`, so this is the clamp -- not a fixed
+            // height. The stock 200pt starts scrolling after a handful of rows,
+            // which hides entries that are simply below the fold: a block's
+            // instance selector would scroll rather than grow the moment an
+            // element was added.
+            ui.spacing_mut().combo_height = COMBO_POPUP_MAX_HEIGHT;
             combo.show_ui(ui, add_contents)
         })
         .inner;
@@ -2367,11 +2401,22 @@ pub(in crate::app) fn draw_foundation_block_index_row(
                     .selected_text(truncate_for_cell(&selected_text, 280.0))
                     .width(300.0),
                 |ui| {
-                    if ui.selectable_label(current < 0, "<none>").clicked() {
+                    // Same as the instance selector: open showing what is
+                    // selected, not the top of a long palette.
+                    let just_opened = combo_popup_just_opened(ui);
+                    let none_row = ui.selectable_label(current < 0, "<none>");
+                    if just_opened && current < 0 {
+                        none_row.scroll_to_me(Some(egui::Align::Center));
+                    }
+                    if none_row.clicked() {
                         new_index = Some(-1);
                     }
                     for (i, label) in labels.iter().enumerate() {
-                        if ui.selectable_label(current == i as i64, label).clicked() {
+                        let row = ui.selectable_label(current == i as i64, label);
+                        if just_opened && current == i as i64 {
+                            row.scroll_to_me(Some(egui::Align::Center));
+                        }
+                        if row.clicked() {
                             new_index = Some(i as i64);
                         }
                     }

--- a/src/app/foundation/containers.rs
+++ b/src/app/foundation/containers.rs
@@ -2414,3 +2414,122 @@ pub(in crate::app) fn draw_foundation_block_index_row(
         }
     });
 }
+
+#[cfg(test)]
+mod palette_repro_tests {
+    use super::*;
+
+    /// Reproduction probe for "a tag added to the scenario vehicle palette does
+    /// not appear in the vehicles block's dropdown until save + reopen".
+    /// Runs the same add-then-set-reference flow on every editing kit present.
+    #[test]
+    fn palette_addition_reaches_the_block_index_dropdown() {
+        let cases = [
+            ("halo3_mcc", "levels/multi/riverworld/riverworld.scenario"),
+            ("haloreach_mcc", "levels/multi/35_island/35_island.scenario"),
+            ("halo2_mcc", "scenarios/solo/05a_deltaapproach/05a_deltaapproach.scenario"),
+            ("haloce_mcc", "levels/d40/d40.scenario"),
+        ];
+        let defs = std::path::Path::new("definitions");
+        let names = crate::format::TagNameIndex::default();
+        let group = u32::from_be_bytes(*b"scnr");
+        let mut failures = Vec::new();
+
+        for (game, rel) in cases {
+            let tag_path = std::path::Path::new("/Users/camden/Halo")
+                .join(game)
+                .join("tags")
+                .join(rel);
+            if !tag_path.exists() {
+                eprintln!("skip {game}: {} missing", tag_path.display());
+                continue;
+            }
+            let Ok(mut tag) =
+                crate::source::read_tag_at_path(&tag_path, Some(game), Some(defs), group)
+            else {
+                eprintln!("skip {game}: could not read scenario");
+                continue;
+            };
+
+            // The dropdown a `vehicles` element's block-index field would show.
+            let options = |tag: &blam_tags::TagFile| -> Option<Vec<String>> {
+                let root = tag.root();
+                for field in root.fields_all() {
+                    if let Some(block) = field.as_block()
+                        && field.name() == "vehicles"
+                        && let Some(element) = block.element(0)
+                    {
+                        for sub in element.fields_all() {
+                            if sub.definition().block_index_target().is_some()
+                                && let Some((labels, target)) = block_index_target_options(
+                                    &element,
+                                    &sub,
+                                    &names,
+                                    Some(root),
+                                    "vehicles[0]",
+                                )
+                                && target.contains("palette")
+                            {
+                                return Some(labels);
+                            }
+                        }
+                    }
+                }
+                None
+            };
+            let palette_len = |tag: &blam_tags::TagFile| -> Option<usize> {
+                tag.root().fields_all().find_map(|field| {
+                    (field.name() == "vehicle palette")
+                        .then(|| field.as_block().map(|block| block.len()))
+                        .flatten()
+                })
+            };
+
+            let Some(before) = options(&tag) else {
+                eprintln!("skip {game}: no vehicles block-index field resolved");
+                continue;
+            };
+            let before_len = palette_len(&tag).unwrap_or(0);
+            let mut dirty = false;
+            let status = crate::app::apply_block_ops(
+                &mut tag,
+                vec![BlockOp {
+                    path: "vehicle palette".to_owned(),
+                    kind: BlockOpKind::Add,
+                }],
+                &mut dirty,
+            );
+            let after_len = palette_len(&tag).unwrap_or(0);
+            let after = options(&tag).unwrap_or_default();
+            eprintln!(
+                "{game}: palette {before_len} -> {after_len}, dropdown {} -> {} ({status:?})",
+                before.len(),
+                after.len()
+            );
+            if after_len != before_len + 1 {
+                failures.push(format!("{game}: palette did not grow"));
+                continue;
+            }
+            if after.len() != before.len() + 1 {
+                failures.push(format!(
+                    "{game}: dropdown stayed at {} option(s) after the palette grew to {after_len}",
+                    after.len()
+                ));
+                continue;
+            }
+            // And the label follows the reference the user then sets.
+            let edit = PendingFieldEdit {
+                path: format!("vehicle palette[{before_len}]/name"),
+                input: "objects/vehicles/warthog/warthog.vehicle".to_owned(),
+            };
+            let applied = crate::app::apply_pending_edits(&mut tag, vec![edit], &mut dirty);
+            let labelled = options(&tag).unwrap_or_default();
+            let last = labelled.last().cloned().unwrap_or_default();
+            eprintln!("{game}: new label {last:?} ({:?})", applied.status);
+            if !last.contains("warthog") {
+                failures.push(format!("{game}: label did not pick up the reference: {last:?}"));
+            }
+        }
+        assert!(failures.is_empty(), "{failures:#?}");
+    }
+}

--- a/src/app/foundation/tests.rs
+++ b/src/app/foundation/tests.rs
@@ -121,7 +121,7 @@ mod tests {
         let _ = std::fs::remove_dir_all(&root);
     }
 
-    fn with_test_edit_context(assertion: impl FnOnce(&FieldEditContext<'_>)) {
+    fn with_test_edit_context(assertion: impl FnOnce(&mut FieldEditContext<'_>)) {
         let definitions_root = locate_definitions_root();
         let mut buffers = EditDrafts::default();
         let mut pending = Vec::new();
@@ -143,6 +143,7 @@ mod tests {
         let mut tsv_paste_request = None;
         let mut tag_reference_picker = None;
         let edit = FieldEditContext {
+            expand_all: None,
             view_scope: "test",
             tag_key: "test",
             group_tag: parse_group_tag("jpt!").unwrap(),
@@ -184,7 +185,8 @@ mod tests {
             field_filter: None,
             field_nav: None,
         };
-        assertion(&edit);
+        let mut edit = edit;
+        assertion(&mut edit);
     }
 
     #[test]
@@ -551,5 +553,24 @@ mod tests {
         for (field_name, expected) in cases {
             assert_eq!(semantic_short_index_target_key(field_name), expected);
         }
+    }
+
+    /// Expand/collapse-all is a direct instruction about the whole tag, so it
+    /// has to win over the rules that otherwise decide a container's open
+    /// state — the search filter's, and a reference jump forcing its target's
+    /// ancestors open. Every container type resolves through here, so this is
+    /// the one place that ordering is decided.
+    #[test]
+    fn expand_all_overrides_the_other_open_rules() {
+        with_test_edit_context(|edit| {
+            // Nothing asked for: the caller's own default stands.
+            assert_eq!(edit.resolve_open("some/block", true), None);
+
+            edit.expand_all = Some(true);
+            assert_eq!(edit.resolve_open("some/block", false), Some(true));
+
+            edit.expand_all = Some(false);
+            assert_eq!(edit.resolve_open("some/block", true), Some(false));
+        });
     }
 }

--- a/src/app/foundation/tests.rs
+++ b/src/app/foundation/tests.rs
@@ -144,6 +144,7 @@ mod tests {
         let mut tag_reference_picker = None;
         let edit = FieldEditContext {
             expand_all: None,
+            nested_default: NestedDefault::default(),
             view_scope: "test",
             tag_key: "test",
             group_tag: parse_group_tag("jpt!").unwrap(),
@@ -571,6 +572,27 @@ mod tests {
 
             edit.expand_all = Some(false);
             assert_eq!(edit.resolve_open("some/block", true), Some(false));
+        });
+    }
+
+    /// The preference adjusts each container's *default* rather than forcing
+    /// its state, so a group the user has since opened or closed keeps their
+    /// choice — egui only consults a default when it has nothing stored.
+    #[test]
+    fn nested_default_overrides_only_the_schema_default() {
+        with_test_edit_context(|edit| {
+            edit.nested_default = NestedDefault::Schema;
+            assert!(edit.default_open(true));
+            assert!(!edit.default_open(false));
+
+            edit.nested_default = NestedDefault::Collapsed;
+            assert!(!edit.default_open(true), "collapsed must close a section the schema opens");
+
+            edit.nested_default = NestedDefault::Expanded;
+            assert!(edit.default_open(false), "expanded must open a section the schema closes");
+
+            // And it stays a default: nothing here forces an open state.
+            assert_eq!(edit.resolve_open("some/block", true), None);
         });
     }
 }

--- a/src/app/kit.rs
+++ b/src/app/kit.rs
@@ -80,6 +80,10 @@ pub(super) struct Kit {
     /// one walks several packages.
     pub(super) ce_sound_bindings: HashMap<String, Arc<crate::source::ce_audio::CeSoundBinding>>,
 
+    /// Pending expand/collapse-all requests, keyed by tag. Raised from the tag
+    /// tab's menu and consumed by the next draw of that tag's pane.
+    pub(super) pending_expand: HashMap<String, bool>,
+
     // --- Per-tag "Search fields" state ---
     pub(super) field_search: HashMap<String, String>,
     /// The last query actually applied per tag, so the collapse is a one-shot
@@ -158,6 +162,7 @@ impl Kit {
             rmdf_cache: HashMap::new(),
             rmop_cache: HashMap::new(),
             ce_sound_bindings: HashMap::new(),
+            pending_expand: HashMap::new(),
             field_search: HashMap::new(),
             field_search_applied: HashMap::new(),
             browser_mode: BrowserMode::default(),

--- a/src/app/kit.rs
+++ b/src/app/kit.rs
@@ -97,6 +97,13 @@ pub(super) struct Kit {
     pub(super) browser_sort: BrowserSort,
     pub(super) filter: String,
     pub(super) filter_cache: FilterCache,
+    /// Which tags the browser should mark as modified, and the signature the
+    /// set was built from. Rebuilt only when that signature changes: resolving
+    /// a tag key to its entry is a linear scan of the source, so doing it for
+    /// every dirty tag every frame would cost far more than the handful of
+    /// lookups it represents.
+    pub(super) modified_tags: std::sync::Arc<ModifiedTags>,
+    pub(super) modified_signature: Vec<String>,
     /// Bumped whenever this kit's source or its `all_entries` set is replaced,
     /// so caches and in-flight async results know to recompute or drop against
     /// fresh data. Per kit, so reloading one kit cannot invalidate another's.
@@ -157,6 +164,8 @@ impl Kit {
             browser_sort: BrowserSort::default(),
             filter: String::new(),
             filter_cache: FilterCache::default(),
+            modified_tags: std::sync::Arc::new(ModifiedTags::default()),
+            modified_signature: Vec::new(),
             generation: 0,
             field_index: FieldValueIndex::default(),
             keywords: KeywordStore::default(),
@@ -169,6 +178,20 @@ impl Kit {
             pending_campaign_project: None,
             pending_restore_tags: Vec::new(),
         }
+    }
+
+    /// Whether this workspace holds edits that are not written into the game:
+    /// unsaved open documents, or tags stashed in its project.
+    ///
+    /// One predicate for both, because the tab's dot and its colour were
+    /// computed separately and drifted apart — closing the last stashed tag
+    /// left the dot showing while the colour went back to clean.
+    pub(super) fn has_unwritten_modifications(&self) -> bool {
+        self.parsed_tags.values().any(|document| document.dirty)
+            || self
+                .campaign_project
+                .as_ref()
+                .is_some_and(|project| !project.overlays.is_empty())
     }
 
     /// Whether this kit is an empty workspace rather than a loaded source.

--- a/src/app/prefs.rs
+++ b/src/app/prefs.rs
@@ -62,6 +62,10 @@ pub(super) fn load_gui_prefs() -> GuiPrefs {
     GuiPrefs {
         browser_mode,
         browser_sort,
+        nested_default: nested_default_from_str(
+            value.get("nested_default").and_then(Value::as_str),
+        )
+        .unwrap_or_default(),
         show_browser_prefixes: value
             .get("show_browser_prefixes")
             .and_then(Value::as_bool)
@@ -394,6 +398,7 @@ pub(super) fn save_gui_prefs(
     let value = json!({
         "browser_mode": browser_mode_str(prefs.browser_mode),
         "browser_sort": browser_sort_str(prefs.browser_sort),
+        "nested_default": nested_default_str(prefs.nested_default),
         "show_browser_prefixes": prefs.show_browser_prefixes,
         "folders_before_tags": prefs.folders_before_tags,
         "double_click_to_open_tags": prefs.double_click_to_open_tags,
@@ -494,6 +499,23 @@ fn browser_sort_from_str(text: Option<&str>) -> Option<BrowserSort> {
         "name" => Some(BrowserSort::Name),
         "type" => Some(BrowserSort::Type),
         _ => None,
+    }
+}
+
+fn nested_default_from_str(text: Option<&str>) -> Option<NestedDefault> {
+    match text? {
+        "schema" => Some(NestedDefault::Schema),
+        "collapsed" => Some(NestedDefault::Collapsed),
+        "expanded" => Some(NestedDefault::Expanded),
+        _ => None,
+    }
+}
+
+fn nested_default_str(nested: NestedDefault) -> &'static str {
+    match nested {
+        NestedDefault::Schema => "schema",
+        NestedDefault::Collapsed => "collapsed",
+        NestedDefault::Expanded => "expanded",
     }
 }
 
@@ -812,6 +834,29 @@ mod tests {
         assert!(clean_favorite_relative_path(PathBuf::from("../brute.model")).is_none());
         assert!(clean_favorite_relative_path(PathBuf::from("./brute.model")).is_none());
         assert!(clean_favorite_relative_path(PathBuf::new()).is_none());
+    }
+}
+
+#[cfg(test)]
+mod nested_default_tests {
+    use super::*;
+
+    /// The stored spelling has to round trip, or the setting silently reverts
+    /// to Default on the next launch.
+    #[test]
+    fn every_nested_default_round_trips_through_its_stored_name() {
+        for option in NestedDefault::ALL {
+            assert_eq!(
+                nested_default_from_str(Some(nested_default_str(option))),
+                Some(option),
+                "{} did not round trip",
+                option.label()
+            );
+        }
+        // An absent or unrecognised value falls back rather than failing the
+        // whole preferences load.
+        assert_eq!(nested_default_from_str(None), None);
+        assert_eq!(nested_default_from_str(Some("nonsense")), None);
     }
 }
 

--- a/src/app/project.rs
+++ b/src/app/project.rs
@@ -407,17 +407,50 @@ impl Baboon {
     }
 
     fn ensure_campaign_project(&mut self, kit: usize, now: f64) {
-        if self.current_source_is_campaign_project_capable(kit)
-            && self.kits[kit].campaign_project.is_none()
+        if !self.current_source_is_campaign_project_capable(kit)
+            || self.kits[kit].campaign_project.is_some()
         {
-            let root = self.kits[kit]
-                .source
-                .as_ref()
-                .map(|source| source.source.root_path().to_path_buf());
-            self.kits[kit].campaign_project = Some(ActiveCampaignProject::fresh(
-                campaign_recovery_path(root.as_deref()),
-                now,
-            ));
+            return;
+        }
+        let root = self.kits[kit]
+            .source
+            .as_ref()
+            .map(|source| source.source.root_path().to_path_buf());
+        let path = campaign_recovery_path(root.as_deref());
+        // Adopt the recovery file already sitting at this path rather than
+        // starting empty. It holds this very source's stashed edits, and it is
+        // keyed by a hash of the source root, so a file being there at all
+        // means it belongs to this install.
+        //
+        // Starting fresh made the file write-only: the first autosave, within
+        // a second of the source mounting, overwrote everything stashed in
+        // earlier sessions. Only a session restore or File > Open Baboon
+        // Project ever read one back.
+        let restored = match load_campaign_project(&path) {
+            // A snapshot recorded for a different source would mean a hash
+            // collision; ignore it rather than serve one install's edits to
+            // another.
+            Ok(snapshot)
+                if root
+                    .as_deref()
+                    .is_none_or(|root| snapshot.source_path == root) =>
+            {
+                Some(snapshot)
+            }
+            _ => None,
+        };
+        self.kits[kit].campaign_project = Some(match &restored {
+            Some(snapshot) => ActiveCampaignProject::from_snapshot(path, snapshot, now),
+            None => ActiveCampaignProject::fresh(path, now),
+        });
+        if let Some(count) = restored
+            .as_ref()
+            .map(|snapshot| snapshot.overlays.len())
+            .filter(|count| *count > 0)
+        {
+            self.status = format!(
+                "Restored {count} stashed modification(s) from this workspace's last session"
+            );
         }
     }
 

--- a/src/app/project.rs
+++ b/src/app/project.rs
@@ -545,6 +545,55 @@ impl Baboon {
         }))
     }
 
+    /// Refresh this kit's set of modified tags if anything has changed since it
+    /// was last built.
+    ///
+    /// The signature is the identity of everything that would land in the set:
+    /// the dirty documents' keys and the stashed overlays' identities. Both are
+    /// small — a handful of entries — so building and comparing it every frame
+    /// is far cheaper than the entry lookups the rebuild performs.
+    pub(super) fn refresh_modified_tags(&mut self, kit: usize) {
+        let mut signature: Vec<String> = self.kits[kit]
+            .parsed_tags
+            .iter()
+            .filter(|(_, document)| document.dirty)
+            .map(|(key, _)| key.clone())
+            .collect();
+        if let Some(project) = self.kits[kit].campaign_project.as_ref() {
+            signature.extend(project.overlays.keys().cloned());
+        }
+        signature.sort();
+        if signature == self.kits[kit].modified_signature {
+            return;
+        }
+        let mut modified = ModifiedTags::default();
+        let dirty_keys: Vec<String> = self.kits[kit]
+            .parsed_tags
+            .iter()
+            .filter(|(_, document)| document.dirty)
+            .map(|(key, _)| key.clone())
+            .collect();
+        for key in dirty_keys {
+            if let Some(entry) = self.entry_for_key_in(kit, &key) {
+                modified.insert(entry);
+            }
+        }
+        // Stashed tags need not be open, so they are resolved from the project
+        // rather than from the open documents.
+        let identities: Vec<String> = self.kits[kit]
+            .campaign_project
+            .as_ref()
+            .map(|project| project.overlays.keys().cloned().collect())
+            .unwrap_or_default();
+        for identity in identities {
+            if let Some(entry) = self.campaign_entry_for_identity(kit, &identity) {
+                modified.insert(&entry);
+            }
+        }
+        self.kits[kit].modified_tags = std::sync::Arc::new(modified);
+        self.kits[kit].modified_signature = signature;
+    }
+
     /// Forget one tag's stashed overlay, so the tag reads as its source has it
     /// again. Returns whether anything was stashed for it.
     ///

--- a/src/app/project.rs
+++ b/src/app/project.rs
@@ -512,6 +512,85 @@ impl Baboon {
         }))
     }
 
+    /// Forget one tag's stashed overlay, so the tag reads as its source has it
+    /// again. Returns whether anything was stashed for it.
+    ///
+    /// Overlays are otherwise only ever inserted: without this, clearing a
+    /// document's dirty flag left the edited bytes in the project and reopening
+    /// the tag brought them straight back.
+    pub(super) fn forget_campaign_overlay(&mut self, kit: usize, key: &str) -> bool {
+        let Some(entry) = self.entry_for_key_in(kit, key).cloned() else {
+            return false;
+        };
+        let Some((identity, ..)) = campaign_entry_project_parts(&entry) else {
+            return false;
+        };
+        self.kits[kit]
+            .campaign_project
+            .as_mut()
+            .is_some_and(|project| project.overlays.remove(&identity).is_some())
+    }
+
+    /// Forget every stashed overlay in this kit's project, returning how many
+    /// tags were carrying one.
+    pub(super) fn forget_all_campaign_overlays(&mut self, kit: usize) -> usize {
+        let Some(project) = self.kits[kit].campaign_project.as_mut() else {
+            return 0;
+        };
+        let count = project.overlays.len();
+        project.overlays.clear();
+        count
+    }
+
+    /// Identities of the tags this kit currently has stashed, as display paths.
+    pub(super) fn stashed_campaign_tags(&self, kit: usize) -> Vec<String> {
+        let Some(project) = self.kits[kit].campaign_project.as_ref() else {
+            return Vec::new();
+        };
+        let mut paths: Vec<String> = project
+            .overlays
+            .values()
+            .map(|overlay| overlay.logical_path.clone())
+            .collect();
+        paths.sort();
+        paths
+    }
+
+    /// Throw away everything this workspace has not written into the game:
+    /// every stashed overlay and every unsaved document. The tags then reload
+    /// exactly as the game ships them.
+    pub(super) fn clear_campaign_stash(&mut self, kit: usize, ctx: &egui::Context) {
+        self.active = kit;
+        let stashed = self.forget_all_campaign_overlays(kit);
+        let open = self.kits[kit].open_tabs.clone();
+        // Every parsed document goes, not just the dirty ones: a document
+        // opened from the project reads clean while still holding the stashed
+        // bytes, so keeping it would put the edits straight back.
+        {
+            let kit_state = &mut self.kits[kit];
+            kit_state.parsed_tags.clear();
+            kit_state.loading_tags.clear();
+            kit_state.bitmap_previews.clear();
+            kit_state.model_previews.clear();
+            kit_state.field_search.clear();
+            kit_state.field_search_applied.clear();
+            kit_state.edit_buffers.clear();
+        }
+        let now = ctx.input(|input| input.time);
+        if let Err(error) = self.checkpoint_campaign_project(kit, now) {
+            self.status = format!("Could not update the Campaign Evolved project: {error}");
+            return;
+        }
+        for key in open {
+            self.select_entry(key, ctx.clone());
+        }
+        self.status = match stashed {
+            0 => "Cleared this workspace's unsaved modifications".to_owned(),
+            1 => "Cleared 1 stashed modification".to_owned(),
+            n => format!("Cleared {n} stashed modifications"),
+        };
+    }
+
     pub(super) fn checkpoint_campaign_project(&mut self, kit: usize, now: f64) -> Result<bool, String> {
         let Some(snapshot) = self.capture_campaign_project(kit, now)? else {
             return Ok(false);

--- a/src/app/project.rs
+++ b/src/app/project.rs
@@ -449,7 +449,7 @@ impl Baboon {
             if !document.dirty {
                 continue;
             }
-            let Some(entry) = self.entry_for_key(key) else {
+            let Some(entry) = self.entry_for_key_in(kit, key) else {
                 continue;
             };
             let Some((identity, logical_path, kind, package)) = campaign_entry_project_parts(entry)
@@ -478,7 +478,7 @@ impl Baboon {
         let floating_order: Vec<String> = Vec::new();
         let mut tabs = Vec::new();
         for key in self.kits[kit].open_tabs.iter().chain(floating_order.iter()) {
-            let Some(entry) = self.entry_for_key(key) else {
+            let Some(entry) = self.entry_for_key_in(kit, key) else {
                 continue;
             };
             let Some((identity, logical_path, kind, package)) = campaign_entry_project_parts(entry)
@@ -496,7 +496,7 @@ impl Baboon {
             });
         }
         let selected_identity = self.kits[kit].selected_key.as_ref().and_then(|key| {
-            self.entry_for_key(key)
+            self.entry_for_key_in(kit, key)
                 .and_then(campaign_entry_project_parts)
                 .map(|(identity, _, _, _)| identity)
         });
@@ -838,7 +838,7 @@ impl Baboon {
         if self.kits[kit].parsed_tags.contains_key(key) {
             return true;
         }
-        let Some(entry) = self.entry_for_key(key).cloned() else {
+        let Some(entry) = self.entry_for_key_in(kit, key).cloned() else {
             return false;
         };
         let Some((identity, _, _, _)) = campaign_entry_project_parts(&entry) else {

--- a/src/app/shader/widgets.rs
+++ b/src/app/shader/widgets.rs
@@ -484,6 +484,8 @@ pub(in crate::app) fn draw_shader_grid_row_readonly(
     let mut tsv_paste_request = None;
     let mut tag_reference_picker = None;
     let mut ctx = FieldEditContext {
+        // The shader grid draws no collapsible containers of its own.
+        expand_all: None,
         view_scope: "readonly",
         tag_key: "",
         group_tag: 0,

--- a/src/app/shader/widgets.rs
+++ b/src/app/shader/widgets.rs
@@ -486,6 +486,7 @@ pub(in crate::app) fn draw_shader_grid_row_readonly(
     let mut ctx = FieldEditContext {
         // The shader grid draws no collapsible containers of its own.
         expand_all: None,
+        nested_default: NestedDefault::default(),
         view_scope: "readonly",
         tag_key: "",
         group_tag: 0,

--- a/src/app/state/documents.rs
+++ b/src/app/state/documents.rs
@@ -58,6 +58,10 @@ pub(in crate::app) struct DirtyTagEntry {
 /// being vetoed and prompting again.
 pub(in crate::app) struct SaveChangesPrompt {
     pub(in crate::app) visible: bool,
+    /// Whether this workspace can hold edits in a Baboon project rather than
+    /// writing them into the game. Container sources can; a loose kit has
+    /// nowhere to stash to, so it is offered Save or nothing.
+    pub(in crate::app) can_stash: bool,
     pub(in crate::app) dirty_tags: Vec<DirtyTagEntry>,
     pub(in crate::app) pending_action: PendingCloseAction,
     pub(in crate::app) error: Option<String>,
@@ -68,6 +72,7 @@ impl Default for SaveChangesPrompt {
     fn default() -> Self {
         Self {
             visible: false,
+            can_stash: false,
             dirty_tags: Vec::new(),
             pending_action: PendingCloseAction::CloseApp,
             error: None,
@@ -289,6 +294,14 @@ pub(in crate::app) struct ImportTagDialog {
 
 /// A parsed imported tag awaiting a "discard unsaved edits?" confirmation before
 /// it overwrites an already-open, dirty document at `target_key`.
+/// Pending "throw away everything this workspace has not written into the
+/// game" confirmation, listing what it is about to drop.
+pub(in crate::app) struct ClearStashConfirm {
+    pub(in crate::app) kit: KitId,
+    pub(in crate::app) stashed: Vec<String>,
+    pub(in crate::app) unsaved: usize,
+}
+
 pub(in crate::app) struct PendingImport {
     pub(in crate::app) tag: TagFile,
     pub(in crate::app) target_key: String,

--- a/src/app/state/editing.rs
+++ b/src/app/state/editing.rs
@@ -89,6 +89,14 @@ impl EditDrafts {
         self.entries.insert(key, EditDraft::new(value));
     }
 
+    /// Drop every draft belonging to one tag. Drafts are keyed `tag|path`, so
+    /// discarding a tag's edits has to take its half-typed values with it or
+    /// they would be re-applied over the reloaded document.
+    pub(in crate::app) fn forget_tag(&mut self, tag_key: &str) {
+        let prefix = format!("{tag_key}|");
+        self.entries.retain(|key, _| !key.starts_with(&prefix));
+    }
+
     pub(in crate::app) fn accept_successful_edits(
         &mut self,
         tag_key: &str,

--- a/src/app/state/editing.rs
+++ b/src/app/state/editing.rs
@@ -483,6 +483,8 @@ pub(in crate::app) struct FieldEditContext<'a> {
     /// consumed by the pane that draws it. egui remembers each container's
     /// state, so a single frame of forcing is enough to make it stick.
     pub(in crate::app) expand_all: Option<bool>,
+    /// How nested containers start out, from preferences.
+    pub(in crate::app) nested_default: NestedDefault,
 }
 
 impl FieldEditContext<'_> {
@@ -494,6 +496,16 @@ impl FieldEditContext<'_> {
     /// whose normal default is `default_open`. `None` means "leave the node's
     /// stored state alone" (no filter applied this frame); `Some(open)` forces
     /// it this frame.
+    /// The starting open state for a container whose schema-derived default is
+    /// `schema_default`, after the preference is applied.
+    ///
+    /// This adjusts the *default* rather than forcing the state each frame, so
+    /// a container the user has since opened or closed by hand keeps whatever
+    /// they chose — egui only consults a default when it has nothing stored.
+    pub(in crate::app) fn default_open(&self, schema_default: bool) -> bool {
+        self.nested_default.applies_to(schema_default)
+    }
+
     pub(in crate::app) fn resolve_open(&self, node_path: &str, default_open: bool) -> Option<bool> {
         // An explicit expand/collapse-all wins over everything: it is a direct
         // instruction about this whole tag, issued this frame. Every container

--- a/src/app/state/editing.rs
+++ b/src/app/state/editing.rs
@@ -479,6 +479,10 @@ pub(in crate::app) struct FieldEditContext<'a> {
     /// Active reference-jump navigation. When set for this tag, its target
     /// field's ancestor blocks are force-opened and the field is glowed.
     pub(in crate::app) field_nav: Option<&'a FieldNav>,
+    /// One-shot "expand everything" / "collapse everything" for this tag,
+    /// consumed by the pane that draws it. egui remembers each container's
+    /// state, so a single frame of forcing is enough to make it stick.
+    pub(in crate::app) expand_all: Option<bool>,
 }
 
 impl FieldEditContext<'_> {
@@ -491,6 +495,13 @@ impl FieldEditContext<'_> {
     /// stored state alone" (no filter applied this frame); `Some(open)` forces
     /// it this frame.
     pub(in crate::app) fn resolve_open(&self, node_path: &str, default_open: bool) -> Option<bool> {
+        // An explicit expand/collapse-all wins over everything: it is a direct
+        // instruction about this whole tag, issued this frame. Every container
+        // type -- groups, structs, blocks, arrays -- resolves its open state
+        // here, so this one line reaches all of them.
+        if self.expand_all.is_some() {
+            return self.expand_all;
+        }
         // A reference-jump forces every ancestor of its target field open so the
         // field can be scrolled into view. Takes precedence over the search filter.
         if let Some(nav) = self.field_nav {

--- a/src/app/state/prefs.rs
+++ b/src/app/state/prefs.rs
@@ -43,6 +43,57 @@ pub(in crate::app) enum HelpPanelTab {
     MapNames,
 }
 
+/// How nested containers in the tag editor start out.
+///
+/// `Schema` keeps each container's own judgement — top-level groups and
+/// priority sections open, deeply nested blocks closed — which suits browsing
+/// an unfamiliar tag. The other two override it outright for people who would
+/// rather always start from one end.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub(in crate::app) enum NestedDefault {
+    #[default]
+    Schema,
+    Collapsed,
+    Expanded,
+}
+
+impl NestedDefault {
+    pub(in crate::app) const ALL: [NestedDefault; 3] = [
+        NestedDefault::Schema,
+        NestedDefault::Collapsed,
+        NestedDefault::Expanded,
+    ];
+
+    pub(in crate::app) fn label(self) -> &'static str {
+        match self {
+            NestedDefault::Schema => "Default",
+            NestedDefault::Collapsed => "Collapsed",
+            NestedDefault::Expanded => "Expanded",
+        }
+    }
+
+    pub(in crate::app) fn help(self) -> &'static str {
+        match self {
+            NestedDefault::Schema => {
+                "Each group, struct and block decides for itself — top-level \
+                 sections open, deeply nested ones closed"
+            }
+            NestedDefault::Collapsed => "Every nested group, struct and block starts closed",
+            NestedDefault::Expanded => "Every nested group, struct and block starts open",
+        }
+    }
+
+    /// The starting open state for a container whose schema-derived default is
+    /// `schema_default`.
+    pub(in crate::app) fn applies_to(self, schema_default: bool) -> bool {
+        match self {
+            NestedDefault::Schema => schema_default,
+            NestedDefault::Collapsed => false,
+            NestedDefault::Expanded => true,
+        }
+    }
+}
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(in crate::app) enum SettingsTab {
     Startup,
@@ -156,6 +207,7 @@ impl SessionRestore {
 pub(in crate::app) struct GuiPrefs {
     pub(in crate::app) browser_mode: BrowserMode,
     pub(in crate::app) browser_sort: BrowserSort,
+    pub(in crate::app) nested_default: NestedDefault,
     pub(in crate::app) show_browser_prefixes: bool,
     pub(in crate::app) folders_before_tags: bool,
     pub(in crate::app) double_click_to_open_tags: bool,
@@ -186,6 +238,7 @@ impl Default for GuiPrefs {
         Self {
             browser_mode: BrowserMode::default(),
             browser_sort: BrowserSort::default(),
+            nested_default: NestedDefault::default(),
             show_browser_prefixes: false,
             folders_before_tags: false,
             double_click_to_open_tags: false,

--- a/src/app/style.rs
+++ b/src/app/style.rs
@@ -50,6 +50,9 @@ pub(super) fn foundation_visuals() -> egui::Visuals {
 /// separate font). Falls back to the regular family when no bold font is found.
 pub(super) const FOUNDATION_BOLD: &str = "foundation_bold";
 
+/// Name of the last-resort face appended to every family for glyph coverage.
+const GLYPH_FALLBACK: &str = "glyph_fallback";
+
 pub(super) fn foundation_fonts() -> FontDefinitions {
     let mut fonts = FontDefinitions::default();
     for path in [
@@ -68,6 +71,39 @@ pub(super) fn foundation_fonts() -> FontDefinitions {
                 .insert(0, "foundation_ui".to_owned());
             break;
         }
+    }
+
+    // Glyph fallback, appended *last* so it only supplies characters the fonts
+    // above lack — the UI keeps the face it already had.
+    //
+    // Without it the default family on macOS and Linux is Ubuntu-Light plus the
+    // two emoji fonts, and none of the three carry the arrows and geometric
+    // shapes the UI uses: the modified-tag dot rendered as a tofu box. Windows
+    // never showed it, because Segoe/Tahoma above is inserted at index 0 and
+    // has them all.
+    for path in [
+        // Verified to carry every glyph the UI uses that the defaults miss.
+        "/System/Library/Fonts/Supplemental/Arial Unicode.ttf",
+        "/System/Library/Fonts/Apple Symbols.ttf",
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+        "/usr/share/fonts/truetype/noto/NotoSansSymbols2-Regular.ttf",
+        "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
+        r"C:\Windows\Fonts\seguisym.ttf",
+    ] {
+        let Ok(bytes) = std::fs::read(path) else {
+            continue;
+        };
+        fonts
+            .font_data
+            .insert(GLYPH_FALLBACK.to_owned(), FontData::from_owned(bytes));
+        for family in [FontFamily::Proportional, FontFamily::Monospace] {
+            fonts
+                .families
+                .entry(family)
+                .or_default()
+                .push(GLYPH_FALLBACK.to_owned());
+        }
+        break;
     }
 
     // Bold face for headers (Foundation uses FontWeight=Bold). Try common

--- a/src/app/ui.rs
+++ b/src/app/ui.rs
@@ -389,7 +389,37 @@ impl Baboon {
                 self.launch_sapien();
             }
 
-            ui.separator();
+            // Campaign Evolved holds unsaved edits in a project rather than in
+            // the game's files, so a workspace accumulates stashed
+            // modifications across sessions. This is the way back to the
+            // shipped tags; it is drawn here, outside the workspace tree, so it
+            // always acts on the focused kit.
+            if self.current_source_is_campaign_project_capable(self.active) {
+                let stashed = self.stashed_campaign_tags(self.active);
+                let unsaved = self.kits[self.active]
+                    .parsed_tags
+                    .values()
+                    .filter(|document| document.dirty)
+                    .count();
+                let anything = !stashed.is_empty() || unsaved > 0;
+                let icon = button_icon_image(ui, ButtonIcon::Garbage, text_dark(), 16.0);
+                let response = ui.add_enabled(anything, egui::Button::image(icon));
+                if response
+                    .on_hover_text(
+                        "Clear this workspace's unsaved modifications, returning every tag to \
+                         the way the game ships it",
+                    )
+                    .on_disabled_hover_text("This workspace has no unsaved modifications")
+                    .clicked()
+                {
+                    self.clear_stash_confirm = Some(ClearStashConfirm {
+                        kit: self.active_kit_id(),
+                        stashed,
+                        unsaved,
+                    });
+                }
+                ui.separator();
+            }
             self.draw_editing_kit_shortcut_buttons(ui);
         });
     }

--- a/src/app/ui/browser_panel.rs
+++ b/src/app/ui/browser_panel.rs
@@ -53,6 +53,12 @@ impl Baboon {
         // below also borrows `self.kits[kit_index].filter`, `self.kits[kit_index].filter_cache`, and
         // `self.status`, and a method call would borrow all of `self`.
         let kit_id = self.kits[kit_index].id;
+        // Refreshed before the tree is drawn, and published into egui memory so
+        // the row and folder painters can reach it without threading it through
+        // every drawing function. The browsers draw one after another, so what
+        // is in memory during this tree's draw is this kit's own set.
+        self.refresh_modified_tags(kit_index);
+        set_browser_modified_tags(ui, std::sync::Arc::clone(&self.kits[kit_index].modified_tags));
         let kit = &mut self.kits[kit_index];
         if let Some(source) = kit.source.as_mut() {
             ui.add_space(8.0);

--- a/src/app/ui/dialogs.rs
+++ b/src/app/ui/dialogs.rs
@@ -448,6 +448,91 @@ impl Baboon {
     /// Destructive-save confirmation for Campaign Evolved container tags. Save
     /// overwrites the shipped pak files in place, so we always confirm and point
     /// the user at Export Mod as the non-destructive alternative.
+    /// Confirmation for the Campaign Evolved "clear modifications" action.
+    ///
+    /// It is irreversible and can drop work stashed in earlier sessions, so it
+    /// lists exactly what is about to go rather than asking in the abstract.
+    pub(super) fn draw_clear_stash_confirm_window(&mut self, ctx: &egui::Context) {
+        let Some(confirm) = self.clear_stash_confirm.as_ref() else {
+            return;
+        };
+        let kit = confirm.kit;
+        let stashed = confirm.stashed.clone();
+        let unsaved = confirm.unsaved;
+        let mut open = true;
+        let mut do_clear = false;
+        let mut cancel = false;
+        egui::Window::new("Clear unsaved modifications?")
+            .id(egui::Id::new("clear_stash_confirm"))
+            .open(&mut open)
+            .collapsible(false)
+            .resizable(false)
+            .default_width(520.0)
+            .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
+            .show(ctx, |ui| {
+                ui.label(
+                    RichText::new(
+                        "Every tag in this workspace goes back to the way the game ships it.",
+                    )
+                    .color(text_dark()),
+                );
+                ui.add_space(6.0);
+                if unsaved > 0 {
+                    let noun = if unsaved == 1 { "tag" } else { "tags" };
+                    ui.label(
+                        RichText::new(format!("{unsaved} open {noun} with unsaved edits"))
+                            .color(text_dark()),
+                    );
+                }
+                if !stashed.is_empty() {
+                    ui.add_space(4.0);
+                    ui.label(
+                        RichText::new(format!(
+                            "{} tag(s) stashed in this workspace's project, including any kept \
+                             from earlier sessions:",
+                            stashed.len()
+                        ))
+                        .color(text_dark()),
+                    );
+                    ui.add_space(4.0);
+                    egui::ScrollArea::vertical()
+                        .max_height(160.0)
+                        .show(ui, |ui| {
+                            for path in &stashed {
+                                ui.label(RichText::new(path).color(text_dark()).monospace().small());
+                            }
+                        });
+                }
+                ui.add_space(8.0);
+                ui.label(
+                    RichText::new(
+                        "This cannot be undone. Tags already saved into the game's pak files, \
+                         and mods you have already exported, are not affected.",
+                    )
+                    .color(egui::Color32::from_rgb(210, 120, 90)),
+                );
+                ui.add_space(10.0);
+                ui.horizontal(|ui| {
+                    if ui.button("Clear Modifications").clicked() {
+                        do_clear = true;
+                    }
+                    if ui.button("Cancel").clicked() {
+                        cancel = true;
+                    }
+                });
+            });
+        if !open || cancel {
+            self.clear_stash_confirm = None;
+        } else if do_clear {
+            self.clear_stash_confirm = None;
+            // Resolved rather than assumed: the workspace may have been closed
+            // while the confirmation was up.
+            if let Some(index) = self.resolve_kit(kit) {
+                self.clear_campaign_stash(index, ctx);
+            }
+        }
+    }
+
     pub(super) fn draw_overwrite_confirm_window(&mut self, ctx: &egui::Context) {
         let Some(key) = self.overwrite_confirm.clone() else {
             return;

--- a/src/app/ui/first_run.rs
+++ b/src/app/ui/first_run.rs
@@ -112,6 +112,9 @@ impl Baboon {
             }
         });
         ui.add_space(12.0);
+        ui.label(RichText::new("Tag editor").strong());
+        self.draw_nested_default_picker(ui);
+        ui.add_space(12.0);
         ui.label(RichText::new("Appearance").strong());
         ui.checkbox(&mut self.dark_mode, "Dark mode");
         ui.horizontal(|ui| {

--- a/src/app/ui/kit_tiles.rs
+++ b/src/app/ui/kit_tiles.rs
@@ -86,14 +86,7 @@ impl egui_tiles::Behavior<KitId> for KitPaneBehavior<'_> {
             return RichText::new("(closed)").color(subtle_dark()).into();
         };
         let kit = &self.app.kits[index];
-        // Stashed edits count as modifications too. They are not written into
-        // the game, and the tag holding them may not even be open, so without
-        // this a workspace carrying work from an earlier session looked clean.
-        let stashed = kit
-            .campaign_project
-            .as_ref()
-            .is_some_and(|project| !project.overlays.is_empty());
-        let dirty = stashed || kit.parsed_tags.values().any(|document| document.dirty);
+        let dirty = kit.has_unwritten_modifications();
         let label = kit_strip_label(kit);
         let text = if dirty {
             format!("• {label}")
@@ -189,12 +182,8 @@ impl egui_tiles::Behavior<KitId> for KitPaneBehavior<'_> {
     ) -> Color32 {
         let base = if state.active { menu_bar() } else { left_panel() };
         let dirty = matches!(tiles.get(tile_id), Some(egui_tiles::Tile::Pane(kit_id))
-            if self.app.kit_index(*kit_id).is_some_and(|index| {
-                self.app.kits[index]
-                    .parsed_tags
-                    .values()
-                    .any(|document| document.dirty)
-            }));
+            if self.app.kit_index(*kit_id)
+                .is_some_and(|index| self.app.kits[index].has_unwritten_modifications()));
         if dirty {
             tint_toward(base, Color32::from_rgb(184, 134, 11), 0.20)
         } else {

--- a/src/app/ui/kit_tiles.rs
+++ b/src/app/ui/kit_tiles.rs
@@ -86,7 +86,14 @@ impl egui_tiles::Behavior<KitId> for KitPaneBehavior<'_> {
             return RichText::new("(closed)").color(subtle_dark()).into();
         };
         let kit = &self.app.kits[index];
-        let dirty = kit.parsed_tags.values().any(|document| document.dirty);
+        // Stashed edits count as modifications too. They are not written into
+        // the game, and the tag holding them may not even be open, so without
+        // this a workspace carrying work from an earlier session looked clean.
+        let stashed = kit
+            .campaign_project
+            .as_ref()
+            .is_some_and(|project| !project.overlays.is_empty());
+        let dirty = stashed || kit.parsed_tags.values().any(|document| document.dirty);
         let label = kit_strip_label(kit);
         let text = if dirty {
             format!("• {label}")

--- a/src/app/ui/kit_tiles.rs
+++ b/src/app/ui/kit_tiles.rs
@@ -89,7 +89,7 @@ impl egui_tiles::Behavior<KitId> for KitPaneBehavior<'_> {
         let dirty = kit.parsed_tags.values().any(|document| document.dirty);
         let label = kit_strip_label(kit);
         let text = if dirty {
-            format!("● {label}")
+            format!("• {label}")
         } else {
             label
         };

--- a/src/app/ui/search_windows.rs
+++ b/src/app/ui/search_windows.rs
@@ -733,7 +733,7 @@ impl Baboon {
                 ui.horizontal(|ui| {
                     if indexed {
                         ui.label(
-                            RichText::new("● indexed — searches are instant")
+                            RichText::new("• indexed — searches are instant")
                                 .color(Color32::from_rgb(120, 170, 90))
                                 .small(),
                         );

--- a/src/app/ui/settings.rs
+++ b/src/app/ui/settings.rs
@@ -114,6 +114,26 @@ impl Baboon {
         );
     }
 
+    /// Radio row for how nested containers in the tag editor start out.
+    /// Shared by Settings and the first-run wizard so the two cannot drift.
+    pub(super) fn draw_nested_default_picker(&mut self, ui: &mut Ui) {
+        ui.label(RichText::new("Groups, structs and blocks start").color(text_dark()));
+        ui.horizontal(|ui| {
+            for option in NestedDefault::ALL {
+                ui.radio_value(&mut self.nested_default, option, option.label())
+                    .on_hover_text(option.help());
+            }
+        });
+        ui.label(
+            RichText::new(
+                "Applies to tags opened from now on. A group you open or close yourself keeps \
+                 the state you chose.",
+            )
+            .color(subtle_dark())
+            .small(),
+        );
+    }
+
     pub(super) fn draw_settings_browser_tab(&mut self, ui: &mut Ui) {
         ui.label(RichText::new("Browser").color(text_dark()).strong());
         ui.add_space(4.0);
@@ -125,6 +145,10 @@ impl Baboon {
             &mut self.folders_before_tags,
             "List subfolders before tags in browser",
         );
+        ui.add_space(12.0);
+        ui.label(RichText::new("Tag editor").color(text_dark()).strong());
+        ui.add_space(4.0);
+        self.draw_nested_default_picker(ui);
     }
 
     pub(super) fn draw_settings_editing_kits_tab(&mut self, ui: &mut Ui) {

--- a/src/app/ui/shell.rs
+++ b/src/app/ui/shell.rs
@@ -997,6 +997,7 @@ impl Baboon {
         self.draw_import_tag_window(ctx);
         self.draw_import_discard_confirm(ctx);
         self.draw_overwrite_confirm_window(ctx);
+        self.draw_clear_stash_confirm_window(ctx);
         self.draw_tag_conversion_window(ctx);
         self.draw_folder_conversion_window(ctx);
         self.draw_about_window(ctx);

--- a/src/app/ui/shell.rs
+++ b/src/app/ui/shell.rs
@@ -257,6 +257,58 @@ impl Baboon {
                             ui.close_menu();
                             self.redo_current_tag();
                         }
+                        ui.separator();
+                        // The same two actions as the tab context menu and the
+                        // toolbar, spelled out. An unlabelled trash icon among
+                        // the tool launchers is not where anyone looks for this.
+                        let selected = self.kits[self.active].selected_key.clone();
+                        let discardable = selected
+                            .as_deref()
+                            .is_some_and(|key| self.tag_has_discardable_changes(self.active, key));
+                        if ui
+                            .add_enabled(
+                                discardable,
+                                egui::Button::new("Discard Unsaved Changes"),
+                            )
+                            .on_hover_text(
+                                "Return the current tag to the way its source has it",
+                            )
+                            .clicked()
+                        {
+                            ui.close_menu();
+                            if let Some(key) = selected {
+                                self.discard_tag_changes(self.active, &key, ctx);
+                            }
+                        }
+                        if self.current_source_is_campaign_project_capable(self.active) {
+                            let stashed = self.stashed_campaign_tags(self.active);
+                            let unsaved = self.kits[self.active]
+                                .parsed_tags
+                                .values()
+                                .filter(|document| document.dirty)
+                                .count();
+                            if ui
+                                .add_enabled(
+                                    !stashed.is_empty() || unsaved > 0,
+                                    egui::Button::new("Clear All Unsaved Modifications..."),
+                                )
+                                .on_hover_text(
+                                    "Return every tag in this workspace to the way the game \
+                                     ships it, including edits stashed in earlier sessions",
+                                )
+                                .on_disabled_hover_text(
+                                    "This workspace has no unsaved modifications",
+                                )
+                                .clicked()
+                            {
+                                ui.close_menu();
+                                self.clear_stash_confirm = Some(ClearStashConfirm {
+                                    kit: self.active_kit_id(),
+                                    stashed,
+                                    unsaved,
+                                });
+                            }
+                        }
                     });
                     ui.menu_button("Tools", |ui| {
                         if ui.button("Run Tool...").clicked() {

--- a/src/app/ui/tag_pane.rs
+++ b/src/app/ui/tag_pane.rs
@@ -184,6 +184,16 @@ impl Baboon {
 
         // Snapshot for undo before a mutating batch. Coalesces continuous edits
         // into one entry; closes the window on frames with no edits.
+        // Every deferred op this pane collected, including the kinds the undo
+        // window below deliberately ignores. Used only to decide whether the
+        // frame needs redrawing.
+        let mutated = !pending.is_empty()
+            || !block_ops.is_empty()
+            || !shader_ops.is_empty()
+            || !shader_param_ops.is_empty()
+            || !h2_shader_param_ops.is_empty()
+            || !function_data_ops.is_empty()
+            || !model_variant_ops.is_empty();
         if !pending.is_empty()
             || !block_ops.is_empty()
             || !shader_ops.is_empty()
@@ -268,6 +278,14 @@ impl Baboon {
         }
 
         kit.parsed_tags.insert(key, doc);
+        // These ops are applied *after* the pane has been drawn, so the frame
+        // on screen still shows the tag as it was before the edit. egui only
+        // redraws when new input arrives, so nothing here is guaranteed to be
+        // visible until something else happens to wake the UI -- an added block
+        // element missing from that block's own instance selector, for one.
+        if mutated {
+            ctx.request_repaint();
+        }
 
         if let Some(key) = bitmap_reimport {
             self.begin_reimport_bitmap(key, ctx.clone());

--- a/src/app/ui/tag_pane.rs
+++ b/src/app/ui/tag_pane.rs
@@ -155,6 +155,7 @@ impl Baboon {
                 .as_ref()
                 .filter(|nav| nav.kit == kit_id && nav.tag_key == key),
             expand_all,
+            nested_default: self.nested_default,
         };
 
         if is_bitmap_tag(entry) {

--- a/src/app/ui/tag_pane.rs
+++ b/src/app/ui/tag_pane.rs
@@ -75,6 +75,10 @@ impl Baboon {
         let mut bitmap_reimport = None;
         let mut tsv_paste_request = None;
 
+        // Taken rather than read: it is a one-shot, and egui remembers the
+        // state each container lands in, so forcing it for a single frame is
+        // what makes it stick.
+        let expand_all = kit.pending_expand.remove(&key);
         let field_filter = compute_pending_field_filter(
             &doc.tag,
             supports_field_search,
@@ -150,6 +154,7 @@ impl Baboon {
                 .field_nav
                 .as_ref()
                 .filter(|nav| nav.kit == kit_id && nav.tag_key == key),
+            expand_all,
         };
 
         if is_bitmap_tag(entry) {

--- a/src/app/ui/tag_tiles.rs
+++ b/src/app/ui/tag_tiles.rs
@@ -20,6 +20,8 @@ struct TagPaneBehavior<'a> {
     /// the same reason closes are: they mutate the layout or the open set.
     reveal: Option<String>,
     discard: Option<String>,
+    /// Tag to expand or collapse throughout, and which of the two.
+    expand: Option<(String, bool)>,
     close_all: bool,
     close_all_but: Option<String>,
 }
@@ -155,6 +157,18 @@ impl egui_tiles::Behavior<String> for TagPaneBehavior<'_> {
                 .clicked()
             {
                 self.discard = Some(key.clone());
+                ui.close_menu();
+            }
+            ui.separator();
+            // Every container in the tag resolves its open state through one
+            // place, so these reach groups, structs, blocks and arrays alike,
+            // however deeply nested.
+            if ui.button("Expand all").clicked() {
+                self.expand = Some((key.clone(), true));
+                ui.close_menu();
+            }
+            if ui.button("Collapse all").clicked() {
+                self.expand = Some((key.clone(), false));
                 ui.close_menu();
             }
             ui.separator();
@@ -339,6 +353,7 @@ impl Baboon {
             focused: None,
             reveal: None,
             discard: None,
+            expand: None,
             close_all: false,
             close_all_but: None,
         };
@@ -347,6 +362,7 @@ impl Baboon {
         let focused = behavior.focused.take();
         let reveal = behavior.reveal.take();
         let discard = behavior.discard.take();
+        let expand = behavior.expand.take();
         let close_all = behavior.close_all;
         let close_all_but = behavior.close_all_but.take();
         self.kits[kit_index].tag_tree = tree;
@@ -375,6 +391,9 @@ impl Baboon {
         }
         if let Some(key) = discard {
             self.discard_tag_changes(kit_index, &key, ctx);
+        }
+        if let Some((key, open)) = expand {
+            self.kits[kit_index].pending_expand.insert(key, open);
         }
         if close_all {
             self.request_close_action(PendingCloseAction::CloseAllTabs, ctx);

--- a/src/app/ui/tag_tiles.rs
+++ b/src/app/ui/tag_tiles.rs
@@ -19,6 +19,7 @@ struct TagPaneBehavior<'a> {
     /// Deferred tab context-menu choices, applied after the tree is drawn for
     /// the same reason closes are: they mutate the layout or the open set.
     reveal: Option<String>,
+    discard: Option<String>,
     close_all: bool,
     close_all_but: Option<String>,
 }
@@ -130,9 +131,22 @@ impl egui_tiles::Behavior<String> for TagPaneBehavior<'_> {
             return button_response;
         };
         let key = key.clone();
+        let discardable = self.app.tag_has_discardable_changes(self.kit_index, &key);
         button_response.context_menu(|ui| {
             if ui.button("Reveal in browser").clicked() {
                 self.reveal = Some(key.clone());
+                ui.close_menu();
+            }
+            ui.separator();
+            // Offered for every game. For a loose kit this drops the in-memory
+            // edits and re-reads the file; for a container kit it also forgets
+            // what the project stashed, or the edit comes straight back.
+            if ui
+                .add_enabled(discardable, egui::Button::new("Discard unsaved changes"))
+                .on_disabled_hover_text("This tag has no unsaved changes")
+                .clicked()
+            {
+                self.discard = Some(key.clone());
                 ui.close_menu();
             }
             ui.separator();
@@ -316,6 +330,7 @@ impl Baboon {
             close_requests: Vec::new(),
             focused: None,
             reveal: None,
+            discard: None,
             close_all: false,
             close_all_but: None,
         };
@@ -323,6 +338,7 @@ impl Baboon {
         let close_requests = std::mem::take(&mut behavior.close_requests);
         let focused = behavior.focused.take();
         let reveal = behavior.reveal.take();
+        let discard = behavior.discard.take();
         let close_all = behavior.close_all;
         let close_all_but = behavior.close_all_but.take();
         self.kits[kit_index].tag_tree = tree;
@@ -335,6 +351,9 @@ impl Baboon {
         }
         if let Some(key) = reveal {
             self.reveal_in_browser(&key);
+        }
+        if let Some(key) = discard {
+            self.discard_tag_changes(kit_index, &key, ctx);
         }
         if close_all {
             self.request_close_action(PendingCloseAction::CloseAllTabs, ctx);

--- a/src/app/ui/tag_tiles.rs
+++ b/src/app/ui/tag_tiles.rs
@@ -96,7 +96,7 @@ impl egui_tiles::Behavior<String> for TagPaneBehavior<'_> {
             .map(tag_tab_label)
             .unwrap_or_else(|| pane.clone());
         let text = if dirty {
-            format!("● {label}")
+            format!("• {label}")
         } else {
             label
         };

--- a/src/source/loading.rs
+++ b/src/source/loading.rs
@@ -800,3 +800,98 @@ mod paks_dir_tests {
         let _ = std::fs::remove_dir_all(&root);
     }
 }
+
+#[cfg(test)]
+mod mod_export_tests {
+    use super::*;
+
+    const PAKS: &str = "/Users/camden/Halo/halo-campaign-evolved_pc/Meteorite/Content/Paks";
+
+    /// End-to-end check of what Export Mod actually writes, short of the game
+    /// loading it: take a real container tag, change a byte, write an override
+    /// container, then read the tag back out of that container.
+    ///
+    /// Reported as "it creates the pak but ingame nothing happens", and the
+    /// in-game load has never been verified on this machine — so this pins down
+    /// whether the artifact carries the edit at all.
+    #[test]
+    fn exported_mod_container_carries_the_edited_bytes() {
+        if !Path::new(PAKS).exists() {
+            eprintln!("skipping: {PAKS} not present");
+            return;
+        }
+        let defs = Path::new(env!("CARGO_MANIFEST_DIR")).join("definitions");
+        let names = TagNameIndex::load_from_definitions(&defs);
+        let loaded =
+            load_iostore_container_set(PathBuf::from(PAKS), &names, &defs).expect("mount");
+        let TagSource::IoStoreContainerSet { ref containers, .. } = loaded.source else {
+            panic!("expected a container set");
+        };
+
+        // A tag whose bytes we can perturb without changing its length, so the
+        // export takes the common same-size path.
+        let (container, rel_path, original) = loaded
+            .entries
+            .iter()
+            .find_map(|entry| match &entry.location {
+                TagEntryLocation::Container {
+                    container,
+                    rel_path,
+                } => {
+                    let archive = &containers.get(*container)?.archive;
+                    let bytes = archive.read(rel_path).ok()?;
+                    (bytes.len() > 64).then(|| (*container, rel_path.clone(), bytes))
+                }
+                _ => None,
+            })
+            .expect("a readable container tag");
+
+        let mut edited = original.clone();
+        let last = edited.len() - 1;
+        edited[last] ^= 0xFF;
+
+        let archive = containers[container].archive.clone();
+        let dir = std::env::temp_dir().join(format!("baboon-modexport-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let out = dir.join("mymod-WinGDK_P.utoc");
+        blam_tags::iostore::writer::write_mod_container_ex(
+            &[(archive.as_ref(), rel_path.as_str(), edited.as_slice())],
+            &[],
+            &out,
+        )
+        .expect("write override container");
+
+        // The game discovers containers by scanning `Paks/*.pak`, so all three
+        // files have to be there — a missing stub is a mod that never loads.
+        for ext in ["utoc", "ucas", "pak"] {
+            let path = out.with_extension(ext);
+            assert!(path.is_file(), "{} was not written", path.display());
+            eprintln!(
+                "{}: {} bytes",
+                path.file_name().unwrap().to_string_lossy(),
+                std::fs::metadata(&path).unwrap().len()
+            );
+        }
+
+        // An override container carries chunks by id with no directory index --
+        // the game resolves packages through the global store, not this TOC --
+        // so the payload is checked by chunk rather than by path. The chunk id
+        // itself is taken from the base archive when the override is built, so
+        // it matches the tag it is overriding by construction.
+        let reopened =
+            blam_tags::iostore::IoStoreArchive::open(&out).expect("reopen exported container");
+        assert_eq!(
+            reopened.chunk_count(),
+            1,
+            "a same-size override should be exactly one chunk"
+        );
+        let served = reopened.read_chunk(0).expect("read the override chunk");
+        assert_eq!(
+            served, edited,
+            "the exported container did not carry the edited bytes for {rel_path}"
+        );
+        assert_ne!(served, original, "the exported container carried the base bytes");
+        eprintln!("override verified for {rel_path} ({} bytes)", served.len());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}


### PR DESCRIPTION
Bug reports from users since v0.2.0, and what chasing them turned up.

## A block element was missing from its own selector

Reported as a palette entry not appearing in the vehicle block until the tag was saved, closed and reopened.

The model layer turned out to be innocent, and proving that took two passes: a first probe only resolved a root-level target block, where the ancestor walk short-circuits before it ever calls `root.descend`. The second walks a scenario for every block-index field at any depth, rebuilding the struct path the way the app does — `name#ordinal` segments — and adds an element to whatever block each field targets. **49 fields across the Halo 3 and Reach scenarios, all live.** A third checks the simpler claim across four editing kits: **400 root blocks, 201 of them empty, all grow.** Both are kept as characterization tests.

The cause was in the UI. A combo popup's `Area` and `ScrollArea` store their size in egui memory under the popup's id, and that remembered size becomes the space the content is laid out in. Once the list grew past the size the popup had when it was last open, it kept the old size and scrolled instead of growing — a stable state, not a one-frame lag, which is why it persisted. The id is keyed on `view_scope` and `tag_key`, and that is exactly why closing and reopening the tag cured it: the tag comes back in a new tile, so the popup gets a new id and fresh state. The item count is now part of the id, which retires that memory the moment the list changes.

Alongside it: popups grow to fit their items before scrolling (`combo_height` is a clamp, not a fixed height), both block dropdowns open on their selected row rather than at the top, and a pane requests a redraw after applying the deferred edits it collected while drawing — without it the frame on screen still showed the tag as it was before the edit, and egui had no reason to draw another.

## Closing a tag never asked to save

Upstream skipped the unsaved-changes prompt entirely for a container source, checkpointing the project instead on the grounds that it retains the edits. It does — but silently, and there was no way to decline. Overlays were only ever inserted, never removed, and no revert command existed anywhere, so an edit to a container tag could not be taken back: clearing a document's dirty flag left the stashed bytes behind and reopening the tag restored them.

The prompt is raised for container sources again, with a third choice. **Save** still overwrites the game's pak files in place. **Stash for Mod** keeps the edits in the workspace's project for Export Mod — what used to happen silently, now named and chosen. **Don't Save** forgets the overlay as well as the dirty flag, so it means what it says.

Two more ways out: tag tabs get "Discard unsaved changes" for every game (a loose kit re-reads the file, a container kit also forgets the stash), and a Campaign Evolved workspace can be cleared back to shipped tags from the Edit menu or the toolbar, behind a confirmation that lists what it is about to drop.

A prerequisite came first: `capture_campaign_project` and `load_campaign_overlay_for_key` both take a kit, then resolved every tag key through `entry_for_key`, which reads the *active* kit. Autosave runs for every kit, so a workspace in the background wrote a project containing none of its edits and could not restore the overlays it had.

## Edits did not survive a restart, and a built mod did nothing in game

Two causes, both on the writing side.

Loading a Campaign Evolved source built a *fresh* project with no overlays, and the first autosave — within a second of mounting — wrote that over the recovery file holding everything stashed earlier. The file was effectively write-only: only a session restore or File > Open Baboon Project ever read one back. It now adopts the file already at that path, checking the recorded source path rather than trusting the hash.

And Export Mod wrote a `.baboon` sidecar beside the exported mod, then repointed the workspace at it. Every later autosave went to a file next to the mod, the workspace's own recovery file stopped being updated, and the next launch adopted a stale one. The sidecar stays as an export artifact; the workspace keeps its own project.

A workspace tab now counts stashed overlays as modifications, so work from an earlier session is visible rather than reading as clean.

The export artifact itself is verified rather than assumed: a test flips a byte in a real container tag, writes an override container through the same `write_mod_container_ex` Export Mod calls, and reads the payload back. All three files are written, the `.pak` stub is 339 bytes — the same size as the game's own `pakchunk115-WinGDK.pak`, the stub-beside-a-real-ucas pattern this imitates — and the chunk carries the edited bytes, addressed by a chunk id taken from the base archive. Read back by chunk rather than by path, because an override container has no directory index: the game resolves packages through the global store.

## Tofu in the UI

The modified-tag marker rendered as a box. `FontDefinitions::default` on macOS and Linux is Ubuntu-Light plus the two emoji fonts, and none of the three carries U+25CF — nor six other characters the UI uses. Windows never showed it, because the Segoe/Tahoma face is inserted at index 0 and has them all.

A system face is appended *last* to the proportional and monospace families, so it only supplies glyphs the fonts above lack and the UI keeps the face it had. Candidates were checked with fonttools for coverage of exactly the missing characters rather than picked by reputation: Arial Unicode and Menlo carry all seven, Helvetica one. The dot itself becomes U+2022, which Ubuntu-Light has, so the most visible indicator renders even where no fallback face is present.

## Testing

`cargo test`: 325 passed, 0 failed. Three new tests carry real assertions — the two block-index characterizations and the mod-container round trip.

What the tests cannot reach needs a human, and none of it has been run:

- Stash on close, quit, reopen: the edits should come back and the workspace tab should show a dot.
- Discard from the tab menu and from Edit, then reopen the tag.
- Clear All Unsaved Modifications with two workspaces open.
- Export after a restart, and confirm the tag count in the status line.
- Whether an exported mod now loads in game. The container is verified to carry the right bytes, but nothing here proves the game mounts it, and that has never been confirmed on any machine.

Note this branch is cut from `main`, not from #28, and both touch `tag_tiles.rs` — whichever merges second needs a small conflict resolution there.
