### PR TITLE
Review a mod before exporting it

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -189,6 +189,8 @@ pub struct Baboon {
     clear_stash_confirm: Option<ClearStashConfirm>,
     /// Shown after Export Mod, explaining what to do with the files.
     exported_mod: Option<ExportedMod>,
+    /// Review of a pending Export Mod, before anything is written.
+    mod_export: Option<ModExportDialog>,
     about_open: bool,
     help_panel_tab: HelpPanelTab,
     help_docs: HelpDocsState,
@@ -387,6 +389,7 @@ impl Baboon {
             overwrite_confirm: None,
             clear_stash_confirm: None,
             exported_mod: None,
+            mod_export: None,
             about_open: false,
             help_panel_tab: HelpPanelTab::About,
             help_docs: HelpDocsState::load(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -269,7 +269,6 @@ pub struct Baboon {
     /// Modal close transaction; the pending action is executed only after every
     /// selected dirty document has been saved or discard is confirmed.
     save_changes_prompt: SaveChangesPrompt,
-    project_checkpoint_prompt: Option<ProjectCheckpointPrompt>,
     /// Startup-only prompt reconstructed from the prior session file.
     last_opened_windows: Option<LastOpenedWindowsPrompt>,
     /// Pending destructive block op (delete / delete all) awaiting confirm.
@@ -471,7 +470,6 @@ impl Baboon {
             saved_terminal_open_games: terminal_open_games.clone(),
             terminal_open_games,
             save_changes_prompt: SaveChangesPrompt::default(),
-            project_checkpoint_prompt: None,
             last_opened_windows,
             block_confirm: None,
             audio: audio::AudioState::default(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -187,6 +187,8 @@ pub struct Baboon {
     /// Pending confirmation for the Campaign Evolved "clear modifications"
     /// toolbar action, which is irreversible.
     clear_stash_confirm: Option<ClearStashConfirm>,
+    /// Shown after Export Mod, explaining what to do with the files.
+    exported_mod: Option<ExportedMod>,
     about_open: bool,
     help_panel_tab: HelpPanelTab,
     help_docs: HelpDocsState,
@@ -384,6 +386,7 @@ impl Baboon {
             import_discard_confirm: None,
             overwrite_confirm: None,
             clear_stash_confirm: None,
+            exported_mod: None,
             about_open: false,
             help_panel_tab: HelpPanelTab::About,
             help_docs: HelpDocsState::load(),

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -76,6 +76,17 @@ pub(in crate::app) fn added_text() -> Color32 {
     Color32::from_rgb(126, 186, 108)
 }
 
+/// Background wash behind the shipped side of a diff, and behind the edited
+/// side. Kept dark: the editor draws its own widgets on top, and a strong fill
+/// would fight them rather than frame them.
+pub(in crate::app) fn removed_wash() -> Color32 {
+    Color32::from_rgb(52, 30, 30)
+}
+
+pub(in crate::app) fn added_wash() -> Color32 {
+    Color32::from_rgb(28, 46, 32)
+}
+
 /// Colour for a value or element that is going away. Paired with a `-` marker,
 /// so red and green never carry the meaning by themselves.
 pub(in crate::app) fn removed_text() -> Color32 {

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -69,6 +69,13 @@ pub(in crate::app) fn browser_modified_tags(ui: &Ui) -> Option<std::sync::Arc<Mo
     ui.data(|data| data.get_temp::<std::sync::Arc<ModifiedTags>>(modified_tags_id()))
 }
 
+/// Colour for a tag that this workspace created, with no counterpart in the
+/// game. Paired with a `+` marker wherever it is used, so the meaning does not
+/// rest on colour alone.
+pub(in crate::app) fn added_text() -> Color32 {
+    Color32::from_rgb(126, 186, 108)
+}
+
 /// Colour for a tag or folder holding edits that are not written into the game.
 /// The same goldenrod the workspace tab is tinted with.
 pub(in crate::app) fn modified_text() -> Color32 {

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -76,6 +76,12 @@ pub(in crate::app) fn added_text() -> Color32 {
     Color32::from_rgb(126, 186, 108)
 }
 
+/// Colour for a value or element that is going away. Paired with a `-` marker,
+/// so red and green never carry the meaning by themselves.
+pub(in crate::app) fn removed_text() -> Color32 {
+    Color32::from_rgb(214, 106, 106)
+}
+
 /// Colour for a tag or folder holding edits that are not written into the game.
 /// The same goldenrod the workspace tab is tinted with.
 pub(in crate::app) fn modified_text() -> Color32 {

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -2461,7 +2461,7 @@ impl Baboon {
         Some(self.editing_kit_root()?.join("data"))
     }
 
-    fn open_folder_in_explorer(&mut self, path: PathBuf, label: &str) {
+    pub(super) fn open_folder_in_explorer(&mut self, path: PathBuf, label: &str) {
         if !path.is_dir() {
             self.status = format!("{label} folder not found: {}", path.display());
             return;
@@ -3328,6 +3328,15 @@ impl Baboon {
                         // recovery file and every tag opened as the game ships
                         // it -- the edits read as never having been saved.
                         let _ = self.checkpoint_campaign_project(exporting, 0.0);
+                        self.exported_mod = Some(ExportedMod {
+                            stem: stem.to_owned(),
+                            directory: output
+                                .parent()
+                                .map(Path::to_path_buf)
+                                .unwrap_or_default(),
+                            count,
+                            skipped,
+                        });
                         self.status = if skipped == 0 {
                             format!(
                                 "Exported {count} tag(s) → {stem}.utoc/.ucas/.pak/.baboon \

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -3308,7 +3308,51 @@ impl Baboon {
             name: "mymod".to_owned(),
             folder,
             overwrite_acknowledged: false,
+            expanded: HashSet::new(),
+            diffs: HashMap::new(),
         });
+    }
+
+    /// Compute the field differences for one reviewed tag, against the tag as
+    /// the game ships it.
+    ///
+    /// `read_entry` reads from the container, so the baseline is the shipped
+    /// tag rather than anything the workspace has stashed -- which is the
+    /// comparison the reviewer actually wants: what this mod changes about the
+    /// game, not what changed since the last autosave.
+    pub(super) fn diff_reviewed_tag(&self, kit: usize, identity: &str) -> ModRowDiff {
+        const LIMIT: usize = 5000;
+        let failed = |error: String| ModRowDiff {
+            rows: Vec::new(),
+            truncated: false,
+            error: Some(error),
+        };
+        let Some(dialog) = self.mod_export.as_ref() else {
+            return failed("The review is no longer open".to_owned());
+        };
+        let Some(overlay) = dialog.snapshot.overlays.get(identity) else {
+            return failed("This tag is no longer in the export".to_owned());
+        };
+        let Some(entry) = self.campaign_entry_for_identity(kit, identity) else {
+            return failed("This tag is no longer in the source".to_owned());
+        };
+        let Some(source) = self.kits.get(kit).and_then(|kit| kit.source.as_ref()) else {
+            return failed("No source loaded".to_owned());
+        };
+        let base = match crate::source::read_entry(&source.source, &entry) {
+            Ok(base) => base,
+            Err(error) => return failed(format!("Could not read the shipped tag: {error}")),
+        };
+        let edited = match TagFile::read_from_bytes(&overlay.bytes) {
+            Ok(edited) => edited,
+            Err(error) => return failed(format!("Could not read the edited tag: {error}")),
+        };
+        let (rows, truncated) = diff_tags(&base, &edited, &self.kits[kit].names, LIMIT);
+        ModRowDiff {
+            rows,
+            truncated,
+            error: None,
+        }
     }
 
     /// Write the reviewed mod. `included` are the identities the user kept.

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -1955,7 +1955,7 @@ impl Baboon {
     }
 
     pub(super) fn request_close_action(&mut self, action: PendingCloseAction, ctx: &egui::Context) {
-        if self.save_changes_prompt.visible || self.project_checkpoint_prompt.is_some() {
+        if self.save_changes_prompt.visible {
             return;
         }
         // The save prompt and every save path below it address documents by
@@ -5745,73 +5745,6 @@ impl Baboon {
                     self.save_changes_prompt.error = Some(message);
                 }
             }
-        }
-    }
-
-    pub(super) fn handle_project_checkpoint_prompt(&mut self, ctx: &egui::Context) {
-        let Some(prompt) = self.project_checkpoint_prompt.as_ref() else {
-            return;
-        };
-        let error = prompt.error.clone();
-        let mut retry = false;
-        let mut discard = false;
-        let mut cancel = false;
-        egui::Window::new("Campaign Project Checkpoint Failed")
-            .collapsible(false)
-            .resizable(false)
-            .anchor(egui::Align2::CENTER_CENTER, Vec2::ZERO)
-            .default_width(520.0)
-            .show(ctx, |ui| {
-                ui.label(
-                    RichText::new(
-                        "Baboon could not preserve the latest Campaign Evolved project state.",
-                    )
-                    .color(text_dark()),
-                );
-                ui.add_space(6.0);
-                ui.label(RichText::new(error).color(Color32::from_rgb(180, 48, 40)));
-                ui.add_space(8.0);
-                ui.label(
-                    RichText::new(
-                        "Retry the checkpoint, explicitly discard the uncheckpointed changes, \
-                         or cancel closing.",
-                    )
-                    .color(subtle_dark()),
-                );
-                ui.add_space(10.0);
-                ui.horizontal(|ui| {
-                    retry = ui.button("Retry").clicked();
-                    discard = ui.button("Discard and Close").clicked();
-                    cancel = ui.button("Cancel").clicked();
-                });
-            });
-        if retry {
-            let now = ctx.input(|input| input.time);
-            match self.checkpoint_campaign_project(self.active, now) {
-                Ok(_) => {
-                    let action = self
-                        .project_checkpoint_prompt
-                        .take()
-                        .expect("checkpoint prompt exists")
-                        .action;
-                    self.execute_close_action(action, ctx);
-                }
-                Err(error) => {
-                    if let Some(prompt) = self.project_checkpoint_prompt.as_mut() {
-                        prompt.error = error.clone();
-                    }
-                    self.status = format!("Could not checkpoint Campaign Evolved project: {error}");
-                }
-            }
-        } else if discard {
-            let action = self
-                .project_checkpoint_prompt
-                .take()
-                .expect("checkpoint prompt exists")
-                .action;
-            self.execute_close_action(action, ctx);
-        } else if cancel {
-            self.project_checkpoint_prompt = None;
         }
     }
 

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -3062,7 +3062,7 @@ impl Baboon {
                     .next()
                     .and_then(|f| f.strip_suffix(".ubulk"))
                     .unwrap_or("tag");
-                let Some(output) = pick_override_utoc(&format!("{stem}-WinGDK_P.utoc")) else {
+                let Some(output) = pick_override_utoc(&format!("{stem}_P.utoc")) else {
                     return Ok(None);
                 };
                 blam_tags::iostore::writer::write_tag_override(
@@ -3083,7 +3083,7 @@ impl Baboon {
                     .ok_or("could not derive source package path")?;
                 let new_pkg = format!("/Game/Tags/{new_rel}-{group}");
                 let leaf = new_rel.rsplit('/').next().unwrap_or("tag");
-                let Some(output) = pick_override_utoc(&format!("{leaf}-{group}-WinGDK_P.utoc"))
+                let Some(output) = pick_override_utoc(&format!("{leaf}-{group}_P.utoc"))
                 else {
                     return Ok(None);
                 };
@@ -3225,7 +3225,7 @@ impl Baboon {
             }
         };
         let leaf = package.rsplit('/').next().unwrap_or("tag");
-        let Some(output) = pick_override_utoc(&format!("{leaf}-WinGDK_P.utoc")) else {
+        let Some(output) = pick_override_utoc(&format!("{leaf}_P.utoc")) else {
             return;
         };
         match blam_tags::iostore::writer::write_new_tag_container(
@@ -3313,7 +3313,7 @@ impl Baboon {
             self.status = "No modified tags to export — edit a tag first".to_owned();
             return;
         }
-        let Some(mut output) = pick_override_utoc("mymod-WinGDK_P.utoc") else {
+        let Some(mut output) = pick_override_utoc("mymod_P.utoc") else {
             return;
         };
         if output.extension().is_none() {

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -3253,6 +3253,15 @@ impl Baboon {
     /// captured now and kept, so what the user reviews and what is written
     /// cannot drift apart between the two steps.
     pub(super) fn export_mod(&mut self) {
+        self.open_mod_review(false);
+    }
+
+    /// Review what this workspace is carrying, without exporting anything.
+    pub(super) fn review_changes(&mut self) {
+        self.open_mod_review(true);
+    }
+
+    fn open_mod_review(&mut self, review_only: bool) {
         let exporting = self.active;
         let snapshot = match self.capture_campaign_project(exporting, 0.0) {
             Ok(Some(snapshot)) => snapshot,
@@ -3303,6 +3312,7 @@ impl Baboon {
             .unwrap_or_default();
         self.mod_export = Some(ModExportDialog {
             kit: self.active_kit_id(),
+            review_only,
             snapshot,
             rows,
             name: "mymod".to_owned(),
@@ -3339,15 +3349,25 @@ impl Baboon {
         let Some(source) = self.kits.get(kit).and_then(|kit| kit.source.as_ref()) else {
             return failed("No source loaded".to_owned());
         };
+        let edited_tag = match TagFile::read_from_bytes(&overlay.bytes) {
+            Ok(edited) => edited,
+            Err(error) => return failed(format!("Could not read the edited tag: {error}")),
+        };
+        // A tag this workspace created has no shipped counterpart to compare
+        // against, so the whole tag is described instead.
+        if overlay.kind == CampaignProjectTagKind::New {
+            let (rows, truncated) = describe_tag(&edited_tag, &self.kits[kit].names, LIMIT);
+            return ModRowDiff {
+                rows,
+                truncated,
+                error: None,
+            };
+        }
         let base = match crate::source::read_entry(&source.source, &entry) {
             Ok(base) => base,
             Err(error) => return failed(format!("Could not read the shipped tag: {error}")),
         };
-        let edited = match TagFile::read_from_bytes(&overlay.bytes) {
-            Ok(edited) => edited,
-            Err(error) => return failed(format!("Could not read the edited tag: {error}")),
-        };
-        let (rows, truncated) = diff_tags(&base, &edited, &self.kits[kit].names, LIMIT);
+        let (rows, truncated) = diff_tags(&base, &edited_tag, &self.kits[kit].names, LIMIT);
         ModRowDiff {
             rows,
             truncated,

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -3292,6 +3292,7 @@ impl Baboon {
                 ModExportRow {
                     identity: overlay.identity.clone(),
                     display_path: overlay.logical_path.clone(),
+                    group_tag: overlay.group_tag,
                     kind,
                     include: kind != ModExportChange::Unresolved,
                     bytes: overlay.bytes.len(),
@@ -3334,6 +3335,8 @@ impl Baboon {
         const LIMIT: usize = 5000;
         let failed = |error: String| ModRowDiff {
             rows: Vec::new(),
+            base: None,
+            edited: None,
             truncated: false,
             error: Some(error),
         };
@@ -3359,6 +3362,8 @@ impl Baboon {
             let (rows, truncated) = describe_tag(&edited_tag, &self.kits[kit].names, LIMIT);
             return ModRowDiff {
                 rows,
+                base: None,
+                edited: Some(edited_tag),
                 truncated,
                 error: None,
             };
@@ -3370,6 +3375,8 @@ impl Baboon {
         let (rows, truncated) = diff_tags(&base, &edited_tag, &self.kits[kit].names, LIMIT);
         ModRowDiff {
             rows,
+            base: Some(base),
+            edited: Some(edited_tag),
             truncated,
             error: None,
         }

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -87,11 +87,17 @@ fn pick_override_utoc(default_name: &str) -> Option<PathBuf> {
 /// so the mod builds correctly and does nothing. That is not a naming
 /// preference to be respected -- a mod without it is simply broken -- and it is
 /// exactly what a user renaming the default to something meaningful drops.
+///
+/// Confirmed against the game's own mount path: it compares the last six
+/// characters to `_P.pak` case-insensitively and adds `100 × version` to the
+/// pak order, where the version defaults to 1 and only rises if the name
+/// carries `_<digits>_` before the suffix. A base pak scores 4, so any `_P`
+/// mod at 104 outranks it, and `_p` is accepted just as readily.
 fn ensure_priority_suffix(path: PathBuf) -> PathBuf {
     let Some(stem) = path.file_stem().and_then(|stem| stem.to_str()) else {
         return path;
     };
-    if stem.ends_with("_P") {
+    if stem.len() >= 2 && stem[stem.len() - 2..].eq_ignore_ascii_case("_p") {
         return path;
     }
     let extension = path
@@ -6095,10 +6101,17 @@ mod tests {
             ensure_priority_suffix(PathBuf::from("/mods/mymod-WinGDK_P.utoc")),
             PathBuf::from("/mods/mymod-WinGDK_P.utoc")
         );
-        // `_p` is not the same thing to the loader, so it is not treated as one.
+        // The loader folds case before comparing, so a lowercase suffix
+        // already has priority and must not collect a second one.
         assert_eq!(
             ensure_priority_suffix(PathBuf::from("/mods/thing_p.utoc")),
-            PathBuf::from("/mods/thing_p_P.utoc")
+            PathBuf::from("/mods/thing_p.utoc")
+        );
+        // A version before the suffix raises priority further; it is still a
+        // suffixed name and must be left alone.
+        assert_eq!(
+            ensure_priority_suffix(PathBuf::from("/mods/thing_2_P.utoc")),
+            PathBuf::from("/mods/thing_2_P.utoc")
         );
     }
 

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -3432,6 +3432,94 @@ impl Baboon {
         }
     }
 
+    /// Dump everything the review is working from into `folder`, so a diff
+    /// that looks wrong can be reproduced away from the UI.
+    ///
+    /// Writes the computed rows as JSON, and for every tag both sides as raw
+    /// bytes: the tag as the game ships it and the tag as this workspace has
+    /// it. Those two files are enough to re-run the comparison exactly.
+    pub(super) fn save_review_diagnostic(&mut self, folder: PathBuf) -> Result<usize, String> {
+        let Some(kit) = self
+            .mod_export
+            .as_ref()
+            .map(|dialog| dialog.kit)
+            .and_then(|kit| self.resolve_kit(kit))
+        else {
+            return Err("The review is no longer open".to_owned());
+        };
+        let identities: Vec<String> = self
+            .mod_export
+            .as_ref()
+            .map(|dialog| dialog.rows.iter().map(|row| row.identity.clone()).collect())
+            .unwrap_or_default();
+
+        let mut tags = Vec::new();
+        for identity in identities {
+            // Computed on demand, so a diagnostic does not depend on which rows
+            // the user happened to expand.
+            if !self
+                .mod_export
+                .as_ref()
+                .is_some_and(|dialog| dialog.diffs.contains_key(&identity))
+            {
+                let diff = self.diff_reviewed_tag(kit, &identity);
+                if let Some(dialog) = self.mod_export.as_mut() {
+                    dialog.diffs.insert(identity.clone(), diff);
+                }
+            }
+            let Some(dialog) = self.mod_export.as_ref() else {
+                break;
+            };
+            let Some(diff) = dialog.diffs.get(&identity) else {
+                continue;
+            };
+            let Some(row) = dialog.rows.iter().find(|row| row.identity == identity) else {
+                continue;
+            };
+            let stem: String = identity
+                .chars()
+                .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+                .collect();
+            for (suffix, tag) in [("base", diff.base.as_ref()), ("edited", diff.edited.as_ref())] {
+                let Some(tag) = tag else { continue };
+                let bytes = tag
+                    .write_to_bytes()
+                    .map_err(|error| format!("Could not serialize {identity}: {error}"))?;
+                std::fs::write(folder.join(format!("{stem}.{suffix}.tag")), bytes)
+                    .map_err(|error| format!("Could not write {stem}.{suffix}.tag: {error}"))?;
+            }
+            tags.push(serde_json::json!({
+                "identity": identity,
+                "path": row.display_path,
+                "kind": match row.kind {
+                    ModExportChange::New => "new",
+                    ModExportChange::Modified => "modified",
+                    ModExportChange::Unresolved => "unresolved",
+                },
+                "bytes": row.bytes,
+                "error": diff.error,
+                "truncated": diff.truncated,
+                "rows": diff
+                    .rows
+                    .iter()
+                    .map(|row| serde_json::json!({
+                        "path": row.path,
+                        "base_path": row.base_path,
+                        "before": row.a,
+                        "after": row.b,
+                    }))
+                    .collect::<Vec<_>>(),
+            }));
+        }
+        let count = tags.len();
+        let document = serde_json::json!({ "tags": tags });
+        let text = serde_json::to_string_pretty(&document)
+            .map_err(|error| format!("Could not encode the diagnostic: {error}"))?;
+        std::fs::write(folder.join("review-diagnostic.json"), text)
+            .map_err(|error| format!("Could not write review-diagnostic.json: {error}"))?;
+        Ok(count)
+    }
+
     /// Write the reviewed mod. `included` are the identities the user kept.
     pub(super) fn write_reviewed_mod(
         &mut self,

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -45,6 +45,41 @@ const ENTRY_INDEX_REFRESH_INTERVAL_SECS: f64 = 30.0;
 /// Normalize a user-entered container tag path: lowercase, `\`→`/`, collapse
 /// repeated slashes, and trim leading/trailing slashes and any tag extension.
 /// Yields the container-relative logical path (e.g. `objects/foo/bar`).
+/// Walk up from a resolved `Paks` directory to the folder a user would have
+/// picked to open it.
+///
+/// Sessions written before the chosen folder was recorded hold the inner path,
+/// and restoring from it remembers *that* as a recent folder -- so "Paks"
+/// reappeared after every restart however often it was removed. Walking up
+/// while the parent still resolves to the same directory undoes that without
+/// assuming a particular layout.
+fn install_root_for_paks(paks_dir: &Path) -> PathBuf {
+    // The two layouts `find_paks_dir` looks for directly, in its own order.
+    // Probing it instead would walk too far: it also *searches* four levels
+    // down, so distant ancestors resolve to this same directory and the walk
+    // would climb out of the install entirely.
+    for suffix in [
+        ["Meteorite", "Content", "Paks"].as_slice(),
+        ["Content", "Paks"].as_slice(),
+    ] {
+        let mut candidate = paks_dir;
+        let matched = suffix.iter().rev().all(|expected| {
+            let hit = candidate
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.eq_ignore_ascii_case(expected));
+            if hit && let Some(parent) = candidate.parent() {
+                candidate = parent;
+            }
+            hit
+        });
+        if matched {
+            return candidate.to_path_buf();
+        }
+    }
+    paks_dir.to_path_buf()
+}
+
 fn normalize_container_tag_rel(input: &str) -> String {
     let lowered = input.trim().replace('\\', "/").to_ascii_lowercase();
     let mut segments: Vec<&str> = lowered
@@ -2133,6 +2168,15 @@ impl Baboon {
                 (LastSessionSourceKind::IoStoreContainerSet, root.clone())
             }
         };
+        // Record the folder the user actually chose, not the directory the
+        // source ended up reading from. They differ for exactly the sources
+        // whose root is resolved inwards: a container set mounts from
+        // `<install>/Meteorite/Content/Paks`, and a loose kit from
+        // `<kit>/tags`. Storing the resolved one meant every session restore
+        // reloaded that inner path and remembered *it* as a recent folder, so
+        // "Paks" reappeared in the recents list after each restart however
+        // often it was removed.
+        let source_path = kit.requested_path.clone().unwrap_or(source_path);
         let mut tags = Vec::new();
         for key in ordered_unique_keys(kit.open_tabs.iter()) {
             let Some(entry) = source
@@ -2214,7 +2258,7 @@ impl Baboon {
                 // Upstream added container sources to the session format, so a
                 // Campaign Evolved install now comes back with the rest.
                 LastSessionSourceKind::IoStoreContainerSet => {
-                    self.begin_load_folder_path(source_path, ctx.clone())
+                    self.begin_load_folder_path(install_root_for_paks(&source_path), ctx.clone())
                 }
             }
             // The loaders route to a kit and leave it active, so this stages
@@ -6023,6 +6067,32 @@ mod tests {
     /// containers and loses, so it builds correctly and does nothing. Renaming
     /// the default to something meaningful is exactly how it gets dropped --
     /// which is how one was reported.
+    /// A session written before the chosen folder was recorded holds the
+    /// resolved `Paks` directory. Restoring from it put that directory back
+    /// into the recents list on every launch, which is how "Paks" kept
+    /// reappearing however often it was removed.
+    #[test]
+    fn a_paks_directory_walks_back_up_to_the_opened_folder() {
+        let root = std::env::temp_dir().join(format!("baboon-paks-{}", std::process::id()));
+        let paks = root.join("Meteorite").join("Content").join("Paks");
+        std::fs::create_dir_all(&paks).unwrap();
+        // `find_paks_dir` needs a container present to recognise the folder.
+        std::fs::write(paks.join("pakchunk0-WinGDK.utoc"), []).unwrap();
+
+        assert_eq!(super::install_root_for_paks(&paks), root);
+        // Already the opened folder: nothing to strip.
+        assert_eq!(super::install_root_for_paks(&root), root);
+        // The shorter layout the resolver also accepts.
+        assert_eq!(
+            super::install_root_for_paks(&root.join("Content").join("Paks")),
+            root
+        );
+        // An unfamiliar layout is left exactly as it is rather than guessed at.
+        let odd = root.join("somewhere").join("Paks");
+        assert_eq!(super::install_root_for_paks(&odd), odd);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
     #[test]
     fn a_mod_always_gets_the_priority_suffix() {
         assert_eq!(

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -3247,6 +3247,11 @@ impl Baboon {
 
     /// Bundle every modified Campaign Evolved project tag into one portable `_P`
     /// overlay and write its `.baboon` recovery project beside the triplet.
+    /// Open the review of what Export Mod would write.
+    ///
+    /// Nothing is written and no destination is chosen here. The snapshot is
+    /// captured now and kept, so what the user reviews and what is written
+    /// cannot drift apart between the two steps.
     pub(super) fn export_mod(&mut self) {
         let exporting = self.active;
         let snapshot = match self.capture_campaign_project(exporting, 0.0) {
@@ -3260,6 +3265,60 @@ impl Baboon {
                 return;
             }
         };
+        let mut rows: Vec<ModExportRow> = snapshot
+            .overlays
+            .values()
+            .map(|overlay| {
+                // An overlay whose tag no longer resolves cannot be written.
+                // That was previously counted into a status line and dropped;
+                // it is a row here, so it is at least visible.
+                let resolvable = self
+                    .campaign_entry_for_identity(exporting, &overlay.identity)
+                    .is_some();
+                let kind = match (resolvable, overlay.kind) {
+                    (false, _) => ModExportChange::Unresolved,
+                    (true, CampaignProjectTagKind::New) => ModExportChange::New,
+                    (true, CampaignProjectTagKind::Existing) => ModExportChange::Modified,
+                };
+                ModExportRow {
+                    identity: overlay.identity.clone(),
+                    display_path: overlay.logical_path.clone(),
+                    kind,
+                    include: kind != ModExportChange::Unresolved,
+                    bytes: overlay.bytes.len(),
+                    reason: (kind == ModExportChange::Unresolved)
+                        .then(|| "not in this source".to_owned()),
+                }
+            })
+            .collect();
+        rows.sort_by(|a, b| a.display_path.cmp(&b.display_path));
+
+        // The container source's root is already the game's `Paks` directory,
+        // so a mod exported straight there needs no copying at all.
+        let folder = self
+            .kits[exporting]
+            .source
+            .as_ref()
+            .map(|source| source.source.root_path().to_path_buf())
+            .unwrap_or_default();
+        self.mod_export = Some(ModExportDialog {
+            kit: self.active_kit_id(),
+            snapshot,
+            rows,
+            name: "mymod".to_owned(),
+            folder,
+            overwrite_acknowledged: false,
+        });
+    }
+
+    /// Write the reviewed mod. `included` are the identities the user kept.
+    pub(super) fn write_reviewed_mod(
+        &mut self,
+        snapshot: &CampaignProjectSnapshot,
+        included: &HashSet<String>,
+        output: PathBuf,
+    ) {
+        let exporting = self.active;
         let Some(source) = self.source() else {
             self.status = "No source loaded".to_owned();
             return;
@@ -3273,6 +3332,9 @@ impl Baboon {
         let mut new_pkgs: Vec<(Vec<u8>, Vec<u8>, String)> = Vec::new();
         let mut skipped = 0usize;
         for overlay in snapshot.overlays.values() {
+            if !included.contains(&overlay.identity) {
+                continue;
+            }
             let Some(entry) = self.campaign_entry_for_identity(exporting, &overlay.identity) else {
                 skipped += 1;
                 continue;
@@ -3283,11 +3345,7 @@ impl Baboon {
                         skipped += 1;
                         continue;
                     };
-                    overrides.push((
-                        m.archive.clone(),
-                        rel_path.clone(),
-                        overlay.bytes.clone(),
-                    ));
+                    overrides.push((m.archive.clone(), rel_path.clone(), overlay.bytes.clone()));
                 }
                 TagEntryLocation::NewContainer {
                     template_container,
@@ -3310,14 +3368,8 @@ impl Baboon {
         }
         let count = overrides.len() + new_pkgs.len();
         if count == 0 {
-            self.status = "No modified tags to export — edit a tag first".to_owned();
+            self.status = "Nothing selected to export".to_owned();
             return;
-        }
-        let Some(mut output) = pick_override_utoc("mymod_P.utoc") else {
-            return;
-        };
-        if output.extension().is_none() {
-            output.set_extension("utoc");
         }
         let override_refs: Vec<(&blam_tags::iostore::IoStoreArchive, &str, &[u8])> = overrides
             .iter()
@@ -3332,53 +3384,41 @@ impl Baboon {
                 redirect_from: None,
             })
             .collect();
-        match blam_tags::iostore::writer::write_mod_container_ex(&override_refs, &new_refs, &output) {
+        match blam_tags::iostore::writer::write_mod_container_ex(&override_refs, &new_refs, &output)
+        {
             Ok(()) => {
-                let stem = output.file_stem().and_then(|s| s.to_str()).unwrap_or("mod");
+                let stem = output
+                    .file_stem()
+                    .and_then(|stem| stem.to_str())
+                    .unwrap_or("mod")
+                    .to_owned();
                 let sidecar = output.with_extension("baboon");
-                match save_campaign_project(&sidecar, &snapshot) {
-                    Ok(()) => {
-                        // The sidecar is an export artifact: a copy that travels
-                        // with the mod so it can be resumed or shared. The
-                        // workspace keeps its own project.
-                        //
-                        // Repointing it here sent every later autosave to a file
-                        // beside the exported mod, wherever the user put that,
-                        // and the workspace's own recovery file stopped being
-                        // updated. The next launch then adopted the stale
-                        // recovery file and every tag opened as the game ships
-                        // it -- the edits read as never having been saved.
-                        let _ = self.checkpoint_campaign_project(exporting, 0.0);
-                        self.exported_mod = Some(ExportedMod {
-                            stem: stem.to_owned(),
-                            directory: output
-                                .parent()
-                                .map(Path::to_path_buf)
-                                .unwrap_or_default(),
-                            count,
-                            skipped,
-                        });
-                        self.status = if skipped == 0 {
-                            format!(
-                                "Exported {count} tag(s) → {stem}.utoc/.ucas/.pak/.baboon \
-                                 (base game unchanged)"
-                            )
-                        } else {
-                            format!(
-                                "Exported {count} tag(s) with .baboon recovery; skipped {skipped} \
-                                 unresolved project tag(s)"
-                            )
-                        };
-                    }
-                    Err(error) => {
-                        self.status = format!(
-                            "Exported {count} tag(s) to {stem}.utoc/.ucas/.pak, but the .baboon \
-                             recovery file failed: {error}"
-                        );
-                    }
+                if let Err(error) = save_campaign_project(&sidecar, snapshot) {
+                    self.status = format!(
+                        "Exported {count} tag(s), but the .baboon sidecar failed: {error}"
+                    );
+                }
+                // The sidecar travels with the mod; the workspace keeps its own
+                // project, checkpointed here so it carries what the export did.
+                let _ = self.checkpoint_campaign_project(exporting, 0.0);
+                let directory = output.parent().map(Path::to_path_buf).unwrap_or_default();
+                let in_place = self
+                    .source()
+                    .map(|source| source.source.root_path() == directory)
+                    .unwrap_or(false);
+                self.status = format!("Exported {count} tag(s) as {stem}");
+                // Written straight into the game's own folder: there is nothing
+                // to copy, so the instructions would only be noise.
+                if !in_place {
+                    self.exported_mod = Some(ExportedMod {
+                        stem,
+                        directory,
+                        count,
+                        skipped,
+                    });
                 }
             }
-            Err(e) => self.status = format!("Export Mod failed: {e}"),
+            Err(error) => self.status = format!("Export Mod failed: {error}"),
         }
     }
 

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -77,7 +77,28 @@ fn pick_override_utoc(default_name: &str) -> Option<PathBuf> {
     if output.extension().is_none() {
         output.set_extension("utoc");
     }
-    Some(output)
+    Some(ensure_priority_suffix(output))
+}
+
+/// Force the `_P` suffix onto a mod's file name.
+///
+/// It is what gives an override container priority over the game's own
+/// containers; without it the mod mounts alongside them and the base tag wins,
+/// so the mod builds correctly and does nothing. That is not a naming
+/// preference to be respected -- a mod without it is simply broken -- and it is
+/// exactly what a user renaming the default to something meaningful drops.
+fn ensure_priority_suffix(path: PathBuf) -> PathBuf {
+    let Some(stem) = path.file_stem().and_then(|stem| stem.to_str()) else {
+        return path;
+    };
+    if stem.ends_with("_P") {
+        return path;
+    }
+    let extension = path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .unwrap_or("utoc");
+    path.with_file_name(format!("{stem}_P.{extension}"))
 }
 
 #[cfg(any(windows, test))]
@@ -5945,6 +5966,31 @@ fn render_last_opened_windows_prompt(
 
 #[cfg(test)]
 mod tests {
+    use super::ensure_priority_suffix;
+    use std::path::PathBuf;
+
+    /// A mod without `_P` mounts at the same priority as the game's own
+    /// containers and loses, so it builds correctly and does nothing. Renaming
+    /// the default to something meaningful is exactly how it gets dropped --
+    /// which is how one was reported.
+    #[test]
+    fn a_mod_always_gets_the_priority_suffix() {
+        assert_eq!(
+            ensure_priority_suffix(PathBuf::from("/mods/h2a_magnum.utoc")),
+            PathBuf::from("/mods/h2a_magnum_P.utoc")
+        );
+        // Already correct, including the platform suffix the game itself uses.
+        assert_eq!(
+            ensure_priority_suffix(PathBuf::from("/mods/mymod-WinGDK_P.utoc")),
+            PathBuf::from("/mods/mymod-WinGDK_P.utoc")
+        );
+        // `_p` is not the same thing to the loader, so it is not treated as one.
+        assert_eq!(
+            ensure_priority_suffix(PathBuf::from("/mods/thing_p.utoc")),
+            PathBuf::from("/mods/thing_p_P.utoc")
+        );
+    }
+
     use super::*;
 
     #[test]

--- a/src/app/editor/diff.rs
+++ b/src/app/editor/diff.rs
@@ -83,6 +83,43 @@ fn align_by_identity(
     Some(pairs)
 }
 
+/// The matched pairs whose element moved, as indices into `matched`.
+///
+/// Reordering a block changes nothing inside any element, so a diff that only
+/// reports fields says nothing happened -- while the exported tag is genuinely
+/// different, and for a palette the difference matters a great deal: block
+/// index fields elsewhere name elements by position, so moving one silently
+/// repoints every reference to it.
+///
+/// Only the smallest set that explains the reordering is reported. Everything
+/// on the longest increasing run of destination indices stayed in relative
+/// order and did not move; inserting an element shifts the ones below it
+/// without reordering anything, and must not light them all up.
+fn moved_pairs(matched: &[(usize, usize)]) -> Vec<usize> {
+    // Longest increasing subsequence over the destination indices, by patience
+    // sorting, reconstructed through predecessor links.
+    let mut piles: Vec<usize> = Vec::new();
+    let mut previous = vec![usize::MAX; matched.len()];
+    for (i, &(_, bi)) in matched.iter().enumerate() {
+        let at = piles.partition_point(|&p| matched[p].1 < bi);
+        if at > 0 {
+            previous[i] = piles[at - 1];
+        }
+        if at == piles.len() {
+            piles.push(i);
+        } else {
+            piles[at] = i;
+        }
+    }
+    let mut kept = vec![false; matched.len()];
+    let mut cursor = piles.last().copied();
+    while let Some(i) = cursor {
+        kept[i] = true;
+        cursor = (previous[i] != usize::MAX).then_some(previous[i]);
+    }
+    (0..matched.len()).filter(|&i| !kept[i]).collect()
+}
+
 /// The identity an element is matched on: whatever names it to a reader.
 fn element_identity(element: Option<TagStruct<'_>>, names: &TagNameIndex) -> Option<String> {
     foundation::block_element_content_label(element?, names)
@@ -114,6 +151,27 @@ fn diff_structs(
                     .map(|i| ((i < ba.len()).then_some(i), (i < bb.len()).then_some(i)))
                     .collect()
             });
+            // Reported before the per-element diffs so a reorder reads as a
+            // property of the block rather than of one element in it.
+            let matched: Vec<(usize, usize)> = pairs
+                .iter()
+                .filter_map(|(x, y)| Some(((*x)?, (*y)?)))
+                .collect();
+            for index in moved_pairs(&matched) {
+                if out.len() > limit {
+                    return;
+                }
+                let (ai, bi) = matched[index];
+                let label = ids_b[bi]
+                    .clone()
+                    .or_else(|| ids_a[ai].clone())
+                    .unwrap_or_else(|| format!("element {ai}"));
+                out.push(TagFieldDiff {
+                    path: format!("{field_path}[{bi}]"),
+                    a: format!("position {ai}"),
+                    b: format!("moved to {bi} — {label}"),
+                });
+            }
             for (ai, bi) in pairs {
                 if out.len() > limit {
                     return;
@@ -177,6 +235,23 @@ fn diff_structs(
             }
         } else if let (Some(sa), Some(sb)) = (fa.as_struct(), fb.as_struct()) {
             diff_structs(&sa, &sb, &field_path, names, out, limit);
+        } else if let (Some(da), Some(db)) = (fa.as_data(), fb.as_data()) {
+            // Raw data fields -- function curves, shader source, import info --
+            // are edited through their own editors and land in an exported mod
+            // like any other change. They have no readable form here, but a
+            // preview that omits them entirely is worse than one that says only
+            // that they moved.
+            if da != db {
+                out.push(TagFieldDiff {
+                    path: field_path,
+                    a: format!("{} bytes", da.len()),
+                    b: if da.len() == db.len() {
+                        format!("{} bytes, contents differ", db.len())
+                    } else {
+                        format!("{} bytes", db.len())
+                    },
+                });
+            }
         } else if let (Some(va), Some(vb)) = (fa.value(), fb.value()) {
             let ta = foundation::format_foundation_scalar_value(names, &va);
             let tb = foundation::format_foundation_scalar_value(names, &vb);
@@ -295,6 +370,38 @@ mod alignment_tests {
         assert!(align_by_identity(&ids(&["a", "b"]), &ids(&["a", "a"])).is_none());
         assert!(align_by_identity(&[None, Some("a".into())], &ids(&["a", "b"])).is_none());
         assert!(align_by_identity(&[], &[]).is_some(), "two empty blocks align trivially");
+    }
+
+    /// An insertion shifts everything below it without reordering anything.
+    /// Reporting those as moved would undo the point of matching by identity.
+    #[test]
+    fn an_insertion_moves_nothing() {
+        // a: warthog ghost banshee -> b: scorpion warthog ghost banshee
+        let matched = [(0, 1), (1, 2), (2, 3)];
+        assert!(super::moved_pairs(&matched).is_empty());
+    }
+
+    /// One element pulled to the front is one move, not three.
+    #[test]
+    fn a_reorder_reports_only_what_actually_moved() {
+        // a: warthog ghost banshee -> b: banshee warthog ghost
+        let matched = [(0, 1), (1, 2), (2, 0)];
+        let moved = super::moved_pairs(&matched);
+        assert_eq!(moved.len(), 1, "only banshee moved: {moved:?}");
+        assert_eq!(matched[moved[0]], (2, 0));
+    }
+
+    #[test]
+    fn an_unchanged_block_reports_no_moves() {
+        assert!(super::moved_pairs(&[(0, 0), (1, 1), (2, 2)]).is_empty());
+        assert!(super::moved_pairs(&[]).is_empty());
+    }
+
+    /// A full reversal cannot be explained by fewer moves than this.
+    #[test]
+    fn a_reversal_keeps_one_element_still() {
+        let matched = [(0, 3), (1, 2), (2, 1), (3, 0)];
+        assert_eq!(super::moved_pairs(&matched).len(), 3);
     }
 
     #[test]

--- a/src/app/editor/diff.rs
+++ b/src/app/editor/diff.rs
@@ -16,6 +16,78 @@ pub(in crate::app) fn diff_tags(
     (out, truncated)
 }
 
+/// Pair up two blocks' elements before diffing them.
+///
+/// Returns `None` when the elements carry no usable identity, leaving the
+/// caller to pair them positionally. Positional pairing is only right when
+/// nothing was inserted or removed: insert one element at the top of a block
+/// and every element after it reads as rewritten, which is the difference
+/// between a diff worth reading and a screen of noise.
+///
+/// Identities have to be present and distinct on *both* sides to be trusted.
+/// Half-identified elements would pair some rows by name and the rest by
+/// position, which is harder to reason about than either rule alone.
+fn align_by_identity(
+    a: &[Option<String>],
+    b: &[Option<String>],
+) -> Option<Vec<(Option<usize>, Option<usize>)>> {
+    let usable = |ids: &[Option<String>]| {
+        let named: Vec<&String> = ids.iter().flatten().collect();
+        named.len() == ids.len() && {
+            let mut seen = HashSet::new();
+            named.iter().all(|id| seen.insert(*id))
+        }
+    };
+    if !usable(a) || !usable(b) {
+        return None;
+    }
+    let index_in_b: HashMap<&String, usize> = b
+        .iter()
+        .enumerate()
+        .filter_map(|(index, id)| id.as_ref().map(|id| (id, index)))
+        .collect();
+    let matched: HashMap<usize, usize> = a
+        .iter()
+        .enumerate()
+        .filter_map(|(ai, id)| {
+            let id = id.as_ref()?;
+            index_in_b.get(id).map(|&bi| (ai, bi))
+        })
+        .collect();
+    let matched_b: HashSet<usize> = matched.values().copied().collect();
+
+    // Walked in the edited tag's order, so the diff reads the way the tag now
+    // does, with removals shown at the point they were taken from.
+    let mut pairs = Vec::new();
+    let mut next_b = 0usize;
+    for (ai, _) in a.iter().enumerate() {
+        match matched.get(&ai) {
+            Some(&bi) => {
+                while next_b < bi {
+                    if !matched_b.contains(&next_b) {
+                        pairs.push((None, Some(next_b)));
+                    }
+                    next_b += 1;
+                }
+                pairs.push((Some(ai), Some(bi)));
+                next_b = bi + 1;
+            }
+            None => pairs.push((Some(ai), None)),
+        }
+    }
+    for bi in next_b..b.len() {
+        if !matched_b.contains(&bi) {
+            pairs.push((None, Some(bi)));
+        }
+    }
+    Some(pairs)
+}
+
+/// The identity an element is matched on: whatever names it to a reader.
+fn element_identity(element: Option<TagStruct<'_>>, names: &TagNameIndex) -> Option<String> {
+    foundation::block_element_content_label(element?, names)
+}
+
 fn diff_structs(
     a: &TagStruct<'_>,
     b: &TagStruct<'_>,
@@ -30,20 +102,73 @@ fn diff_structs(
         }
         let field_path = append_field_path(path, fa.name());
         if let (Some(ba), Some(bb)) = (fa.as_block(), fb.as_block()) {
-            if ba.len() != bb.len() {
-                out.push(TagFieldDiff {
-                    path: field_path.clone(),
-                    a: format!("{} element(s)", ba.len()),
-                    b: format!("{} element(s)", bb.len()),
-                });
-            }
-            for i in 0..ba.len().min(bb.len()) {
-                let (Some(ea), Some(eb)) = (ba.element(i), bb.element(i)) else {
-                    continue;
-                };
-                diff_structs(&ea, &eb, &format!("{field_path}[{i}]"), names, out, limit);
+            let ids_a: Vec<Option<String>> = (0..ba.len())
+                .map(|i| element_identity(ba.element(i), names))
+                .collect();
+            let ids_b: Vec<Option<String>> = (0..bb.len())
+                .map(|i| element_identity(bb.element(i), names))
+                .collect();
+            // Without usable identities there is nothing better than position.
+            let pairs = align_by_identity(&ids_a, &ids_b).unwrap_or_else(|| {
+                (0..ba.len().max(bb.len()))
+                    .map(|i| ((i < ba.len()).then_some(i), (i < bb.len()).then_some(i)))
+                    .collect()
+            });
+            for (ai, bi) in pairs {
+                if out.len() > limit {
+                    return;
+                }
+                match (ai, bi) {
+                    (Some(ai), Some(bi)) => {
+                        let (Some(ea), Some(eb)) = (ba.element(ai), bb.element(bi)) else {
+                            continue;
+                        };
+                        diff_structs(&ea, &eb, &format!("{field_path}[{bi}]"), names, out, limit);
+                    }
+                    // An added or removed element is reported with its
+                    // contents: "one more element" says nothing about what is
+                    // actually being shipped.
+                    (None, Some(bi)) => {
+                        let label = ids_b[bi].clone().unwrap_or_else(|| format!("element {bi}"));
+                        out.push(TagFieldDiff {
+                            path: format!("{field_path}[{bi}]"),
+                            a: String::new(),
+                            b: format!("added — {label}"),
+                        });
+                        if let Some(element) = bb.element(bi) {
+                            dump_struct(
+                                &element,
+                                &format!("{field_path}[{bi}]"),
+                                names,
+                                out,
+                                limit,
+                                true,
+                            );
+                        }
+                    }
+                    (Some(ai), None) => {
+                        let label = ids_a[ai].clone().unwrap_or_else(|| format!("element {ai}"));
+                        out.push(TagFieldDiff {
+                            path: format!("{field_path}[{ai}]"),
+                            a: format!("removed — {label}"),
+                            b: String::new(),
+                        });
+                        if let Some(element) = ba.element(ai) {
+                            dump_struct(
+                                &element,
+                                &format!("{field_path}[{ai}]"),
+                                names,
+                                out,
+                                limit,
+                                false,
+                            );
+                        }
+                    }
+                    (None, None) => {}
+                }
             }
         } else if let (Some(aa), Some(ab)) = (fa.as_array(), fb.as_array()) {
+            // Arrays are fixed-count, so their elements always correspond.
             for i in 0..aa.len().min(ab.len()) {
                 let (Some(ea), Some(eb)) = (aa.element(i), ab.element(i)) else {
                     continue;
@@ -63,5 +188,120 @@ fn diff_structs(
                 });
             }
         }
+    }
+}
+
+/// Emit every scalar in a struct that has no counterpart, so an added or
+/// removed element shows what it actually contains.
+fn dump_struct(
+    st: &TagStruct<'_>,
+    path: &str,
+    names: &TagNameIndex,
+    out: &mut Vec<TagFieldDiff>,
+    limit: usize,
+    added: bool,
+) {
+    for field in st.fields_all() {
+        if out.len() > limit {
+            return;
+        }
+        let field_path = append_field_path(path, field.name());
+        if let Some(block) = field.as_block() {
+            for i in 0..block.len() {
+                if let Some(element) = block.element(i) {
+                    dump_struct(&element, &format!("{field_path}[{i}]"), names, out, limit, added);
+                }
+            }
+        } else if let Some(array) = field.as_array() {
+            for i in 0..array.len() {
+                if let Some(element) = array.element(i) {
+                    dump_struct(&element, &format!("{field_path}[{i}]"), names, out, limit, added);
+                }
+            }
+        } else if let Some(inner) = field.as_struct() {
+            dump_struct(&inner, &field_path, names, out, limit, added);
+        } else if let Some(value) = field.value() {
+            let text = foundation::format_foundation_scalar_value(names, &value);
+            out.push(TagFieldDiff {
+                path: field_path,
+                a: if added { String::new() } else { text.clone() },
+                b: if added { text } else { String::new() },
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+mod alignment_tests {
+    use super::align_by_identity;
+
+    fn ids(names: &[&str]) -> Vec<Option<String>> {
+        names.iter().map(|n| Some((*n).to_owned())).collect()
+    }
+
+    /// The case positional pairing gets wrong: one element inserted at the top.
+    /// Everything below it is the same element as before and must pair with
+    /// itself, or the diff claims the whole block was rewritten.
+    #[test]
+    fn an_insertion_does_not_shift_everything_below_it() {
+        let a = ids(&["warthog", "ghost", "banshee"]);
+        let b = ids(&["scorpion", "warthog", "ghost", "banshee"]);
+        let pairs = align_by_identity(&a, &b).expect("named elements align by identity");
+        assert_eq!(
+            pairs,
+            vec![
+                (None, Some(0)),
+                (Some(0), Some(1)),
+                (Some(1), Some(2)),
+                (Some(2), Some(3)),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_removal_is_reported_where_the_element_was() {
+        let a = ids(&["warthog", "ghost", "banshee"]);
+        let b = ids(&["warthog", "banshee"]);
+        let pairs = align_by_identity(&a, &b).expect("aligns");
+        assert_eq!(
+            pairs,
+            vec![(Some(0), Some(0)), (Some(1), None), (Some(2), Some(1))]
+        );
+    }
+
+    /// Reordering is not a change to any element, so every one still pairs.
+    #[test]
+    fn reordering_pairs_every_element() {
+        let a = ids(&["warthog", "ghost", "banshee"]);
+        let b = ids(&["banshee", "warthog", "ghost"]);
+        let pairs = align_by_identity(&a, &b).expect("aligns");
+        let mut matched: Vec<(usize, usize)> = pairs
+            .iter()
+            .filter_map(|(x, y)| Some(((*x)?, (*y)?)))
+            .collect();
+        matched.sort();
+        assert_eq!(matched, vec![(0, 1), (1, 2), (2, 0)]);
+        assert!(
+            pairs.iter().all(|(x, y)| x.is_some() && y.is_some()),
+            "a pure reorder adds and removes nothing: {pairs:?}"
+        );
+    }
+
+    /// Identities have to be trustworthy on both sides. Anonymous or repeated
+    /// ones fall back to position, which is at least predictable.
+    #[test]
+    fn unusable_identities_fall_back_to_position() {
+        assert!(align_by_identity(&ids(&["a", "a"]), &ids(&["a", "b"])).is_none());
+        assert!(align_by_identity(&ids(&["a", "b"]), &ids(&["a", "a"])).is_none());
+        assert!(align_by_identity(&[None, Some("a".into())], &ids(&["a", "b"])).is_none());
+        assert!(align_by_identity(&[], &[]).is_some(), "two empty blocks align trivially");
+    }
+
+    #[test]
+    fn everything_added_or_everything_removed() {
+        let pairs = align_by_identity(&[], &ids(&["a", "b"])).expect("aligns");
+        assert_eq!(pairs, vec![(None, Some(0)), (None, Some(1))]);
+        let pairs = align_by_identity(&ids(&["a", "b"]), &[]).expect("aligns");
+        assert_eq!(pairs, vec![(Some(0), None), (Some(1), None)]);
     }
 }

--- a/src/app/editor/diff.rs
+++ b/src/app/editor/diff.rs
@@ -120,9 +120,107 @@ fn moved_pairs(matched: &[(usize, usize)]) -> Vec<usize> {
     (0..matched.len()).filter(|&i| !kept[i]).collect()
 }
 
-/// The identity an element is matched on: whatever names it to a reader.
+/// The identity an element is matched on: whatever *names* it.
+///
+/// Deliberately not the instance selector's label, which falls back to the
+/// element's first scalar. A checksum or a bitmask is a value, not a name:
+/// matching on one makes an element that merely had that value edited look
+/// removed and re-added, and blocks full of repeated values -- checksums, bit
+/// vectors -- have no distinct identities at all, so matching is abandoned
+/// exactly where it is needed most.
 fn element_identity(element: Option<TagStruct<'_>>, names: &TagNameIndex) -> Option<String> {
-    foundation::block_element_content_label(element?, names)
+    let element = element?;
+    foundation::first_named_string_label(element)
+        .or_else(|| foundation::first_tag_reference_label(element, names))
+        .or_else(|| foundation::first_string_label(element))
+}
+
+/// A cheap fingerprint of an element's own bytes, for matching elements that
+/// have nothing naming them.
+///
+/// Only the element's fixed-size data, so two elements differing solely inside
+/// a nested block fingerprint alike -- which is what we want: they are the same
+/// element, and recursing finds what changed within it.
+fn element_fingerprint(element: Option<TagStruct<'_>>) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    match element {
+        Some(element) => element.raw().hash(&mut hasher),
+        None => 0u8.hash(&mut hasher),
+    }
+    hasher.finish()
+}
+
+/// Pair elements by content when nothing names them.
+///
+/// A longest-common-subsequence over element fingerprints, so deleting one
+/// element from a block of anonymous ones is reported as one deletion rather
+/// than as every element below it having been rewritten -- which is what
+/// pairing by position does, and what made a single deleted `zone set pvs`
+/// element produce a screen of unrelated changes.
+///
+/// Unmatched runs on both sides at the same point are then zipped together, so
+/// an element whose contents were edited reads as modified rather than as a
+/// removal followed by an addition.
+///
+/// Returns `None` for blocks large enough that the quadratic table is not worth
+/// it; those fall back to position, which is at least predictable.
+fn align_by_content(a: &[u64], b: &[u64]) -> Option<Vec<(Option<usize>, Option<usize>)>> {
+    const MAX_ELEMENTS: usize = 512;
+    if a.len() > MAX_ELEMENTS || b.len() > MAX_ELEMENTS {
+        return None;
+    }
+    let width = b.len() + 1;
+    let mut table = vec![0u32; (a.len() + 1) * width];
+    for i in (0..a.len()).rev() {
+        for j in (0..b.len()).rev() {
+            table[i * width + j] = if a[i] == b[j] {
+                table[(i + 1) * width + j + 1] + 1
+            } else {
+                table[(i + 1) * width + j].max(table[i * width + j + 1])
+            };
+        }
+    }
+    let mut pairs = Vec::new();
+    let mut removed: Vec<usize> = Vec::new();
+    let mut added: Vec<usize> = Vec::new();
+    // Elements dropped on one side and gained on the other, at the same point
+    // in the sequence, are the same element edited.
+    let flush = |pairs: &mut Vec<(Option<usize>, Option<usize>)>,
+                 removed: &mut Vec<usize>,
+                 added: &mut Vec<usize>| {
+        let paired = removed.len().min(added.len());
+        for index in 0..paired {
+            pairs.push((Some(removed[index]), Some(added[index])));
+        }
+        for &index in &removed[paired..] {
+            pairs.push((Some(index), None));
+        }
+        for &index in &added[paired..] {
+            pairs.push((None, Some(index)));
+        }
+        removed.clear();
+        added.clear();
+    };
+    let (mut i, mut j) = (0usize, 0usize);
+    while i < a.len() && j < b.len() {
+        if a[i] == b[j] {
+            flush(&mut pairs, &mut removed, &mut added);
+            pairs.push((Some(i), Some(j)));
+            i += 1;
+            j += 1;
+        } else if table[(i + 1) * width + j] >= table[i * width + j + 1] {
+            removed.push(i);
+            i += 1;
+        } else {
+            added.push(j);
+            j += 1;
+        }
+    }
+    removed.extend(i..a.len());
+    added.extend(j..b.len());
+    flush(&mut pairs, &mut removed, &mut added);
+    Some(pairs)
 }
 
 fn diff_structs(
@@ -145,12 +243,22 @@ fn diff_structs(
             let ids_b: Vec<Option<String>> = (0..bb.len())
                 .map(|i| element_identity(bb.element(i), names))
                 .collect();
-            // Without usable identities there is nothing better than position.
-            let pairs = align_by_identity(&ids_a, &ids_b).unwrap_or_else(|| {
-                (0..ba.len().max(bb.len()))
-                    .map(|i| ((i < ba.len()).then_some(i), (i < bb.len()).then_some(i)))
-                    .collect()
-            });
+            // Names first, since they survive an element's contents changing.
+            // Otherwise match on content, which is the only thing anonymous
+            // elements have. Position is the last resort.
+            let pairs = align_by_identity(&ids_a, &ids_b)
+                .or_else(|| {
+                    let fps_a: Vec<u64> =
+                        (0..ba.len()).map(|i| element_fingerprint(ba.element(i))).collect();
+                    let fps_b: Vec<u64> =
+                        (0..bb.len()).map(|i| element_fingerprint(bb.element(i))).collect();
+                    align_by_content(&fps_a, &fps_b)
+                })
+                .unwrap_or_else(|| {
+                    (0..ba.len().max(bb.len()))
+                        .map(|i| ((i < ba.len()).then_some(i), (i < bb.len()).then_some(i)))
+                        .collect()
+                });
             // Reported before the per-element diffs so a reorder reads as a
             // property of the block rather than of one element in it.
             let matched: Vec<(usize, usize)> = pairs
@@ -439,6 +547,63 @@ mod alignment_tests {
     fn a_reversal_keeps_one_element_still() {
         let matched = [(0, 3), (1, 2), (2, 1), (3, 0)];
         assert_eq!(super::moved_pairs(&matched).len(), 3);
+    }
+
+    /// The reported case: one element deleted from a block whose elements have
+    /// nothing naming them. Pairing by position reports every element below the
+    /// deletion as rewritten; pairing by content reports one deletion.
+    #[test]
+    fn deleting_one_anonymous_element_is_one_deletion() {
+        let a = [10, 20, 30, 40, 50];
+        let b = [10, 20, 40, 50];
+        let pairs = super::align_by_content(&a, &b).expect("aligns");
+        assert_eq!(
+            pairs,
+            vec![
+                (Some(0), Some(0)),
+                (Some(1), Some(1)),
+                (Some(2), None),
+                (Some(3), Some(2)),
+                (Some(4), Some(3)),
+            ]
+        );
+    }
+
+    /// Editing an element changes its fingerprint, so it drops out of the
+    /// common subsequence on both sides at once. Zipping those together is
+    /// what makes it read as modified rather than removed and re-added.
+    #[test]
+    fn editing_an_anonymous_element_reads_as_a_modification() {
+        let a = [10, 20, 30];
+        let b = [10, 99, 30];
+        let pairs = super::align_by_content(&a, &b).expect("aligns");
+        assert_eq!(
+            pairs,
+            vec![(Some(0), Some(0)), (Some(1), Some(1)), (Some(2), Some(2))]
+        );
+    }
+
+    /// Repeated values are ordinary in these blocks -- checksums, bit vectors --
+    /// and must not defeat matching the way duplicate identities do.
+    #[test]
+    fn repeated_content_still_aligns() {
+        let a = [0, 0, 0, 7];
+        let b = [0, 0, 0, 0, 7];
+        let pairs = super::align_by_content(&a, &b).expect("aligns");
+        let added: Vec<_> = pairs.iter().filter(|(x, _)| x.is_none()).collect();
+        assert_eq!(added.len(), 1, "one element gained: {pairs:?}");
+        assert!(
+            pairs.iter().filter(|(_, y)| y.is_none()).count() == 0,
+            "nothing was lost: {pairs:?}"
+        );
+    }
+
+    /// A block big enough that the quadratic table is not worth building falls
+    /// back to position rather than stalling the review.
+    #[test]
+    fn very_large_blocks_fall_back_to_position() {
+        let big: Vec<u64> = (0..600).collect();
+        assert!(super::align_by_content(&big, &big).is_none());
     }
 
     #[test]

--- a/src/app/editor/diff.rs
+++ b/src/app/editor/diff.rs
@@ -161,6 +161,19 @@ fn element_fingerprint(element: Option<TagStruct<'_>>) -> u64 {
     hasher.finish()
 }
 
+/// An element by its own fixed fields only, ignoring everything nested. Two
+/// elements matching here are the same element even if something inside one of
+/// them was edited.
+fn shallow_fingerprint(element: Option<TagStruct<'_>>) -> u64 {
+    use std::hash::Hasher;
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    match element {
+        Some(element) => hasher.write(element.raw()),
+        None => hasher.write_u8(0),
+    }
+    hasher.finish()
+}
+
 fn hash_struct(
     st: &TagStruct<'_>,
     hasher: &mut std::collections::hash_map::DefaultHasher,
@@ -209,7 +222,12 @@ fn hash_struct(
 ///
 /// Returns `None` for blocks large enough that the quadratic table is not worth
 /// it; those fall back to position, which is at least predictable.
-fn align_by_content(a: &[u64], b: &[u64]) -> Option<Vec<(Option<usize>, Option<usize>)>> {
+fn align_by_content(
+    a: &[u64],
+    b: &[u64],
+    a_shallow: &[u64],
+    b_shallow: &[u64],
+) -> Option<Vec<(Option<usize>, Option<usize>)>> {
     const MAX_ELEMENTS: usize = 512;
     if a.len() > MAX_ELEMENTS || b.len() > MAX_ELEMENTS {
         return None;
@@ -233,16 +251,53 @@ fn align_by_content(a: &[u64], b: &[u64]) -> Option<Vec<(Option<usize>, Option<u
     let flush = |pairs: &mut Vec<(Option<usize>, Option<usize>)>,
                  removed: &mut Vec<usize>,
                  added: &mut Vec<usize>| {
-        let paired = removed.len().min(added.len());
-        for index in 0..paired {
-            pairs.push((Some(removed[index]), Some(added[index])));
+        // Editing a value inside an element changes its contents, so it drops
+        // out of the common subsequence even though it is still the same
+        // element. Pair the leftovers on their fixed fields first, which an
+        // edit further down does not disturb -- without this, deleting one
+        // element and editing another paired element 3 against element 4 and
+        // reported every field below as changed.
+        let mut taken = vec![false; added.len()];
+        let mut matched: Vec<(usize, usize)> = Vec::new();
+        for &from in removed.iter() {
+            if let Some(slot) = added
+                .iter()
+                .enumerate()
+                .position(|(slot, &to)| !taken[slot] && a_shallow[from] == b_shallow[to])
+            {
+                taken[slot] = true;
+                matched.push((from, added[slot]));
+            }
         }
-        for &index in &removed[paired..] {
+        let paired_from: Vec<usize> = matched.iter().map(|(from, _)| *from).collect();
+        let paired_to: Vec<usize> = matched.iter().map(|(_, to)| *to).collect();
+        let mut rest_from: Vec<usize> = removed
+            .iter()
+            .copied()
+            .filter(|index| !paired_from.contains(index))
+            .collect();
+        let mut rest_to: Vec<usize> = added
+            .iter()
+            .copied()
+            .filter(|index| !paired_to.contains(index))
+            .collect();
+        for (from, to) in matched {
+            pairs.push((Some(from), Some(to)));
+        }
+        // Whatever is still unaccounted for is paired in order, then reported
+        // as gained or lost.
+        let zipped = rest_from.len().min(rest_to.len());
+        for index in 0..zipped {
+            pairs.push((Some(rest_from[index]), Some(rest_to[index])));
+        }
+        for &index in &rest_from[zipped..] {
             pairs.push((Some(index), None));
         }
-        for &index in &added[paired..] {
+        for &index in &rest_to[zipped..] {
             pairs.push((None, Some(index)));
         }
+        rest_from.clear();
+        rest_to.clear();
         removed.clear();
         added.clear();
     };
@@ -298,7 +353,13 @@ fn diff_structs(
                         (0..ba.len()).map(|i| element_fingerprint(ba.element(i))).collect();
                     let fps_b: Vec<u64> =
                         (0..bb.len()).map(|i| element_fingerprint(bb.element(i))).collect();
-                    align_by_content(&fps_a, &fps_b)
+                    // The same elements by their fixed fields alone, which
+                    // survive an edit to anything nested inside them.
+                    let shallow_a: Vec<u64> =
+                        (0..ba.len()).map(|i| shallow_fingerprint(ba.element(i))).collect();
+                    let shallow_b: Vec<u64> =
+                        (0..bb.len()).map(|i| shallow_fingerprint(bb.element(i))).collect();
+                    align_by_content(&fps_a, &fps_b, &shallow_a, &shallow_b)
                 })
                 .unwrap_or_else(|| {
                     (0..ba.len().max(bb.len()))
@@ -524,6 +585,16 @@ fn dump_struct(
 mod alignment_tests {
     use super::align_by_identity;
 
+    /// Fixed-field keys that match nothing, so a test exercises content
+    /// matching alone rather than the fallback that pairs on them.
+    fn distinct(len: usize) -> Vec<u64> {
+        (0..len as u64).collect()
+    }
+
+    fn distinct_from(offset: usize, len: usize) -> Vec<u64> {
+        (0..len as u64).map(|i| i + 1000 + offset as u64).collect()
+    }
+
     fn ids(names: &[&str]) -> Vec<Option<String>> {
         names.iter().map(|n| Some((*n).to_owned())).collect()
     }
@@ -625,7 +696,7 @@ mod alignment_tests {
     fn deleting_one_anonymous_element_is_one_deletion() {
         let a = [10, 20, 30, 40, 50];
         let b = [10, 20, 40, 50];
-        let pairs = super::align_by_content(&a, &b).expect("aligns");
+        let pairs = super::align_by_content(&a, &b, &distinct(a.len()), &distinct_from(a.len(), b.len())).expect("aligns");
         assert_eq!(
             pairs,
             vec![
@@ -645,7 +716,7 @@ mod alignment_tests {
     fn editing_an_anonymous_element_reads_as_a_modification() {
         let a = [10, 20, 30];
         let b = [10, 99, 30];
-        let pairs = super::align_by_content(&a, &b).expect("aligns");
+        let pairs = super::align_by_content(&a, &b, &distinct(a.len()), &distinct_from(a.len(), b.len())).expect("aligns");
         assert_eq!(
             pairs,
             vec![(Some(0), Some(0)), (Some(1), Some(1)), (Some(2), Some(2))]
@@ -658,7 +729,7 @@ mod alignment_tests {
     fn repeated_content_still_aligns() {
         let a = [0, 0, 0, 7];
         let b = [0, 0, 0, 0, 7];
-        let pairs = super::align_by_content(&a, &b).expect("aligns");
+        let pairs = super::align_by_content(&a, &b, &distinct(a.len()), &distinct_from(a.len(), b.len())).expect("aligns");
         let added: Vec<_> = pairs.iter().filter(|(x, _)| x.is_none()).collect();
         assert_eq!(added.len(), 1, "one element gained: {pairs:?}");
         assert!(
@@ -672,7 +743,7 @@ mod alignment_tests {
     #[test]
     fn very_large_blocks_fall_back_to_position() {
         let big: Vec<u64> = (0..600).collect();
-        assert!(super::align_by_content(&big, &big).is_none());
+        assert!(super::align_by_content(&big, &big, &big, &big).is_none());
     }
 
     #[test]
@@ -794,6 +865,115 @@ mod deletion_repro_tests {
             "{} field(s) outside the deleted element reported as changed, e.g. {:?}",
             strays.len(),
             strays.iter().take(5).collect::<Vec<_>>()
+        );
+    }
+
+    /// The reported case, in full: an element deleted from `zone set pvs` and
+    /// a value edited inside one that shifts up to take its place.
+    ///
+    /// The edit changes that element's contents, so it drops out of the common
+    /// subsequence and used to be paired positionally against its neighbour --
+    /// reporting every field below as changed, each shifted by one position.
+    #[test]
+    fn editing_an_element_that_also_shifts_is_still_the_same_element() {
+        let (Some(base), Some(mut edited)) = (read_a15(), read_a15()) else {
+            eprintln!("skipping: Campaign Evolved not present");
+            return;
+        };
+        let names = crate::format::TagNameIndex::default();
+        let mut dirty = false;
+        crate::app::apply_block_ops(
+            &mut edited,
+            vec![BlockOp {
+                path: "zone set pvs".to_owned(),
+                kind: BlockOpKind::Delete(3),
+            }],
+            &mut dirty,
+        );
+        // Element 4 is now element 3. Editing inside it is what defeated the
+        // alignment.
+        let applied = crate::app::apply_pending_edits(
+            &mut edited,
+            vec![PendingFieldEdit {
+                path: "zone set pvs[3]/bsp checksums[0]/bsp checksum".to_owned(),
+                input: "12345".to_owned(),
+            }],
+            &mut dirty,
+        );
+        assert!(
+            applied.status.is_some(),
+            "the edit has to land for this to test anything"
+        );
+
+        let (rows, _) = diff_tags(&base, &edited, &names, 5000);
+        let modifications: Vec<&TagFieldDiff> = rows
+            .iter()
+            .filter(|row| !row.a.is_empty() && !row.b.is_empty())
+            .collect();
+        assert_eq!(
+            modifications.len(),
+            1,
+            "one value was edited, so one modification: {:?}",
+            modifications
+                .iter()
+                .map(|row| (&row.path, &row.a, &row.b))
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(modifications[0].b, "12345");
+    }
+
+    /// Deleting one element and adding another, as reported.
+    #[test]
+    fn a_deletion_and_an_addition_change_no_values() {
+        let (Some(base), Some(mut edited)) = (read_a15(), read_a15()) else {
+            eprintln!("skipping: Campaign Evolved not present");
+            return;
+        };
+        let names = crate::format::TagNameIndex::default();
+        let mut dirty = false;
+        crate::app::apply_block_ops(
+            &mut edited,
+            vec![
+                BlockOp {
+                    path: "zone set pvs".to_owned(),
+                    kind: BlockOpKind::Delete(3),
+                },
+                BlockOp {
+                    path: "zone sets".to_owned(),
+                    kind: BlockOpKind::Add,
+                },
+            ],
+            &mut dirty,
+        );
+        // The dialog compares the shipped tag against the project overlay,
+        // which is the edited tag serialized and read back -- not the
+        // in-memory one it was edited in.
+        let bytes = edited.write_to_bytes().expect("serialize the edited tag");
+        let edited = TagFile::read_from_bytes(&bytes).expect("read the overlay back");
+        let (rows, _) = diff_tags(&base, &edited, &names, 5000);
+        // Removing one element and adding another changes no value anywhere,
+        // so nothing may be reported as modified: renumbering is not an edit.
+        let modifications: Vec<&TagFieldDiff> = rows
+            .iter()
+            .filter(|row| !row.a.is_empty() && !row.b.is_empty())
+            .collect();
+        assert!(
+            modifications.is_empty(),
+            "{} field(s) reported as changed by a deletion and an addition: {:?}",
+            modifications.len(),
+            modifications
+                .iter()
+                .take(5)
+                .map(|row| (&row.path, &row.a, &row.b))
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            rows.iter().any(|row| row.b.starts_with("added")),
+            "the new element should be reported"
+        );
+        assert!(
+            rows.iter().any(|row| row.a.starts_with("removed")),
+            "the deleted element should be reported"
         );
     }
 }

--- a/src/app/editor/diff.rs
+++ b/src/app/editor/diff.rs
@@ -266,6 +266,24 @@ fn diff_structs(
     }
 }
 
+/// Describe a whole tag as additions, for a tag the game has no counterpart
+/// for.
+///
+/// A new tag has nothing to diff against, but "what is in it" is the same
+/// question the modified rows answer, so it is answered in the same shape and
+/// rendered by the same code rather than through a second presentation.
+pub(in crate::app) fn describe_tag(
+    tag: &TagFile,
+    names: &TagNameIndex,
+    limit: usize,
+) -> (Vec<TagFieldDiff>, bool) {
+    let mut out = Vec::new();
+    dump_struct(&tag.root(), "", names, &mut out, limit, true);
+    let truncated = out.len() > limit;
+    out.truncate(limit);
+    (out, truncated)
+}
+
 /// Emit every scalar in a struct that has no counterpart, so an added or
 /// removed element shows what it actually contains.
 fn dump_struct(

--- a/src/app/editor/diff.rs
+++ b/src/app/editor/diff.rs
@@ -181,7 +181,26 @@ fn diff_structs(
                         let (Some(ea), Some(eb)) = (ba.element(ai), bb.element(bi)) else {
                             continue;
                         };
+                        let before = out.len();
                         diff_structs(&ea, &eb, &format!("{field_path}[{bi}]"), names, out, limit);
+                        // Name the element, but only once something inside it
+                        // turned out to differ: an index alone says very little
+                        // about which of a hundred palette entries this is.
+                        // Both sides carry the name, which is how the renderer
+                        // tells "this element, unchanged in itself" from one
+                        // that was added or removed.
+                        if out.len() > before
+                            && let Some(label) = ids_b[bi].clone()
+                        {
+                            out.insert(
+                                before,
+                                TagFieldDiff {
+                                    path: format!("{field_path}[{bi}]"),
+                                    a: label.clone(),
+                                    b: label,
+                                },
+                            );
+                        }
                     }
                     // An added or removed element is reported with its
                     // contents: "one more element" says nothing about what is

--- a/src/app/editor/diff.rs
+++ b/src/app/editor/diff.rs
@@ -10,7 +10,7 @@ pub(in crate::app) fn diff_tags(
     limit: usize,
 ) -> (Vec<TagFieldDiff>, bool) {
     let mut out = Vec::new();
-    diff_structs(&a.root(), &b.root(), "", names, &mut out, limit);
+    diff_structs(&a.root(), &b.root(), "", "", names, &mut out, limit);
     let truncated = out.len() > limit;
     out.truncate(limit);
     (out, truncated)
@@ -227,6 +227,7 @@ fn diff_structs(
     a: &TagStruct<'_>,
     b: &TagStruct<'_>,
     path: &str,
+    base_path: &str,
     names: &TagNameIndex,
     out: &mut Vec<TagFieldDiff>,
     limit: usize,
@@ -236,6 +237,7 @@ fn diff_structs(
             return;
         }
         let field_path = append_field_path(path, fa.name());
+        let base_field_path = append_field_path(base_path, fa.name());
         if let (Some(ba), Some(bb)) = (fa.as_block(), fb.as_block()) {
             let ids_a: Vec<Option<String>> = (0..ba.len())
                 .map(|i| element_identity(ba.element(i), names))
@@ -276,6 +278,7 @@ fn diff_structs(
                     .unwrap_or_else(|| format!("element {ai}"));
                 out.push(TagFieldDiff {
                     path: format!("{field_path}[{bi}]"),
+                    base_path: Some(format!("{base_field_path}[{ai}]")),
                     a: format!("position {ai}"),
                     b: format!("moved to {bi} — {label}"),
                 });
@@ -290,7 +293,15 @@ fn diff_structs(
                             continue;
                         };
                         let before = out.len();
-                        diff_structs(&ea, &eb, &format!("{field_path}[{bi}]"), names, out, limit);
+                        diff_structs(
+                            &ea,
+                            &eb,
+                            &format!("{field_path}[{bi}]"),
+                            &format!("{base_field_path}[{ai}]"),
+                            names,
+                            out,
+                            limit,
+                        );
                         // Name the element, but only once something inside it
                         // turned out to differ: an index alone says very little
                         // about which of a hundred palette entries this is.
@@ -304,6 +315,7 @@ fn diff_structs(
                                 before,
                                 TagFieldDiff {
                                     path: format!("{field_path}[{bi}]"),
+                                    base_path: Some(format!("{base_field_path}[{ai}]")),
                                     a: label.clone(),
                                     b: label,
                                 },
@@ -317,6 +329,7 @@ fn diff_structs(
                         let label = ids_b[bi].clone().unwrap_or_else(|| format!("element {bi}"));
                         out.push(TagFieldDiff {
                             path: format!("{field_path}[{bi}]"),
+                            base_path: None,
                             a: String::new(),
                             b: format!("added — {label}"),
                         });
@@ -335,6 +348,7 @@ fn diff_structs(
                         let label = ids_a[ai].clone().unwrap_or_else(|| format!("element {ai}"));
                         out.push(TagFieldDiff {
                             path: format!("{field_path}[{ai}]"),
+                            base_path: Some(format!("{base_field_path}[{ai}]")),
                             a: format!("removed — {label}"),
                             b: String::new(),
                         });
@@ -358,10 +372,18 @@ fn diff_structs(
                 let (Some(ea), Some(eb)) = (aa.element(i), ab.element(i)) else {
                     continue;
                 };
-                diff_structs(&ea, &eb, &format!("{field_path}[{i}]"), names, out, limit);
+                diff_structs(
+                    &ea,
+                    &eb,
+                    &format!("{field_path}[{i}]"),
+                    &format!("{base_field_path}[{i}]"),
+                    names,
+                    out,
+                    limit,
+                );
             }
         } else if let (Some(sa), Some(sb)) = (fa.as_struct(), fb.as_struct()) {
-            diff_structs(&sa, &sb, &field_path, names, out, limit);
+            diff_structs(&sa, &sb, &field_path, &base_field_path, names, out, limit);
         } else if let (Some(da), Some(db)) = (fa.as_data(), fb.as_data()) {
             // Raw data fields -- function curves, shader source, import info --
             // are edited through their own editors and land in an exported mod
@@ -371,6 +393,7 @@ fn diff_structs(
             if da != db {
                 out.push(TagFieldDiff {
                     path: field_path,
+                    base_path: Some(base_field_path),
                     a: format!("{} bytes", da.len()),
                     b: if da.len() == db.len() {
                         format!("{} bytes, contents differ", db.len())
@@ -385,6 +408,7 @@ fn diff_structs(
             if ta != tb {
                 out.push(TagFieldDiff {
                     path: field_path,
+                    base_path: Some(base_field_path),
                     a: ta,
                     b: tb,
                 });
@@ -443,7 +467,8 @@ fn dump_struct(
         } else if let Some(value) = field.value() {
             let text = foundation::format_foundation_scalar_value(names, &value);
             out.push(TagFieldDiff {
-                path: field_path,
+                path: field_path.clone(),
+                base_path: (!added).then_some(field_path),
                 a: if added { String::new() } else { text.clone() },
                 b: if added { text } else { String::new() },
             });
@@ -612,5 +637,28 @@ mod alignment_tests {
         assert_eq!(pairs, vec![(None, Some(0)), (None, Some(1))]);
         let pairs = align_by_identity(&ids(&["a", "b"]), &[]).expect("aligns");
         assert_eq!(pairs, vec![(Some(0), None), (Some(1), None)]);
+    }
+}
+#[cfg(test)]
+mod base_path_tests {
+    use super::*;
+
+    /// Deleting an element shifts every index below it, so the same field lives
+    /// at two different paths. A side-by-side view has to know both, or it
+    /// reads the wrong element out of the shipped tag.
+    #[test]
+    fn a_diff_row_knows_both_sides_paths() {
+        let names = TagNameIndex::default();
+        let a = TagFile::new("definitions/halo3_mcc/sound_classes.json").unwrap();
+        let mut b = TagFile::new("definitions/halo3_mcc/sound_classes.json").unwrap();
+        crate::app::add_block_element(&mut b, "sound classes").unwrap();
+        let (rows, _) = diff_tags(&a, &b, &names, 5000);
+        assert!(!rows.is_empty());
+        // An added element exists only on the edited side.
+        assert!(
+            rows.iter()
+                .any(|row| row.base_path.is_none() && row.b.starts_with("added")),
+            "an added element has no path in the shipped tag: {rows:?}"
+        );
     }
 }

--- a/src/app/editor/diff.rs
+++ b/src/app/editor/diff.rs
@@ -135,20 +135,64 @@ fn element_identity(element: Option<TagStruct<'_>>, names: &TagNameIndex) -> Opt
         .or_else(|| foundation::first_string_label(element))
 }
 
-/// A cheap fingerprint of an element's own bytes, for matching elements that
+/// How deep a fingerprint follows nested structure before it stops. Deep enough
+/// to reach what distinguishes real elements, bounded so a pathological tag
+/// cannot make aligning one block cost the whole document.
+const FINGERPRINT_DEPTH: usize = 6;
+
+/// A fingerprint of an element's whole contents, for matching elements that
 /// have nothing naming them.
 ///
-/// Only the element's fixed-size data, so two elements differing solely inside
-/// a nested block fingerprint alike -- which is what we want: they are the same
-/// element, and recursing finds what changed within it.
+/// Nested data is included, and that is the point. `raw()` covers only a
+/// struct's fixed-size fields, and for a good many blocks everything that
+/// tells one element from another lives in child blocks -- a `zone set pvs`
+/// element is a version, a mask and some flags, with the checksums and cluster
+/// data underneath. Fingerprinting the fixed part alone made those elements
+/// indistinguishable, so the aligner matched an arbitrary valid subsequence
+/// and every field below a deletion read as changed, each one shifted by
+/// exactly one position.
 fn element_fingerprint(element: Option<TagStruct<'_>>) -> u64 {
-    use std::hash::{Hash, Hasher};
+    use std::hash::Hasher;
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     match element {
-        Some(element) => element.raw().hash(&mut hasher),
-        None => 0u8.hash(&mut hasher),
+        Some(element) => hash_struct(&element, &mut hasher, 0),
+        None => hasher.write_u8(0),
     }
     hasher.finish()
+}
+
+fn hash_struct(
+    st: &TagStruct<'_>,
+    hasher: &mut std::collections::hash_map::DefaultHasher,
+    depth: usize,
+) {
+    use std::hash::Hasher;
+    hasher.write(st.raw());
+    if depth >= FINGERPRINT_DEPTH {
+        return;
+    }
+    for field in st.fields_all() {
+        if let Some(block) = field.as_block() {
+            // The count matters: two otherwise identical elements holding
+            // different numbers of children are different elements.
+            hasher.write_usize(block.len());
+            for index in 0..block.len() {
+                if let Some(element) = block.element(index) {
+                    hash_struct(&element, hasher, depth + 1);
+                }
+            }
+        } else if let Some(array) = field.as_array() {
+            for index in 0..array.len() {
+                if let Some(element) = array.element(index) {
+                    hash_struct(&element, hasher, depth + 1);
+                }
+            }
+        } else if let Some(inner) = field.as_struct() {
+            hash_struct(&inner, hasher, depth + 1);
+        } else if let Some(data) = field.as_data() {
+            hasher.write(data);
+        }
+    }
 }
 
 /// Pair elements by content when nothing names them.
@@ -659,6 +703,97 @@ mod base_path_tests {
             rows.iter()
                 .any(|row| row.base_path.is_none() && row.b.starts_with("added")),
             "an added element has no path in the shipped tag: {rows:?}"
+        );
+    }
+}
+#[cfg(test)]
+mod deletion_repro_tests {
+    use super::*;
+
+    const PAKS: &str = "/Users/camden/Halo/halo-campaign-evolved_pc/Meteorite/Content/Paks";
+
+    fn read_a15() -> Option<TagFile> {
+        if !std::path::Path::new(PAKS).exists() {
+            return None;
+        }
+        let defs = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("definitions");
+        let names = crate::format::TagNameIndex::load_from_definitions(&defs);
+        let loaded = crate::source::load_iostore_container_set(
+            std::path::PathBuf::from(PAKS),
+            &names,
+            &defs,
+        )
+        .ok()?;
+        let entry = loaded
+            .entries
+            .iter()
+            .find(|entry| entry.display_path.ends_with("a15.scenario"))?
+            .clone();
+        crate::source::read_entry(&loaded.source, &entry).ok()
+    }
+
+    /// Deleting one `zone set pvs` element reported a screen of changes through
+    /// everything below it, each value shifted by exactly one position -- the
+    /// signature of comparing element n against element n+1.
+    ///
+    /// These elements are a version, a mask and some flags, with everything
+    /// that tells them apart in nested blocks, so a fingerprint of the fixed
+    /// data alone could not distinguish them and the aligner paired the wrong
+    /// ones.
+    #[test]
+    fn deleting_a_zone_set_reports_only_that_deletion() {
+        let (Some(base), Some(mut edited)) = (read_a15(), read_a15()) else {
+            eprintln!("skipping: Campaign Evolved not present");
+            return;
+        };
+        let names = crate::format::TagNameIndex::default();
+        let before = base
+            .root()
+            .fields_all()
+            .find_map(|field| {
+                (field.name() == "zone set pvs")
+                    .then(|| field.as_block())
+                    .flatten()
+                    .map(|block| block.len())
+            })
+            .expect("a zone set pvs block");
+        assert!(before > 4, "need several elements to shift, got {before}");
+
+        let mut dirty = false;
+        crate::app::apply_block_ops(
+            &mut edited,
+            vec![BlockOp {
+                path: "zone set pvs".to_owned(),
+                kind: BlockOpKind::Delete(3),
+            }],
+            &mut dirty,
+        );
+
+        let (rows, _) = diff_tags(&base, &edited, &names, 5000);
+        let removals: Vec<&TagFieldDiff> = rows
+            .iter()
+            .filter(|row| row.b.is_empty() && row.a.starts_with("removed"))
+            .collect();
+        assert_eq!(
+            removals.len(),
+            1,
+            "one element was deleted, so one removal: {:?}",
+            removals.iter().map(|row| &row.path).collect::<Vec<_>>()
+        );
+
+        // Everything else in the tag is untouched by a deletion further up, so
+        // nothing outside the removed element may be reported as changed.
+        let removed = &removals[0].path;
+        let strays: Vec<&String> = rows
+            .iter()
+            .filter(|row| !row.path.starts_with(removed.as_str()))
+            .map(|row| &row.path)
+            .collect();
+        assert!(
+            strays.is_empty(),
+            "{} field(s) outside the deleted element reported as changed, e.g. {:?}",
+            strays.len(),
+            strays.iter().take(5).collect::<Vec<_>>()
         );
     }
 }

--- a/src/app/editor/tests.rs
+++ b/src/app/editor/tests.rs
@@ -1667,5 +1667,27 @@ mod tag_diff_tests {
             diffs.iter().any(|d| d.path.contains("sound classes")),
             "block element-count difference should be reported"
         );
+        // An added element is reported as added, and with its contents: a bare
+        // "one more element" says nothing about what is being shipped.
+        assert!(
+            diffs.iter().any(|d| d.b.starts_with("added")),
+            "the new element should be marked as added: {diffs:?}"
+        );
+        assert!(
+            diffs
+                .iter()
+                .filter(|d| d.path.starts_with("sound classes[0]/"))
+                .count()
+                > 0,
+            "the added element's own fields should be listed: {diffs:?}"
+        );
+        // Nothing in the added element belongs to the old tag.
+        assert!(
+            diffs
+                .iter()
+                .filter(|d| d.path.starts_with("sound classes[0]"))
+                .all(|d| d.a.is_empty()),
+            "an added element has no previous value: {diffs:?}"
+        );
     }
 }

--- a/src/app/project.rs
+++ b/src/app/project.rs
@@ -1084,4 +1084,60 @@ mod tests {
         );
         let _ = fs::remove_file(path);
     }
+
+    /// Export resolves each stashed overlay back to a tag by identity string,
+    /// taking the first entry that produces a match. Two tags sharing an
+    /// identity would therefore send one tag's edited bytes to the other's
+    /// path in the container -- a mod that builds and does the wrong thing, or
+    /// nothing.
+    #[test]
+    fn container_tag_identities_are_unique() {
+        const PAKS: &str = "/Users/camden/Halo/halo-campaign-evolved_pc/Meteorite/Content/Paks";
+        if !std::path::Path::new(PAKS).exists() {
+            eprintln!("skipping: Campaign Evolved not present");
+            return;
+        }
+        let defs = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("definitions");
+        let names = crate::format::TagNameIndex::load_from_definitions(&defs);
+        let loaded = crate::source::load_iostore_container_set(
+            std::path::PathBuf::from(PAKS),
+            &names,
+            &defs,
+        )
+        .expect("mount container set");
+
+        let mut seen: HashMap<String, String> = HashMap::new();
+        let mut collisions = Vec::new();
+        let mut identified = 0usize;
+        for entry in loaded.entries.iter().chain(loaded.all_entries.iter()) {
+            let Some((identity, ..)) = campaign_entry_project_parts(entry) else {
+                continue;
+            };
+            identified += 1;
+            let location = match &entry.location {
+                TagEntryLocation::Container {
+                    container,
+                    rel_path,
+                } => format!("container {container}: {rel_path}"),
+                TagEntryLocation::NewContainer { package, .. } => format!("new: {package}"),
+                _ => "other".to_owned(),
+            };
+            match seen.get(&identity) {
+                Some(existing) if *existing != location => {
+                    collisions.push(format!("{identity}: {existing} vs {location}"));
+                }
+                Some(_) => {}
+                None => {
+                    seen.insert(identity, location);
+                }
+            }
+        }
+        eprintln!("{identified} identified tag(s), {} distinct", seen.len());
+        assert!(
+            collisions.is_empty(),
+            "{} identity collision(s):\n{}",
+            collisions.len(),
+            collisions.iter().take(10).cloned().collect::<Vec<_>>().join("\n")
+        );
+    }
 }

--- a/src/app/state/documents.rs
+++ b/src/app/state/documents.rs
@@ -317,6 +317,71 @@ pub(in crate::app) struct ImportTagDialog {
 /// it overwrites an already-open, dirty document at `target_key`.
 /// Pending "throw away everything this workspace has not written into the
 /// game" confirmation, listing what it is about to drop.
+/// One tag the export is about to write, as reviewed before writing.
+pub(in crate::app) struct ModExportRow {
+    pub(in crate::app) identity: String,
+    pub(in crate::app) display_path: String,
+    pub(in crate::app) kind: ModExportChange,
+    pub(in crate::app) include: bool,
+    pub(in crate::app) bytes: usize,
+    /// Why this tag cannot be exported, when it cannot.
+    pub(in crate::app) reason: Option<String>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(in crate::app) enum ModExportChange {
+    /// A tag this workspace created, with no counterpart in the game.
+    New,
+    /// An edit to a tag the game ships.
+    Modified,
+    /// In the workspace's project, but no longer resolvable in this source.
+    Unresolved,
+}
+
+/// Review of what Export Mod is about to write, shown before anything is
+/// written and before a destination is chosen.
+///
+/// Holds the captured snapshot rather than re-deriving one on confirm, so what
+/// was reviewed and what is written cannot disagree.
+pub(in crate::app) struct ModExportDialog {
+    pub(in crate::app) kit: KitId,
+    pub(in crate::app) snapshot: CampaignProjectSnapshot,
+    pub(in crate::app) rows: Vec<ModExportRow>,
+    pub(in crate::app) name: String,
+    pub(in crate::app) folder: PathBuf,
+    /// True once the user has accepted overwriting the files already there.
+    pub(in crate::app) overwrite_acknowledged: bool,
+}
+
+impl ModExportDialog {
+    /// The file stem the mod will be written under. `_P` is what gives an
+    /// override container priority over the game's own, so it is part of the
+    /// name rather than something the user can leave off.
+    pub(in crate::app) fn stem(&self) -> String {
+        let name = self.name.trim();
+        if name.ends_with("_P") {
+            name.to_owned()
+        } else {
+            format!("{name}_P")
+        }
+    }
+
+    pub(in crate::app) fn included(&self) -> impl Iterator<Item = &ModExportRow> {
+        self.rows.iter().filter(|row| row.include)
+    }
+
+    /// Files that already exist where this would be written. A mod is three
+    /// files plus its project sidecar, and only the container was ever guarded.
+    pub(in crate::app) fn existing_files(&self) -> Vec<String> {
+        let stem = self.stem();
+        ["utoc", "ucas", "pak", "baboon"]
+            .into_iter()
+            .map(|extension| format!("{stem}.{extension}"))
+            .filter(|name| self.folder.join(name).exists())
+            .collect()
+    }
+}
+
 /// What Export Mod just wrote, so the app can say what to do with it.
 ///
 /// A mod is three files, and only the `.pak` looks like one. The status line

--- a/src/app/state/documents.rs
+++ b/src/app/state/documents.rs
@@ -317,6 +317,18 @@ pub(in crate::app) struct ImportTagDialog {
 /// it overwrites an already-open, dirty document at `target_key`.
 /// Pending "throw away everything this workspace has not written into the
 /// game" confirmation, listing what it is about to drop.
+/// What Export Mod just wrote, so the app can say what to do with it.
+///
+/// A mod is three files, and only the `.pak` looks like one. The status line
+/// used to carry the instruction and no longer did; it also clears itself after
+/// a few seconds, which is not long enough to act on.
+pub(in crate::app) struct ExportedMod {
+    pub(in crate::app) stem: String,
+    pub(in crate::app) directory: PathBuf,
+    pub(in crate::app) count: usize,
+    pub(in crate::app) skipped: usize,
+}
+
 pub(in crate::app) struct ClearStashConfirm {
     pub(in crate::app) kit: KitId,
     pub(in crate::app) stashed: Vec<String>,

--- a/src/app/state/documents.rs
+++ b/src/app/state/documents.rs
@@ -379,6 +379,7 @@ impl Default for NewTagDialog {
     }
 }
 
+#[derive(Debug)]
 pub(in crate::app) struct TagFieldDiff {
     pub(in crate::app) path: String,
     pub(in crate::app) a: String,

--- a/src/app/state/documents.rs
+++ b/src/app/state/documents.rs
@@ -321,6 +321,7 @@ pub(in crate::app) struct ImportTagDialog {
 pub(in crate::app) struct ModExportRow {
     pub(in crate::app) identity: String,
     pub(in crate::app) display_path: String,
+    pub(in crate::app) group_tag: u32,
     pub(in crate::app) kind: ModExportChange,
     pub(in crate::app) include: bool,
     pub(in crate::app) bytes: usize,
@@ -342,6 +343,10 @@ pub(in crate::app) enum ModExportChange {
 /// expanded and kept for as long as the review is open.
 pub(in crate::app) struct ModRowDiff {
     pub(in crate::app) rows: Vec<TagFieldDiff>,
+    /// The two tags the rows were computed from, kept so each change can be
+    /// rendered through the real field editor rather than described.
+    pub(in crate::app) base: Option<blam_tags::TagFile>,
+    pub(in crate::app) edited: Option<blam_tags::TagFile>,
     pub(in crate::app) truncated: bool,
     pub(in crate::app) error: Option<String>,
 }
@@ -474,7 +479,12 @@ impl Default for NewTagDialog {
 
 #[derive(Debug)]
 pub(in crate::app) struct TagFieldDiff {
+    /// Path in the edited tag.
     pub(in crate::app) path: String,
+    /// Path in the tag as shipped, when it differs -- deleting an element
+    /// shifts every index below it, so the same field lives at two paths and a
+    /// side-by-side view needs both to find it.
+    pub(in crate::app) base_path: Option<String>,
     pub(in crate::app) a: String,
     pub(in crate::app) b: String,
 }

--- a/src/app/state/documents.rs
+++ b/src/app/state/documents.rs
@@ -324,7 +324,7 @@ pub(in crate::app) struct ModExportRow {
     pub(in crate::app) reason: Option<String>,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(in crate::app) enum ModExportChange {
     /// A tag this workspace created, with no counterpart in the game.
     New,

--- a/src/app/state/documents.rs
+++ b/src/app/state/documents.rs
@@ -338,6 +338,14 @@ pub(in crate::app) enum ModExportChange {
     Unresolved,
 }
 
+/// A modified tag's field-level differences, computed when its row is first
+/// expanded and kept for as long as the review is open.
+pub(in crate::app) struct ModRowDiff {
+    pub(in crate::app) rows: Vec<TagFieldDiff>,
+    pub(in crate::app) truncated: bool,
+    pub(in crate::app) error: Option<String>,
+}
+
 /// Review of what Export Mod is about to write, shown before anything is
 /// written and before a destination is chosen.
 ///
@@ -351,6 +359,11 @@ pub(in crate::app) struct ModExportDialog {
     pub(in crate::app) folder: PathBuf,
     /// True once the user has accepted overwriting the files already there.
     pub(in crate::app) overwrite_acknowledged: bool,
+    /// Rows the user has opened. Diffs are computed on first expansion rather
+    /// than up front: each one costs a container read and two parses, which
+    /// would make opening the review scale with how much is stashed.
+    pub(in crate::app) expanded: HashSet<String>,
+    pub(in crate::app) diffs: HashMap<String, ModRowDiff>,
 }
 
 impl ModExportDialog {

--- a/src/app/state/documents.rs
+++ b/src/app/state/documents.rs
@@ -353,6 +353,9 @@ pub(in crate::app) struct ModRowDiff {
 /// was reviewed and what is written cannot disagree.
 pub(in crate::app) struct ModExportDialog {
     pub(in crate::app) kit: KitId,
+    /// Opened to look rather than to export: the same review without a
+    /// destination or an Export button.
+    pub(in crate::app) review_only: bool,
     pub(in crate::app) snapshot: CampaignProjectSnapshot,
     pub(in crate::app) rows: Vec<ModExportRow>,
     pub(in crate::app) name: String,

--- a/src/app/state/documents.rs
+++ b/src/app/state/documents.rs
@@ -369,14 +369,39 @@ pub(in crate::app) struct ModExportDialog {
     pub(in crate::app) diffs: HashMap<String, ModRowDiff>,
 }
 
+/// Fold a mod name into a file-safe stem, keeping its capitalisation.
+///
+/// The name becomes three file names in a folder the user never types, so
+/// spaces and punctuation are separators to normalise rather than characters
+/// to carry through. Anything that is not a letter, digit, hyphen or
+/// underscore becomes a hyphen, runs collapse, and the ends are trimmed --
+/// kebab case, with the user's own casing left alone.
+///
+/// Underscores survive deliberately: `_P` marks a mod's priority, and folding
+/// it to `-P` would leave a second one appended.
+pub(in crate::app) fn sanitize_mod_name(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    for c in name.chars() {
+        if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+            out.push(c);
+        } else if !out.ends_with('-') {
+            out.push('-');
+        }
+    }
+    out.trim_matches('-').to_owned()
+}
+
 impl ModExportDialog {
-    /// The file stem the mod will be written under. `_P` is what gives an
-    /// override container priority over the game's own, so it is part of the
-    /// name rather than something the user can leave off.
+    /// The file stem the mod will be written under.
+    ///
+    /// `_P` is what gives an override container priority over the game's own,
+    /// so it is part of the name rather than something the user can leave off.
+    /// The game folds case before comparing, so a name already ending `_p` is
+    /// left as it is.
     pub(in crate::app) fn stem(&self) -> String {
-        let name = self.name.trim();
-        if name.ends_with("_P") {
-            name.to_owned()
+        let name = sanitize_mod_name(&self.name);
+        if name.len() >= 2 && name[name.len() - 2..].eq_ignore_ascii_case("_p") {
+            name
         } else {
             format!("{name}_P")
         }

--- a/src/app/state/documents.rs
+++ b/src/app/state/documents.rs
@@ -81,11 +81,6 @@ impl Default for SaveChangesPrompt {
     }
 }
 
-pub(in crate::app) struct ProjectCheckpointPrompt {
-    pub(in crate::app) action: PendingCloseAction,
-    pub(in crate::app) error: String,
-}
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(in crate::app) enum LastSessionSourceKind {
     SingleFile,

--- a/src/app/state/documents.rs
+++ b/src/app/state/documents.rs
@@ -497,7 +497,7 @@ impl Default for NewTagDialog {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(in crate::app) struct TagFieldDiff {
     /// Path in the edited tag.
     pub(in crate::app) path: String,

--- a/src/app/state/editing.rs
+++ b/src/app/state/editing.rs
@@ -625,6 +625,7 @@ pub(in crate::app) enum FieldFilterAction {
 /// Which collapsible nodes a "Search fields" query wants open. Paths are the
 /// canonical field paths with element indices (`[3]`) stripped, so they're
 /// independent of which block element happens to be selected.
+#[derive(Clone)]
 pub(in crate::app) struct FieldFilter {
     /// Canonical paths of every field that should render while searching:
     /// matches, their ancestor containers, and the contents of name-matched

--- a/src/app/ui/dialogs.rs
+++ b/src/app/ui/dialogs.rs
@@ -3,6 +3,42 @@
 
 use super::*;
 
+/// One changed element and the rows that belong to it.
+struct DiffSection {
+    /// Path in the edited tag, e.g. `zone set pvs[3]`. Empty for the root.
+    element: String,
+    /// The same element in the shipped tag, where the index differs.
+    base_element: Option<String>,
+    label: String,
+    kind: ModExportChange,
+    rows: Vec<TagFieldDiff>,
+}
+
+/// A container in the tag, holding whatever changed inside it.
+#[derive(Default)]
+struct DiffNode {
+    title: String,
+    children: Vec<DiffNode>,
+    sections: Vec<DiffSection>,
+}
+
+impl DiffNode {
+    /// Merge a container that only leads somewhere else into its child, so a
+    /// deep change reads as one breadcrumb rather than a stack of boxes.
+    fn collapse_chains(&mut self) {
+        for child in self.children.iter_mut() {
+            child.collapse_chains();
+        }
+        while self.sections.is_empty() && self.children.len() == 1 && !self.title.is_empty() {
+            let child = self.children.remove(0);
+            // A chevron the shipped fonts carry -- see the glyph fallback work.
+            self.title = format!("{} \u{203a} {}", self.title, child.title);
+            self.children = child.children;
+            self.sections = child.sections;
+        }
+    }
+}
+
 impl Baboon {
     pub(super) fn draw_tag_conversion_window(&mut self, ctx: &egui::Context) {
         if !self.expert_mode {
@@ -464,6 +500,106 @@ impl Baboon {
         }
     }
 
+    /// One section per changed element, in the order the tag has them, each
+    /// carrying the rows that belong to it so its panes can be filtered to just
+    /// those. A single filter over every row made each section render the
+    /// ancestors of every *other* section too -- a block that merely contained a
+    /// change appeared as though it were one.
+    fn build_diff_sections(rows: &[TagFieldDiff]) -> Vec<DiffSection> {
+        let mut sections: Vec<DiffSection> = Vec::new();
+        for row in rows {
+            let (element, _) = Self::split_element_path(&row.path);
+            let base_element = row
+                .base_path
+                .as_deref()
+                .map(|path| Self::split_element_path(path).0.to_owned());
+            let label = if Self::split_element_path(&row.path).1.is_empty() {
+                if row.b.is_empty() { row.a.clone() } else { row.b.clone() }
+            } else {
+                String::new()
+            };
+            // What happened to the element as a whole, from the row that is
+            // about the element rather than about a field inside it.
+            let kind = if Self::split_element_path(&row.path).1.is_empty() {
+                if row.a.is_empty() {
+                    ModExportChange::New
+                } else if row.b.is_empty() {
+                    ModExportChange::Unresolved
+                } else {
+                    ModExportChange::Modified
+                }
+            } else {
+                ModExportChange::Modified
+            };
+            // An added or removed element is reported with all of its
+            // contents, and those rows sit underneath it. They are already
+            // shown by that element's own pane, so they must not each open a
+            // section of their own -- doing so rendered a removed element's
+            // fields as a before/after split against whatever index had
+            // shifted into their place, inventing changes the diff never
+            // reported.
+            if let Some(last) = sections.last_mut()
+                && matches!(last.kind, ModExportChange::New | ModExportChange::Unresolved)
+                && row.path.starts_with(last.element.as_str())
+            {
+                last.rows.push(row.clone());
+                continue;
+            }
+            match sections.last_mut() {
+                Some(last) if last.element == element => {
+                    if last.label.is_empty() && !label.is_empty() {
+                        last.label = label;
+                        last.kind = kind;
+                    }
+                    last.rows.push(row.clone());
+                }
+                _ => sections.push(DiffSection {
+                    element: element.to_owned(),
+                    base_element,
+                    label,
+                    kind,
+                    rows: vec![row.clone()],
+                }),
+            }
+        }
+        sections
+    }
+
+    /// Arrange the sections into the shape of the tag, so a change is shown
+    /// inside the containers that hold it rather than under a path.
+    ///
+    /// Keyed on each section's container path -- its element path without the
+    /// final `[n]` -- split at `/`. An unbranching chain of containers is
+    /// merged into one title: four nested boxes around a single changed dword
+    /// is depth without information.
+    fn build_diff_tree(sections: Vec<DiffSection>) -> DiffNode {
+        let mut root = DiffNode::default();
+        for section in sections {
+            let (container, _) = Self::split_element_index(&section.element);
+            let mut node = &mut root;
+            for segment in container.split('/').filter(|s| !s.is_empty()) {
+                let existing = node
+                    .children
+                    .iter()
+                    .position(|child| child.title == segment);
+                let index = match existing {
+                    Some(index) => index,
+                    None => {
+                        node.children.push(DiffNode {
+                            title: segment.to_owned(),
+                            ..DiffNode::default()
+                        });
+                        node.children.len() - 1
+                    }
+                };
+                node = &mut node.children[index];
+            }
+            node.sections.push(section);
+        }
+        root.collapse_chains();
+        root
+    }
+
     /// Split `zone set pvs[3]` into the block it names and the element index.
     ///
     /// A reader wants to know which block changed and which element of it, not
@@ -639,112 +775,176 @@ impl Baboon {
             );
             return;
         }
-        // One section per changed element, in the order the tag has them, each
-        // carrying the rows that belong to it so its panes can be filtered to
-        // just those. A single filter over every row made each section render
-        // the ancestors of every *other* section too -- a block that merely
-        // contained a change appeared as though it were one.
-        let mut sections: Vec<(String, Option<String>, String, ModExportChange, Vec<TagFieldDiff>)> =
-            Vec::new();
-        for row in &diff.rows {
-            let (element, _) = Self::split_element_path(&row.path);
-            let base_element = row
-                .base_path
-                .as_deref()
-                .map(|path| Self::split_element_path(path).0.to_owned());
-            let label = if Self::split_element_path(&row.path).1.is_empty() {
-                if row.b.is_empty() { row.a.clone() } else { row.b.clone() }
-            } else {
-                String::new()
-            };
-            // What happened to the element as a whole, from the row that is
-            // about the element rather than about a field inside it.
-            let kind = if Self::split_element_path(&row.path).1.is_empty() {
-                if row.a.is_empty() {
-                    ModExportChange::New
-                } else if row.b.is_empty() {
-                    ModExportChange::Unresolved
-                } else {
-                    ModExportChange::Modified
-                }
-            } else {
-                ModExportChange::Modified
-            };
-            // An added or removed element is reported with all of its
-            // contents, and those rows sit underneath it. They are already
-            // shown by that element's own pane, so they must not each open a
-            // section of their own -- doing so rendered a removed element's
-            // fields as a before/after split against whatever index had
-            // shifted into their place, inventing changes the diff never
-            // reported.
-            if let Some((last, _, _, last_kind, last_rows)) = sections.last_mut()
-                && matches!(
-                    last_kind,
-                    ModExportChange::New | ModExportChange::Unresolved
-                )
-                && row.path.starts_with(last.as_str())
-            {
-                last_rows.push(row.clone());
-                continue;
-            }
-            match sections.last_mut() {
-                Some((last, _, existing, existing_kind, last_rows)) if last == element => {
-                    if existing.is_empty() && !label.is_empty() {
-                        *existing = label;
-                        *existing_kind = kind;
-                    }
-                    last_rows.push(row.clone());
-                }
-                _ => sections.push((
-                    element.to_owned(),
-                    base_element,
-                    label,
-                    kind,
-                    vec![row.clone()],
-                )),
-            }
+        let tree = Self::build_diff_tree(Self::build_diff_sections(&diff.rows));
+        Self::draw_diff_node(
+            ui,
+            &tree,
+            0,
+            diff,
+            names,
+            group_tag,
+            game,
+            definitions_root,
+            expert_mode,
+            scope,
+        );
+        if diff.truncated {
+            ui.add_space(4.0);
+            ui.label(
+                RichText::new("More differences than can be listed here.")
+                    .color(subtle_dark())
+                    .small(),
+            );
         }
+    }
 
-        for (element, base_element, label, kind, section_rows) in sections {
-            let filter = Self::diff_field_filter(&section_rows);
-            ui.add_space(8.0);
-            if !element.is_empty() {
-                ui.separator();
-                // `Unresolved` stands in for "gone" here, which is the only
-                // way an element can leave.
-                let (marker, heading) = match kind {
-                    ModExportChange::New => ("+", added_text()),
-                    ModExportChange::Unresolved => ("-", removed_text()),
-                    ModExportChange::Modified => ("~", modified_text()),
-                };
-                // Named as the block it belongs to, with the element called out
-                // inside it. The indexed path answers "where in the file"; what
-                // a reader wants is "which block, and which element of it".
-                let (container, index) = Self::split_element_index(&element);
-                ui.horizontal(|ui| {
-                    ui.label(
-                        RichText::new(container)
-                            .color(text_dark())
-                            .monospace()
-                            .strong(),
+
+    /// How many elements a block has on one side, for the block a change sits
+    /// in.
+    ///
+    /// It is the one fact the element panes cannot convey -- a pane shows the
+    /// element that went, not that the block went from six to five -- and it is
+    /// the first thing a reader checks.
+    fn block_len(tag: &blam_tags::TagFile, container: &str) -> Option<usize> {
+        let (parent, name) = match container.rsplit_once('/') {
+            Some((parent, name)) => (parent, name),
+            None => ("", container),
+        };
+        let root = tag.root();
+        let owner = if parent.is_empty() {
+            root
+        } else {
+            root.descend(parent)?
+        };
+        owner
+            .fields_all()
+            .find(|field| field.name() == name)?
+            .as_block()
+            .map(|block| block.len())
+    }
+
+    /// `6 \u{2192} 5`, when a container's element count changed.
+    fn block_count_change(diff: &ModRowDiff, node: &DiffNode) -> Option<String> {
+        let section = node.sections.first()?;
+        let (container, _) = Self::split_element_index(&section.element);
+        let base_container = section
+            .base_element
+            .as_deref()
+            .map(|element| Self::split_element_index(element).0)
+            .unwrap_or(container);
+        let before = Self::block_len(diff.base.as_ref()?, base_container)?;
+        let after = Self::block_len(diff.edited.as_ref()?, container)?;
+        (before != after).then(|| format!("{before} \u{2192} {after}"))
+    }
+
+    /// One container and everything that changed inside it.
+    #[allow(clippy::too_many_arguments)]
+    fn draw_diff_node(
+        ui: &mut Ui,
+        node: &DiffNode,
+        depth: usize,
+        diff: &ModRowDiff,
+        names: &TagNameIndex,
+        group_tag: u32,
+        game: Option<&str>,
+        definitions_root: Option<&Path>,
+        expert_mode: bool,
+        scope: &str,
+    ) {
+        for section in &node.sections {
+            Self::draw_diff_section(
+                ui,
+                section,
+                diff,
+                names,
+                group_tag,
+                game,
+                definitions_root,
+                expert_mode,
+                scope,
+            );
+        }
+        for child in &node.children {
+            // The editor's own container chrome, so a block in the review looks
+            // like the block it is.
+            let title = match Self::block_count_change(diff, child) {
+                Some(counts) => format!("{}  {counts}", child.title),
+                None => child.title.clone(),
+            };
+            draw_foundation_group(
+                ui,
+                title,
+                ("diff_node", scope, child.title.as_str()),
+                depth,
+                true,
+                None,
+                |ui| {
+                    Self::draw_diff_node(
+                        ui,
+                        child,
+                        depth + 1,
+                        diff,
+                        names,
+                        group_tag,
+                        game,
+                        definitions_root,
+                        expert_mode,
+                        scope,
                     );
-                    ui.label(RichText::new(marker).color(heading).monospace().strong());
-                    if let Some(index) = index {
-                        ui.label(RichText::new(format!("element {index}")).color(heading));
+                },
+            );
+        }
+    }
+
+    /// One changed element, inside whatever container is already drawn around it.
+    #[allow(clippy::too_many_arguments)]
+    fn draw_diff_section(
+        ui: &mut Ui,
+        section: &DiffSection,
+        diff: &ModRowDiff,
+        names: &TagNameIndex,
+        group_tag: u32,
+        game: Option<&str>,
+        definitions_root: Option<&Path>,
+        expert_mode: bool,
+        scope: &str,
+    ) {
+        let DiffSection {
+            element,
+            base_element,
+            label,
+            kind,
+            rows: section_rows,
+        } = section;
+        let (kind, element, base_element, label) = (*kind, element.clone(), base_element.clone(), label.clone());
+        let filter = Self::diff_field_filter(section_rows);
+        ui.add_space(6.0);
+        if !element.is_empty() {
+            // `Unresolved` stands in for "gone", the only way an element leaves.
+            let (marker, heading) = match kind {
+                ModExportChange::New => ("+", added_text()),
+                ModExportChange::Unresolved => ("-", removed_text()),
+                ModExportChange::Modified => ("~", modified_text()),
+            };
+            // The container above already names the block, so this only has to
+            // say which element of it, and what happened to it.
+            let (_, index) = Self::split_element_index(&element);
+            ui.horizontal(|ui| {
+                ui.label(RichText::new(marker).color(heading).monospace().strong());
+                if let Some(index) = index {
+                    ui.label(RichText::new(format!("element {index}")).color(heading));
+                }
+                if !label.is_empty() {
+                    let detail = label
+                        .split_once(" \u{2014} ")
+                        .map(|(_, rest)| rest)
+                        .unwrap_or(label.as_str());
+                    if detail != format!("element {}", index.unwrap_or_default()) {
+                        ui.label(RichText::new(detail).color(heading).small());
                     }
-                    if !label.is_empty() {
-                        // The label already names the element; the redundant
-                        // "added -- " / "removed -- " prefix is the marker's job.
-                        let detail = label
-                            .split_once(" — ")
-                            .map(|(_, rest)| rest)
-                            .unwrap_or(label.as_str());
-                        if detail != format!("element {}", index.unwrap_or_default()) {
-                            ui.label(RichText::new(detail).color(heading).small());
-                        }
-                    }
-                });
-            }
+                }
+            });
+        }
             // Only a modified element has two sides worth comparing. An
             // element that was added or removed exists on one side only, and a
             // half-width pane beside an empty twin says less than one full
@@ -821,15 +1021,6 @@ impl Baboon {
                     });
                 }
             }
-        }
-        if diff.truncated {
-            ui.add_space(4.0);
-            ui.label(
-                RichText::new("More differences than can be listed here.")
-                    .color(subtle_dark())
-                    .small(),
-            );
-        }
     }
 
     /// Review what Export Mod is about to write, and where.
@@ -2151,6 +2342,100 @@ impl Baboon {
 mod mod_export_tests {
     use super::*;
     use std::path::PathBuf;
+
+    /// The reported case, from `review-diagnostic.json`: two top-level fields
+    /// changed, `zone set pvs[3]` deleted, a `zone sets` element added. What the
+    /// reporter asked to see is exactly three things, in the containers that
+    /// hold them -- not 131 rows of shifted indices.
+    #[test]
+    fn tree_matches_the_reported_case() {
+        fn row(path: &str, base: Option<&str>, before: &str, after: &str) -> TagFieldDiff {
+            TagFieldDiff {
+                path: path.to_owned(),
+                base_path: base.map(str::to_owned),
+                a: before.to_owned(),
+                b: after.to_owned(),
+            }
+        }
+        let mut rows = vec![
+            row("flags", Some("flags"), "0x0000 (none set)", "0x000E [...]"),
+            row(
+                "sandbox origin point",
+                Some("sandbox origin point"),
+                "x=0, y=-0, z=0",
+                "x=1, y=2, z=3",
+            ),
+            row(
+                "zone set pvs[3]",
+                Some("zone set pvs[3]"),
+                "removed \u{2014} element 3",
+                "",
+            ),
+        ];
+        // The removed element's own fields follow it, and must fold into it.
+        for field in ["structure bsp mask", "version"] {
+            let path = format!("zone set pvs[3]/{field}");
+            rows.push(row(&path, Some(&path), "11", ""));
+        }
+        rows.push(row("zone sets[5]", None, "", "added \u{2014} element 5"));
+        for field in ["cinematic zones", "hint previous zone set"] {
+            rows.push(row(&format!("zone sets[5]/{field}"), None, "", "0"));
+        }
+
+        let sections = Baboon::build_diff_sections(&rows);
+        let kinds: Vec<_> = sections
+            .iter()
+            .map(|s| (s.element.as_str(), s.kind, s.rows.len()))
+            .collect();
+        assert_eq!(
+            kinds,
+            vec![
+                ("", ModExportChange::Modified, 2),
+                ("zone set pvs[3]", ModExportChange::Unresolved, 3),
+                ("zone sets[5]", ModExportChange::New, 3),
+            ],
+        );
+
+        let tree = Baboon::build_diff_tree(sections);
+        // The two top-level field changes stay at the root; each block holds
+        // only its own changed element.
+        assert_eq!(tree.sections.len(), 1);
+        assert_eq!(tree.sections[0].element, "");
+        let containers: Vec<_> = tree
+            .children
+            .iter()
+            .map(|c| (c.title.as_str(), c.sections.len(), c.children.len()))
+            .collect();
+        assert_eq!(
+            containers,
+            vec![("zone set pvs", 1, 0), ("zone sets", 1, 0)],
+        );
+    }
+
+    /// A change buried several blocks deep reads as one breadcrumb, not a stack
+    /// of boxes each containing only the next.
+    #[test]
+    fn single_child_container_chains_collapse() {
+        let section = DiffSection {
+            element: "structure bsp pvs[0]/cluster pvs[0]/cluster pvs bit vectors[0]".to_owned(),
+            base_element: None,
+            label: String::new(),
+            kind: ModExportChange::Modified,
+            rows: Vec::new(),
+        };
+        let tree = Baboon::build_diff_tree(vec![section]);
+        assert_eq!(tree.children.len(), 1);
+        let chain = &tree.children[0];
+        // Intermediate containers keep their element index -- it is the only
+        // place that says *which* cluster the change is in. The innermost one
+        // drops it because the section row states it.
+        assert_eq!(
+            chain.title,
+            "structure bsp pvs[0] \u{203a} cluster pvs[0] \u{203a} cluster pvs bit vectors",
+        );
+        assert_eq!(chain.sections.len(), 1);
+        assert!(chain.children.is_empty());
+    }
 
     fn dialog(name: &str) -> ModExportDialog {
         ModExportDialog {

--- a/src/app/ui/dialogs.rs
+++ b/src/app/ui/dialogs.rs
@@ -637,7 +637,7 @@ impl Baboon {
         let filter = Self::diff_field_filter(&diff.rows);
 
         // One section per changed element, in the order the tag has them.
-        let mut sections: Vec<(String, Option<String>, String)> = Vec::new();
+        let mut sections: Vec<(String, Option<String>, String, ModExportChange)> = Vec::new();
         for row in &diff.rows {
             let (element, _) = Self::split_element_path(&row.path);
             let base_element = row
@@ -649,29 +649,58 @@ impl Baboon {
             } else {
                 String::new()
             };
+            // What happened to the element as a whole, from the row that is
+            // about the element rather than about a field inside it.
+            let kind = if Self::split_element_path(&row.path).1.is_empty() {
+                if row.a.is_empty() {
+                    ModExportChange::New
+                } else if row.b.is_empty() {
+                    ModExportChange::Unresolved
+                } else {
+                    ModExportChange::Modified
+                }
+            } else {
+                ModExportChange::Modified
+            };
             match sections.last_mut() {
-                Some((last, _, existing)) if last == element => {
+                Some((last, _, existing, existing_kind)) if last == element => {
                     if existing.is_empty() && !label.is_empty() {
                         *existing = label;
+                        *existing_kind = kind;
                     }
                 }
-                _ => sections.push((element.to_owned(), base_element, label)),
+                _ => sections.push((element.to_owned(), base_element, label, kind)),
             }
         }
 
-        for (element, base_element, label) in sections {
+        for (element, base_element, label, kind) in sections {
             ui.add_space(8.0);
             if !element.is_empty() {
                 ui.separator();
+                // `Unresolved` stands in for "gone" here, which is the only
+                // way an element can leave.
+                let (marker, heading) = match kind {
+                    ModExportChange::New => ("+", added_text()),
+                    ModExportChange::Unresolved => ("-", removed_text()),
+                    ModExportChange::Modified => ("~", modified_text()),
+                };
                 ui.horizontal(|ui| {
-                    ui.label(RichText::new(&element).color(modified_text()).monospace());
+                    ui.label(RichText::new(marker).color(heading).monospace().strong());
+                    ui.label(RichText::new(&element).color(heading).monospace());
                     if !label.is_empty() {
-                        ui.label(RichText::new(&label).color(subtle_dark()).small());
+                        ui.label(RichText::new(&label).color(heading).small());
                     }
                 });
             }
             ui.columns(2, |columns| {
                 columns[0].push_id(("diff_before", &element), |ui| {
+                    // Tinted so which side is which is apparent at a glance
+                    // rather than only from the heading above it.
+                    Frame::none()
+                        .fill(removed_wash())
+                        .stroke(Stroke::new(1.0, removed_text().gamma_multiply(0.5)))
+                        .inner_margin(egui::Margin::symmetric(6.0, 6.0))
+                        .show(ui, |ui| {
                     ui.label(RichText::new("before").color(removed_text()).small());
                     match diff.base.as_ref() {
                         Some(base) => Self::draw_diff_side(
@@ -693,8 +722,14 @@ impl Baboon {
                             );
                         }
                     }
+                        });
                 });
                 columns[1].push_id(("diff_after", &element), |ui| {
+                    Frame::none()
+                        .fill(added_wash())
+                        .stroke(Stroke::new(1.0, added_text().gamma_multiply(0.5)))
+                        .inner_margin(egui::Margin::symmetric(6.0, 6.0))
+                        .show(ui, |ui| {
                     ui.label(RichText::new("after").color(added_text()).small());
                     if let Some(edited) = diff.edited.as_ref() {
                         Self::draw_diff_side(
@@ -710,6 +745,7 @@ impl Baboon {
                             &format!("{scope}|after"),
                         );
                     }
+                        });
                 });
             });
         }

--- a/src/app/ui/dialogs.rs
+++ b/src/app/ui/dialogs.rs
@@ -448,28 +448,6 @@ impl Baboon {
     /// Destructive-save confirmation for Campaign Evolved container tags. Save
     /// overwrites the shipped pak files in place, so we always confirm and point
     /// the user at Export Mod as the non-destructive alternative.
-    /// Fold a mod name into a file-safe stem, keeping its capitalisation.
-    ///
-    /// The name becomes three file names in a folder the user never types, so
-    /// spaces and punctuation are separators to be normalised rather than
-    /// characters to carry through. Anything that is not a letter, digit,
-    /// hyphen or underscore becomes a hyphen, runs collapse, and the ends are
-    /// trimmed -- kebab case, with the user's own casing left alone.
-    ///
-    /// Underscores survive deliberately: `_P` is what marks a mod's priority,
-    /// and folding it to `-P` would leave `stem` appending a second one.
-    fn sanitize_mod_name(name: &str) -> String {
-        let mut out = String::with_capacity(name.len());
-        for c in name.chars() {
-            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
-                out.push(c);
-            } else if !out.ends_with('-') {
-                out.push('-');
-            }
-        }
-        out.trim_matches('-').to_owned()
-    }
-
     /// Split a diff path into the element it belongs to and the field within
     /// it, so changes can be grouped under one heading per element.
     ///
@@ -849,6 +827,7 @@ impl Baboon {
         let mut cancel = false;
         let mut export = false;
         let mut browse = false;
+        let mut acknowledge: Option<bool> = None;
         let mut set_all: Option<bool> = None;
         let mut toggled: Option<usize> = None;
         let mut expand_toggled: Option<String> = None;
@@ -1034,16 +1013,29 @@ impl Baboon {
                         RichText::new(format!("Overwrites: {}", existing.join(", ")))
                             .color(egui::Color32::from_rgb(210, 120, 90)),
                     );
+                    // Named and then confirmed. A mod is three files plus its
+                    // sidecar, and replacing someone's existing mod should take
+                    // more than not noticing a line of text.
+                    let mut acknowledged = dialog.overwrite_acknowledged;
+                    if ui
+                        .checkbox(&mut acknowledged, "Replace these files")
+                        .changed()
+                    {
+                        acknowledge = Some(acknowledged);
+                    }
                 }
                 ui.add_space(10.0);
                 ui.horizontal(|ui| {
-                    let ready = name_ok && included > 0;
+                    let overwrite_ok = existing.is_empty() || dialog.overwrite_acknowledged;
+                    let ready = name_ok && included > 0 && overwrite_ok;
                     if ui
                         .add_enabled(ready, egui::Button::new("Export"))
-                        .on_disabled_hover_text(if name_ok {
+                        .on_disabled_hover_text(if !name_ok {
+                            "Enter a name for the mod"
+                        } else if included == 0 {
                             "Nothing is selected to export"
                         } else {
-                            "Enter a name for the mod"
+                            "Confirm that the existing files may be replaced"
                         })
                         .clicked()
                     {
@@ -1058,8 +1050,15 @@ impl Baboon {
         // Applied after the window closes its borrow of `self`.
         if let Some(dialog) = self.mod_export.as_mut() {
             if dialog.name != name_edit {
-                dialog.name = Self::sanitize_mod_name(&name_edit);
+                // Kept verbatim. Folding the buffer on every keystroke ate the
+                // space in "My Mod" before the second word could be typed; the
+                // fold belongs to the file name, which `stem` produces and the
+                // dialog shows live beside the field.
+                dialog.name = name_edit;
                 dialog.overwrite_acknowledged = false;
+            }
+            if let Some(value) = acknowledge {
+                dialog.overwrite_acknowledged = value;
             }
             if let Some(value) = set_all {
                 for row in dialog.rows.iter_mut() {
@@ -2103,15 +2102,26 @@ mod mod_export_tests {
     /// carry through -- while the user's own capitalisation is theirs to keep.
     #[test]
     fn a_mod_name_becomes_a_file_safe_stem() {
-        assert_eq!(Baboon::sanitize_mod_name("My Cool Mod"), "My-Cool-Mod");
-        assert_eq!(Baboon::sanitize_mod_name("h2a magnum!"), "h2a-magnum");
-        assert_eq!(Baboon::sanitize_mod_name("  trimmed  "), "trimmed");
+        assert_eq!(sanitize_mod_name("My Cool Mod"), "My-Cool-Mod");
+        assert_eq!(sanitize_mod_name("h2a magnum!"), "h2a-magnum");
+        assert_eq!(sanitize_mod_name("  trimmed  "), "trimmed");
         // Path syntax cannot survive: these become three files somewhere the
         // user did not choose.
-        assert_eq!(Baboon::sanitize_mod_name("../../etc/passwd"), "etc-passwd");
-        assert_eq!(Baboon::sanitize_mod_name("my:mod?"), "my-mod");
+        assert_eq!(sanitize_mod_name("../../etc/passwd"), "etc-passwd");
+        assert_eq!(sanitize_mod_name("my:mod?"), "my-mod");
         // Underscores stay, so `_P` keeps meaning what it means.
-        assert_eq!(Baboon::sanitize_mod_name("my_mod_P"), "my_mod_P");
-        assert_eq!(dialog(&Baboon::sanitize_mod_name("My Mod")).stem(), "My-Mod_P");
+        assert_eq!(sanitize_mod_name("my_mod_P"), "my_mod_P");
+    }
+
+    /// The buffer holds what the user typed; only the file name is folded.
+    /// Folding as they type ate the space in "My Mod" before the second word
+    /// could be reached.
+    #[test]
+    fn a_name_is_folded_only_when_it_becomes_a_file_name() {
+        assert_eq!(dialog("My Mod").stem(), "My-Mod_P");
+        assert_eq!(dialog("My ").stem(), "My_P");
+        // Already suffixed, in either case the game accepts.
+        assert_eq!(dialog("thing_P").stem(), "thing_P");
+        assert_eq!(dialog("thing_p").stem(), "thing_p");
     }
 }

--- a/src/app/ui/dialogs.rs
+++ b/src/app/ui/dialogs.rs
@@ -461,6 +461,98 @@ impl Baboon {
             .to_owned()
     }
 
+    /// Split a diff path into the element it belongs to and the field within
+    /// it, so changes can be grouped under one heading per element.
+    ///
+    /// Changes nest -- `weapons[2]/triggers[0]/barrels[1]/damage` -- and the
+    /// innermost element is the one worth heading, with the whole chain shown
+    /// so it is unambiguous which one it is.
+    fn split_element_path(path: &str) -> (&str, &str) {
+        match path.rfind(']') {
+            Some(end) => {
+                let field = &path[end + 1..];
+                (&path[..=end], field.strip_prefix('/').unwrap_or(field))
+            }
+            None => ("", path),
+        }
+    }
+
+    /// One tag's differences, grouped by the element each belongs to.
+    fn draw_mod_export_diff(ui: &mut Ui, diff: &ModRowDiff) {
+        if let Some(error) = diff.error.as_deref() {
+            ui.label(RichText::new(error).color(removed_text()).small());
+            return;
+        }
+        if diff.rows.is_empty() {
+            ui.label(
+                RichText::new("No differences from the shipped tag.")
+                    .color(subtle_dark())
+                    .small(),
+            );
+            return;
+        }
+        let mut current = None;
+        for row in &diff.rows {
+            let (element, field) = Self::split_element_path(&row.path);
+            if current != Some(element) {
+                current = Some(element);
+                if !element.is_empty() {
+                    ui.add_space(4.0);
+                    ui.separator();
+                    ui.label(
+                        RichText::new(element)
+                            .color(modified_text())
+                            .monospace()
+                            .small(),
+                    );
+                }
+            }
+            // A whole element added, removed or moved: the row is about the
+            // element itself, not a field inside it.
+            if field.is_empty() {
+                let (marker, color) = if row.a.is_empty() {
+                    ("+", added_text())
+                } else if row.b.is_empty() {
+                    ("-", removed_text())
+                } else {
+                    ("~", modified_text())
+                };
+                ui.horizontal(|ui| {
+                    ui.label(RichText::new(marker).color(color).monospace());
+                    let text = if row.b.is_empty() { &row.a } else { &row.b };
+                    ui.label(RichText::new(text).color(color).small());
+                });
+                continue;
+            }
+            ui.horizontal(|ui| {
+                ui.label(
+                    RichText::new(field)
+                        .color(text_dark())
+                        .monospace()
+                        .small(),
+                );
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    if !row.b.is_empty() {
+                        ui.label(RichText::new(&row.b).color(added_text()).small());
+                        ui.label(RichText::new("+").color(added_text()).monospace().small());
+                    }
+                    if !row.a.is_empty() {
+                        ui.label(RichText::new(&row.a).color(removed_text()).small());
+                        ui.label(RichText::new("-").color(removed_text()).monospace().small());
+                    }
+                });
+            });
+        }
+        if diff.truncated {
+            ui.add_space(4.0);
+            ui.label(
+                RichText::new("More differences than can be listed here.")
+                    .color(subtle_dark())
+                    .small(),
+            );
+        }
+    }
+
     /// Review what Export Mod is about to write, and where.
     ///
     /// The save dialog this replaces asked for one file name when the output is
@@ -506,6 +598,7 @@ impl Baboon {
         let mut browse = false;
         let mut set_all: Option<bool> = None;
         let mut toggled: Option<usize> = None;
+        let mut expand_toggled: Option<String> = None;
         let mut name_edit = dialog.name.clone();
 
         egui::Window::new("Export Mod")
@@ -548,7 +641,20 @@ impl Baboon {
                     .auto_shrink([false, false])
                     .show(ui, |ui| {
                         for (index, row) in dialog.rows.iter().enumerate() {
+                            let expandable = row.kind == ModExportChange::Modified;
+                            let expanded = dialog.expanded.contains(&row.identity);
                             ui.horizontal(|ui| {
+                                if expandable {
+                                    if ui
+                                        .small_button(if expanded { "v" } else { ">" })
+                                        .on_hover_text("Show what changed")
+                                        .clicked()
+                                    {
+                                        expand_toggled = Some(row.identity.clone());
+                                    }
+                                } else {
+                                    ui.add_space(18.0);
+                                }
                                 let mut include = row.include;
                                 let enabled = row.kind != ModExportChange::Unresolved;
                                 if ui
@@ -585,6 +691,20 @@ impl Baboon {
                                     },
                                 );
                             });
+                            if expandable && expanded {
+                                ui.indent(("mod_export_diff", index), |ui| {
+                                    match dialog.diffs.get(&row.identity) {
+                                        Some(diff) => Self::draw_mod_export_diff(ui, diff),
+                                        None => {
+                                            ui.label(
+                                                RichText::new("Comparing...")
+                                                    .color(subtle_dark())
+                                                    .small(),
+                                            );
+                                        }
+                                    }
+                                });
+                            }
                         }
                     });
                 ui.add_space(10.0);
@@ -661,6 +781,35 @@ impl Baboon {
                 && let Some(row) = dialog.rows.get_mut(index)
             {
                 row.include = !row.include;
+            }
+            if let Some(identity) = expand_toggled.as_ref() {
+                if !dialog.expanded.remove(identity) {
+                    dialog.expanded.insert(identity.clone());
+                }
+            }
+        }
+        // Computed outside the window, and only for rows that are open and have
+        // no result yet: each one costs a container read and two parses.
+        let pending: Vec<String> = self
+            .mod_export
+            .as_ref()
+            .map(|dialog| {
+                dialog
+                    .expanded
+                    .iter()
+                    .filter(|identity| !dialog.diffs.contains_key(*identity))
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default();
+        if !pending.is_empty()
+            && let Some(index) = self.resolve_kit(kit)
+        {
+            for identity in pending {
+                let diff = self.diff_reviewed_tag(index, &identity);
+                if let Some(dialog) = self.mod_export.as_mut() {
+                    dialog.diffs.insert(identity, diff);
+                }
             }
         }
         if browse
@@ -1621,6 +1770,8 @@ mod mod_export_tests {
             name: name.to_owned(),
             folder: PathBuf::from("/tmp"),
             overwrite_acknowledged: false,
+            expanded: Default::default(),
+            diffs: Default::default(),
         }
     }
 
@@ -1632,6 +1783,27 @@ mod mod_export_tests {
         assert_eq!(dialog("h2a_magnum").stem(), "h2a_magnum_P");
         assert_eq!(dialog("h2a_magnum_P").stem(), "h2a_magnum_P");
         assert_eq!(dialog("  spaced  ").stem(), "spaced_P");
+    }
+
+    /// Changes nest, and the innermost element is the one worth heading. The
+    /// whole chain is kept so it is unambiguous which element that is.
+    #[test]
+    fn a_diff_path_splits_into_its_element_and_field() {
+        assert_eq!(
+            Baboon::split_element_path("weapons[2]/triggers[0]/barrels[1]/damage"),
+            ("weapons[2]/triggers[0]/barrels[1]", "damage")
+        );
+        // A row about the element itself -- added, removed or moved -- has no
+        // field part, which is how the renderer tells the two apart.
+        assert_eq!(
+            Baboon::split_element_path("vehicle palette[3]"),
+            ("vehicle palette[3]", "")
+        );
+        // A field at the top level of the tag belongs to no element.
+        assert_eq!(
+            Baboon::split_element_path("flags"),
+            ("", "flags")
+        );
     }
 
     /// The name becomes three files in a folder the user never types, so a

--- a/src/app/ui/dialogs.rs
+++ b/src/app/ui/dialogs.rs
@@ -601,7 +601,12 @@ impl Baboon {
         let mut expand_toggled: Option<String> = None;
         let mut name_edit = dialog.name.clone();
 
-        egui::Window::new("Export Mod")
+        let review_only = dialog.review_only;
+        egui::Window::new(if review_only {
+            "Unexported changes"
+        } else {
+            "Export Mod"
+        })
             .id(egui::Id::new("mod_export"))
             .open(&mut open)
             .collapsible(false)
@@ -626,14 +631,16 @@ impl Baboon {
                                 .color(egui::Color32::from_rgb(210, 120, 90)),
                         );
                     }
-                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                        if ui.button("Include none").clicked() {
-                            set_all = Some(false);
-                        }
-                        if ui.button("Include all").clicked() {
-                            set_all = Some(true);
-                        }
-                    });
+                    if !review_only {
+                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                            if ui.button("Include none").clicked() {
+                                set_all = Some(false);
+                            }
+                            if ui.button("Include all").clicked() {
+                                set_all = Some(true);
+                            }
+                        });
+                    }
                 });
                 ui.add_space(6.0);
                 egui::ScrollArea::vertical()
@@ -641,13 +648,19 @@ impl Baboon {
                     .auto_shrink([false, false])
                     .show(ui, |ui| {
                         for (index, row) in dialog.rows.iter().enumerate() {
-                            let expandable = row.kind == ModExportChange::Modified;
+                            // A new tag opens too: it has no counterpart to
+                            // compare against, so it shows what is in it.
+                            let expandable = row.kind != ModExportChange::Unresolved;
                             let expanded = dialog.expanded.contains(&row.identity);
                             ui.horizontal(|ui| {
                                 if expandable {
                                     if ui
                                         .small_button(if expanded { "v" } else { ">" })
-                                        .on_hover_text("Show what changed")
+                                        .on_hover_text(if row.kind == ModExportChange::New {
+                                            "Show what this tag contains"
+                                        } else {
+                                            "Show what changed"
+                                        })
                                         .clicked()
                                     {
                                         expand_toggled = Some(row.identity.clone());
@@ -655,13 +668,15 @@ impl Baboon {
                                 } else {
                                     ui.add_space(18.0);
                                 }
-                                let mut include = row.include;
-                                let enabled = row.kind != ModExportChange::Unresolved;
-                                if ui
-                                    .add_enabled(enabled, egui::Checkbox::new(&mut include, ""))
-                                    .changed()
-                                {
-                                    toggled = Some(index);
+                                if !review_only {
+                                    let mut include = row.include;
+                                    let enabled = row.kind != ModExportChange::Unresolved;
+                                    if ui
+                                        .add_enabled(enabled, egui::Checkbox::new(&mut include, ""))
+                                        .changed()
+                                    {
+                                        toggled = Some(index);
+                                    }
                                 }
                                 let (marker, color) = match row.kind {
                                     ModExportChange::New => ("+", added_text()),
@@ -707,6 +722,15 @@ impl Baboon {
                             }
                         }
                     });
+                if review_only {
+                    ui.add_space(10.0);
+                    ui.horizontal(|ui| {
+                        if ui.button("Close").clicked() {
+                            cancel = true;
+                        }
+                    });
+                    return;
+                }
                 ui.add_space(10.0);
                 ui.horizontal(|ui| {
                     ui.label(RichText::new("Mod name").color(text_dark()));
@@ -1759,6 +1783,7 @@ mod mod_export_tests {
     fn dialog(name: &str) -> ModExportDialog {
         ModExportDialog {
             kit: KitId(0),
+            review_only: false,
             snapshot: CampaignProjectSnapshot {
                 game: "haloce_evolved".to_owned(),
                 source_path: PathBuf::new(),

--- a/src/app/ui/dialogs.rs
+++ b/src/app/ui/dialogs.rs
@@ -973,7 +973,9 @@ impl Baboon {
                                 // window grows to fit it every frame.
                                 egui::ScrollArea::horizontal()
                                     .id_salt((title, &element))
-                                    .auto_shrink([false, false])
+                                    // Fill the pane's width, but only as tall as
+                                    // what is in it.
+                                    .auto_shrink([false, true])
                                     .show(ui, |ui| {
                                         let (tag, path, side) = if before {
                                             (
@@ -1016,7 +1018,11 @@ impl Baboon {
                 ModExportChange::Modified => {
                     ui.horizontal_top(|ui| {
                         pane(ui, half, true, "before");
-                        ui.separator();
+                        // Not a separator: in a horizontal layout it stretches
+                        // to the panel's whole remaining height, which left a
+                        // screen of empty space under two short panes. The two
+                        // washes already read as two panes.
+                        ui.add_space(4.0);
                         pane(ui, half, false, "after");
                     });
                 }

--- a/src/app/ui/dialogs.rs
+++ b/src/app/ui/dialogs.rs
@@ -510,6 +510,8 @@ impl Baboon {
             // A whole element added, removed or moved: the row is about the
             // element itself, not a field inside it.
             if field.is_empty() {
+                // Both sides equal names an element whose own fields changed;
+                // one side empty means the element itself came or went.
                 let (marker, color) = if row.a.is_empty() {
                     ("+", added_text())
                 } else if row.b.is_empty() {

--- a/src/app/ui/dialogs.rs
+++ b/src/app/ui/dialogs.rs
@@ -827,6 +827,7 @@ impl Baboon {
         let mut cancel = false;
         let mut export = false;
         let mut browse = false;
+        let mut save_diagnostic = false;
         let mut acknowledge: Option<bool> = None;
         let mut set_all: Option<bool> = None;
         let mut toggled: Option<usize> = None;
@@ -974,6 +975,13 @@ impl Baboon {
                         if ui.button("Close").clicked() {
                             cancel = true;
                         }
+                        if ui
+                            .button("Save diagnostic...")
+                            .on_hover_text("Write both sides of every tag, and the computed differences, to a folder")
+                            .clicked()
+                        {
+                            save_diagnostic = true;
+                        }
                     });
                     return;
                 }
@@ -1044,6 +1052,13 @@ impl Baboon {
                     if ui.button("Cancel").clicked() {
                         cancel = true;
                     }
+                    if ui
+                        .button("Save diagnostic...")
+                        .on_hover_text("Write both sides of every tag, and the computed differences, to a folder")
+                        .clicked()
+                    {
+                        save_diagnostic = true;
+                    }
                 });
             });
 
@@ -1101,6 +1116,18 @@ impl Baboon {
                     dialog.diffs.insert(identity, diff);
                 }
             }
+        }
+        if save_diagnostic
+            && let Some(folder) = rfd::FileDialog::new()
+                .set_title("Save review diagnostic into folder")
+                .pick_folder()
+        {
+            self.status = match self.save_review_diagnostic(folder.clone()) {
+                Ok(count) => {
+                    format!("Wrote a diagnostic for {count} tag(s) to {}", folder.display())
+                }
+                Err(error) => error,
+            };
         }
         if browse
             && let Some(folder) = rfd::FileDialog::new()

--- a/src/app/ui/dialogs.rs
+++ b/src/app/ui/dialogs.rs
@@ -477,7 +477,13 @@ impl Baboon {
         }
     }
 
-    /// One tag's differences, grouped by the element each belongs to.
+    /// One tag's differences, laid out like the editor: a field label, then
+    /// its old and new values side by side in the editor's own value cells.
+    ///
+    /// The values are the point of the whole dialog, so they are shown the way
+    /// the editor shows values -- readable, full width, in a cell -- rather
+    /// than as small text crammed against the right edge. Old on the left in
+    /// red, new on the right in green.
     fn draw_mod_export_diff(ui: &mut Ui, diff: &ModRowDiff) {
         if let Some(error) = diff.error.as_deref() {
             ui.label(RichText::new(error).color(removed_text()).small());
@@ -491,27 +497,48 @@ impl Baboon {
             );
             return;
         }
+        // Split what is left after the label between the two value cells.
+        let available = ui.available_width();
+        let label_width = (available * 0.34).clamp(120.0, 320.0);
+        let cell_width = ((available - label_width - 24.0) / 2.0).max(80.0);
+
+        // Named, not just coloured: which side is which should not depend on
+        // telling red from green.
+        ui.horizontal(|ui| {
+            ui.add_space(4.0);
+            let (rect, _) = ui.allocate_exact_size(Vec2::new(label_width, 16.0), Sense::hover());
+            let _ = rect;
+            let (before, _) = ui.allocate_exact_size(Vec2::new(cell_width, 16.0), Sense::hover());
+            ui.painter().text(
+                before.left_center() + Vec2::new(5.0, 0.0),
+                Align2::LEFT_CENTER,
+                "before",
+                FontId::proportional(11.0),
+                removed_text(),
+            );
+            let (after, _) = ui.allocate_exact_size(Vec2::new(cell_width, 16.0), Sense::hover());
+            ui.painter().text(
+                after.left_center() + Vec2::new(5.0, 0.0),
+                Align2::LEFT_CENTER,
+                "after",
+                FontId::proportional(11.0),
+                added_text(),
+            );
+        });
+
         let mut current = None;
         for row in &diff.rows {
             let (element, field) = Self::split_element_path(&row.path);
             if current != Some(element) {
                 current = Some(element);
                 if !element.is_empty() {
-                    ui.add_space(4.0);
+                    ui.add_space(6.0);
                     ui.separator();
-                    ui.label(
-                        RichText::new(element)
-                            .color(modified_text())
-                            .monospace()
-                            .small(),
-                    );
                 }
             }
-            // A whole element added, removed or moved: the row is about the
-            // element itself, not a field inside it.
+            // A row about the element itself: added, removed, moved, or naming
+            // an element whose own fields changed.
             if field.is_empty() {
-                // Both sides equal names an element whose own fields changed;
-                // one side empty means the element itself came or went.
                 let (marker, color) = if row.a.is_empty() {
                     ("+", added_text())
                 } else if row.b.is_empty() {
@@ -520,29 +547,54 @@ impl Baboon {
                     ("~", modified_text())
                 };
                 ui.horizontal(|ui| {
-                    ui.label(RichText::new(marker).color(color).monospace());
+                    ui.label(RichText::new(marker).color(color).monospace().strong());
                     let text = if row.b.is_empty() { &row.a } else { &row.b };
-                    ui.label(RichText::new(text).color(color).small());
+                    ui.label(RichText::new(text).color(color).strong());
+                    ui.label(
+                        RichText::new(element)
+                            .color(subtle_dark())
+                            .monospace()
+                            .small(),
+                    );
                 });
                 continue;
             }
             ui.horizontal(|ui| {
-                ui.label(
-                    RichText::new(field)
-                        .color(text_dark())
-                        .monospace()
-                        .small(),
+                ui.add_space(4.0);
+                let (rect, _) =
+                    ui.allocate_exact_size(Vec2::new(label_width, 24.0), Sense::hover());
+                ui.painter().text(
+                    rect.left_center() + Vec2::new(2.0, 0.0),
+                    Align2::LEFT_CENTER,
+                    field,
+                    FontId::proportional(12.5),
+                    text_dark(),
                 );
-                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                    if !row.b.is_empty() {
-                        ui.label(RichText::new(&row.b).color(added_text()).small());
-                        ui.label(RichText::new("+").color(added_text()).monospace().small());
-                    }
-                    if !row.a.is_empty() {
-                        ui.label(RichText::new(&row.a).color(removed_text()).small());
-                        ui.label(RichText::new("-").color(removed_text()).monospace().small());
-                    }
-                });
+                // An absent side means the value did not exist before or does
+                // not exist now; an empty cell says that more clearly than a
+                // missing one, which would misalign the pair.
+                foundation_input_cell_colored(
+                    ui,
+                    &row.a,
+                    cell_width,
+                    if row.a.is_empty() {
+                        subtle_dark()
+                    } else {
+                        removed_text()
+                    },
+                    None,
+                );
+                foundation_input_cell_colored(
+                    ui,
+                    &row.b,
+                    cell_width,
+                    if row.b.is_empty() {
+                        subtle_dark()
+                    } else {
+                        added_text()
+                    },
+                    None,
+                );
             });
         }
         if diff.truncated {
@@ -613,8 +665,8 @@ impl Baboon {
             .open(&mut open)
             .collapsible(false)
             .resizable(true)
-            .default_width(680.0)
-            .default_height(460.0)
+            .default_width(960.0)
+            .default_height(560.0)
             .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
             .show(ctx, |ui| {
                 let Some(dialog) = self.mod_export.as_ref() else {
@@ -646,7 +698,7 @@ impl Baboon {
                 });
                 ui.add_space(6.0);
                 egui::ScrollArea::vertical()
-                    .max_height(240.0)
+                    .max_height(340.0)
                     .auto_shrink([false, false])
                     .show(ui, |ui| {
                         for (index, row) in dialog.rows.iter().enumerate() {

--- a/src/app/ui/dialogs.rs
+++ b/src/app/ui/dialogs.rs
@@ -448,6 +448,100 @@ impl Baboon {
     /// Destructive-save confirmation for Campaign Evolved container tags. Save
     /// overwrites the shipped pak files in place, so we always confirm and point
     /// the user at Export Mod as the non-destructive alternative.
+    /// What to do with a mod that was just exported.
+    ///
+    /// A mod is three files and only the `.pak` looks like one, so copying that
+    /// alone -- the obvious thing to do -- produces a mod the game finds and
+    /// then has nothing to load. The instruction used to live in the status
+    /// line, was lost when exports moved onto projects, and the status line now
+    /// clears itself after a few seconds besides.
+    pub(super) fn draw_exported_mod_window(&mut self, ctx: &egui::Context) {
+        let Some(exported) = self.exported_mod.as_ref() else {
+            return;
+        };
+        let stem = exported.stem.clone();
+        let directory = exported.directory.clone();
+        let count = exported.count;
+        let skipped = exported.skipped;
+        let mut open = true;
+        let mut close = false;
+        let mut reveal = false;
+        egui::Window::new("Mod exported")
+            .id(egui::Id::new("exported_mod"))
+            .open(&mut open)
+            .collapsible(false)
+            .resizable(false)
+            .default_width(560.0)
+            .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
+            .show(ctx, |ui| {
+                ui.label(
+                    RichText::new(format!("{count} tag(s) exported. The base game is unchanged."))
+                        .color(text_dark()),
+                );
+                if skipped > 0 {
+                    ui.add_space(4.0);
+                    ui.label(
+                        RichText::new(format!(
+                            "{skipped} tag(s) in this workspace's project could not be resolved \
+                             and are NOT in this mod."
+                        ))
+                        .color(egui::Color32::from_rgb(210, 120, 90)),
+                    );
+                }
+                ui.add_space(10.0);
+                ui.label(RichText::new("Copy all three files into the game:").color(text_dark()));
+                ui.add_space(4.0);
+                for extension in ["utoc", "ucas", "pak"] {
+                    ui.label(
+                        RichText::new(format!("    {stem}.{extension}"))
+                            .color(text_dark())
+                            .monospace(),
+                    );
+                }
+                ui.add_space(6.0);
+                ui.label(
+                    RichText::new("    Meteorite/Content/Paks/")
+                        .color(text_dark())
+                        .monospace(),
+                );
+                ui.add_space(10.0);
+                ui.label(
+                    RichText::new(
+                        "All three are needed. The .pak is the only one the game scans for, but \
+                         the tag data is in the .ucas -- copying it alone loads nothing.",
+                    )
+                    .color(subtle_dark())
+                    .small(),
+                );
+                ui.add_space(4.0);
+                ui.label(
+                    RichText::new(
+                        "If you rename them, keep the _P suffix. It is what gives the mod \
+                         priority over the game's own files; without it the mod is ignored.",
+                    )
+                    .color(subtle_dark())
+                    .small(),
+                );
+                ui.add_space(12.0);
+                ui.horizontal(|ui| {
+                    if !directory.as_os_str().is_empty()
+                        && ui.button("Show in file browser").clicked()
+                    {
+                        reveal = true;
+                    }
+                    if ui.button("Done").clicked() {
+                        close = true;
+                    }
+                });
+            });
+        if reveal {
+            self.open_folder_in_explorer(directory, "mod");
+        }
+        if !open || close {
+            self.exported_mod = None;
+        }
+    }
+
     /// Confirmation for the Campaign Evolved "clear modifications" action.
     ///
     /// It is irreversible and can drop work stashed in earlier sessions, so it

--- a/src/app/ui/dialogs.rs
+++ b/src/app/ui/dialogs.rs
@@ -621,10 +621,13 @@ impl Baboon {
             );
             return;
         }
-        let filter = Self::diff_field_filter(&diff.rows);
-
-        // One section per changed element, in the order the tag has them.
-        let mut sections: Vec<(String, Option<String>, String, ModExportChange)> = Vec::new();
+        // One section per changed element, in the order the tag has them, each
+        // carrying the rows that belong to it so its panes can be filtered to
+        // just those. A single filter over every row made each section render
+        // the ancestors of every *other* section too -- a block that merely
+        // contained a change appeared as though it were one.
+        let mut sections: Vec<(String, Option<String>, String, ModExportChange, Vec<TagFieldDiff>)> =
+            Vec::new();
         for row in &diff.rows {
             let (element, _) = Self::split_element_path(&row.path);
             let base_element = row
@@ -649,18 +652,43 @@ impl Baboon {
             } else {
                 ModExportChange::Modified
             };
+            // An added or removed element is reported with all of its
+            // contents, and those rows sit underneath it. They are already
+            // shown by that element's own pane, so they must not each open a
+            // section of their own -- doing so rendered a removed element's
+            // fields as a before/after split against whatever index had
+            // shifted into their place, inventing changes the diff never
+            // reported.
+            if let Some((last, _, _, last_kind, last_rows)) = sections.last_mut()
+                && matches!(
+                    last_kind,
+                    ModExportChange::New | ModExportChange::Unresolved
+                )
+                && row.path.starts_with(last.as_str())
+            {
+                last_rows.push(row.clone());
+                continue;
+            }
             match sections.last_mut() {
-                Some((last, _, existing, existing_kind)) if last == element => {
+                Some((last, _, existing, existing_kind, last_rows)) if last == element => {
                     if existing.is_empty() && !label.is_empty() {
                         *existing = label;
                         *existing_kind = kind;
                     }
+                    last_rows.push(row.clone());
                 }
-                _ => sections.push((element.to_owned(), base_element, label, kind)),
+                _ => sections.push((
+                    element.to_owned(),
+                    base_element,
+                    label,
+                    kind,
+                    vec![row.clone()],
+                )),
             }
         }
 
-        for (element, base_element, label, kind) in sections {
+        for (element, base_element, label, kind, section_rows) in sections {
+            let filter = Self::diff_field_filter(&section_rows);
             ui.add_space(8.0);
             if !element.is_empty() {
                 ui.separator();

--- a/src/app/ui/dialogs.rs
+++ b/src/app/ui/dialogs.rs
@@ -448,17 +448,26 @@ impl Baboon {
     /// Destructive-save confirmation for Campaign Evolved container tags. Save
     /// overwrites the shipped pak files in place, so we always confirm and point
     /// the user at Export Mod as the non-destructive alternative.
-    /// Strip anything from a mod name that cannot be part of a file name.
+    /// Fold a mod name into a file-safe stem, keeping its capitalisation.
     ///
-    /// The name becomes three files in a folder the user does not type, so a
-    /// separator or a reserved character here is a write failure later rather
-    /// than a different path.
+    /// The name becomes three file names in a folder the user never types, so
+    /// spaces and punctuation are separators to be normalised rather than
+    /// characters to carry through. Anything that is not a letter, digit,
+    /// hyphen or underscore becomes a hyphen, runs collapse, and the ends are
+    /// trimmed -- kebab case, with the user's own casing left alone.
+    ///
+    /// Underscores survive deliberately: `_P` is what marks a mod's priority,
+    /// and folding it to `-P` would leave `stem` appending a second one.
     fn sanitize_mod_name(name: &str) -> String {
-        name.chars()
-            .filter(|c| !matches!(c, '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|'))
-            .collect::<String>()
-            .trim()
-            .to_owned()
+        let mut out = String::with_capacity(name.len());
+        for c in name.chars() {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                out.push(c);
+            } else if !out.ends_with('-') {
+                out.push('-');
+            }
+        }
+        out.trim_matches('-').to_owned()
     }
 
     /// Split a diff path into the element it belongs to and the field within
@@ -2089,12 +2098,20 @@ mod mod_export_tests {
         );
     }
 
-    /// The name becomes three files in a folder the user never types, so a
-    /// separator would be a write failure rather than a different path.
+    /// The name becomes three file names in a folder the user never types, so
+    /// spaces and punctuation are separators to normalise, not characters to
+    /// carry through -- while the user's own capitalisation is theirs to keep.
     #[test]
-    fn a_mod_name_cannot_contain_path_syntax() {
-        assert_eq!(Baboon::sanitize_mod_name("../../etc/passwd"), "....etcpasswd");
-        assert_eq!(Baboon::sanitize_mod_name("my:mod?"), "mymod");
+    fn a_mod_name_becomes_a_file_safe_stem() {
+        assert_eq!(Baboon::sanitize_mod_name("My Cool Mod"), "My-Cool-Mod");
+        assert_eq!(Baboon::sanitize_mod_name("h2a magnum!"), "h2a-magnum");
         assert_eq!(Baboon::sanitize_mod_name("  trimmed  "), "trimmed");
+        // Path syntax cannot survive: these become three files somewhere the
+        // user did not choose.
+        assert_eq!(Baboon::sanitize_mod_name("../../etc/passwd"), "etc-passwd");
+        assert_eq!(Baboon::sanitize_mod_name("my:mod?"), "my-mod");
+        // Underscores stay, so `_P` keeps meaning what it means.
+        assert_eq!(Baboon::sanitize_mod_name("my_mod_P"), "my_mod_P");
+        assert_eq!(dialog(&Baboon::sanitize_mod_name("My Mod")).stem(), "My-Mod_P");
     }
 }

--- a/src/app/ui/dialogs.rs
+++ b/src/app/ui/dialogs.rs
@@ -464,6 +464,24 @@ impl Baboon {
         }
     }
 
+    /// Split `zone set pvs[3]` into the block it names and the element index.
+    ///
+    /// A reader wants to know which block changed and which element of it, not
+    /// to parse an indexed path.
+    fn split_element_index(element: &str) -> (&str, Option<usize>) {
+        let Some(open) = element.rfind('[') else {
+            return (element, None);
+        };
+        let index = element[open + 1..]
+            .trim_end_matches(']')
+            .parse::<usize>()
+            .ok();
+        match index {
+            Some(index) => (&element[..open], Some(index)),
+            None => (element, None),
+        }
+    }
+
     /// Which fields a diff touched, as the editor's own field filter.
     ///
     /// Canonical (index-free) paths, so one filter serves both sides: deleting
@@ -699,11 +717,31 @@ impl Baboon {
                     ModExportChange::Unresolved => ("-", removed_text()),
                     ModExportChange::Modified => ("~", modified_text()),
                 };
+                // Named as the block it belongs to, with the element called out
+                // inside it. The indexed path answers "where in the file"; what
+                // a reader wants is "which block, and which element of it".
+                let (container, index) = Self::split_element_index(&element);
                 ui.horizontal(|ui| {
+                    ui.label(
+                        RichText::new(container)
+                            .color(text_dark())
+                            .monospace()
+                            .strong(),
+                    );
                     ui.label(RichText::new(marker).color(heading).monospace().strong());
-                    ui.label(RichText::new(&element).color(heading).monospace());
+                    if let Some(index) = index {
+                        ui.label(RichText::new(format!("element {index}")).color(heading));
+                    }
                     if !label.is_empty() {
-                        ui.label(RichText::new(&label).color(heading).small());
+                        // The label already names the element; the redundant
+                        // "added -- " / "removed -- " prefix is the marker's job.
+                        let detail = label
+                            .split_once(" — ")
+                            .map(|(_, rest)| rest)
+                            .unwrap_or(label.as_str());
+                        if detail != format!("element {}", index.unwrap_or_default()) {
+                            ui.label(RichText::new(detail).color(heading).small());
+                        }
                     }
                 });
             }
@@ -2142,6 +2180,23 @@ mod mod_export_tests {
         assert_eq!(dialog("h2a_magnum").stem(), "h2a_magnum_P");
         assert_eq!(dialog("h2a_magnum_P").stem(), "h2a_magnum_P");
         assert_eq!(dialog("  spaced  ").stem(), "spaced_P");
+    }
+
+    /// A heading names the block and the element within it, rather than an
+    /// indexed path the reader has to parse.
+    #[test]
+    fn an_element_path_splits_into_its_block_and_index() {
+        assert_eq!(
+            Baboon::split_element_index("zone set pvs[3]"),
+            ("zone set pvs", Some(3))
+        );
+        // Nested: the chain stays, so it is clear which block is meant.
+        assert_eq!(
+            Baboon::split_element_index("weapons[2]/triggers[0]"),
+            ("weapons[2]/triggers", Some(0))
+        );
+        // Not an element at all.
+        assert_eq!(Baboon::split_element_index("flags"), ("flags", None));
     }
 
     /// Changes nest, and the innermost element is the one worth heading. The

--- a/src/app/ui/dialogs.rs
+++ b/src/app/ui/dialogs.rs
@@ -477,14 +477,151 @@ impl Baboon {
         }
     }
 
-    /// One tag's differences, laid out like the editor: a field label, then
-    /// its old and new values side by side in the editor's own value cells.
+    /// Which fields a diff touched, as the editor's own field filter.
     ///
-    /// The values are the point of the whole dialog, so they are shown the way
-    /// the editor shows values -- readable, full width, in a cell -- rather
-    /// than as small text crammed against the right edge. Old on the left in
-    /// red, new on the right in green.
-    fn draw_mod_export_diff(ui: &mut Ui, diff: &ModRowDiff) {
+    /// Canonical (index-free) paths, so one filter serves both sides: deleting
+    /// an element shifts indices, but `zone set pvs/structure bsp mask` names
+    /// the same field whether it sits at element 3 or 4.
+    fn diff_field_filter(rows: &[TagFieldDiff]) -> FieldFilter {
+        let mut visible_paths = HashSet::new();
+        for row in rows {
+            for path in [Some(&row.path), row.base_path.as_ref()].into_iter().flatten() {
+                let canonical = strip_node_indices(path);
+                // Ancestors too: a container has to render for what is inside
+                // it to be reachable.
+                let mut prefix = canonical.as_str();
+                loop {
+                    visible_paths.insert(prefix.to_owned());
+                    match prefix.rfind('/') {
+                        Some(cut) => prefix = &prefix[..cut],
+                        None => break,
+                    }
+                }
+            }
+        }
+        FieldFilter { visible_paths }
+    }
+
+    /// Render one side of a diff through the real field editor, read-only.
+    ///
+    /// This is the editor's own renderer, not an imitation of it: values are
+    /// formatted, enums named and references resolved exactly as they are when
+    /// editing, which is what makes the change inspectable rather than merely
+    /// visible.
+    #[allow(clippy::too_many_arguments)]
+    fn draw_diff_side(
+        ui: &mut Ui,
+        tag: &blam_tags::TagFile,
+        path: &str,
+        filter: &FieldFilter,
+        names: &TagNameIndex,
+        group_tag: u32,
+        game: Option<&str>,
+        definitions_root: Option<&Path>,
+        expert_mode: bool,
+        scope: &str,
+    ) {
+        // The editor collects deferred edits as it draws. Nothing here is
+        // editable, so they are collected into locals and dropped.
+        let mut buffers = EditDrafts::default();
+        let mut pending = Vec::new();
+        let mut block_ops = Vec::new();
+        let mut block_confirm = None;
+        let mut open_request = None;
+        let mut sound_play_request = None;
+        let mut sound_extract_request = None;
+        let mut tool_import = None;
+        let mut bitmap_reimport = None;
+        let mut shader_ops = Vec::new();
+        let mut shader_param_ops = Vec::new();
+        let mut h2_shader_param_ops = Vec::new();
+        let mut function_data_ops = Vec::new();
+        let mut model_variant_ops = Vec::new();
+        let mut color_request = None;
+        let mut function_request = None;
+        let mut block_clip_request = None;
+        let mut tsv_paste_request = None;
+        let mut tag_reference_picker = None;
+        let root = tag.root();
+        let Some(target) = (if path.is_empty() {
+            Some(root)
+        } else {
+            root.descend(path)
+        }) else {
+            ui.label(
+                RichText::new("not present on this side")
+                    .color(subtle_dark())
+                    .small(),
+            );
+            return;
+        };
+        let filter_action = FieldFilterAction::Apply((*filter).clone());
+        let mut edit = FieldEditContext {
+            expand_all: Some(true),
+            nested_default: NestedDefault::Expanded,
+            view_scope: scope,
+            tag_key: scope,
+            group_tag,
+            root: Some(root),
+            game,
+            definitions_root,
+            names: Some(names),
+            tags_root: None,
+            tag_reference_catalog: None,
+            tag_reference_picker: &mut tag_reference_picker,
+            status: None,
+            editable: false,
+            show_block_sizes: false,
+            buffers: &mut buffers,
+            pending: &mut pending,
+            block_ops: &mut block_ops,
+            block_confirm: &mut block_confirm,
+            open_request: &mut open_request,
+            sound_play_request: &mut sound_play_request,
+            sound_status: None,
+            sound_volume: 1.0,
+            sound_extract_request: &mut sound_extract_request,
+            sound_language: None,
+            ce_sound: None,
+            ce_paks_root: None,
+            tool_import: &mut tool_import,
+            bitmap_reimport: &mut bitmap_reimport,
+            shader_ops: &mut shader_ops,
+            shader_param_ops: &mut shader_param_ops,
+            h2_shader_param_ops: &mut h2_shader_param_ops,
+            function_data_ops: &mut function_data_ops,
+            model_variant_ops: &mut model_variant_ops,
+            color_request: &mut color_request,
+            function_request: &mut function_request,
+            block_clipboard: None,
+            docs: None,
+            tsv_paste_request: &mut tsv_paste_request,
+            block_clip_request: &mut block_clip_request,
+            field_filter: Some(&filter_action),
+            field_nav: None,
+        };
+        draw_struct_fields_inline(ui, target, names, 0, expert_mode, path, &mut edit);
+    }
+
+    /// One tag's differences, each shown through the real field editor with
+    /// the shipped value on the left and the edited one on the right.
+    ///
+    /// Rendered per changed element rather than as one whole-tag view: the
+    /// editor shows a block one element at a time behind its instance
+    /// selector, so changes spanning elements 3 and 7 could never both be on
+    /// screen. Each changed element gets its own section, which is what makes
+    /// the whole change visible at once.
+    #[allow(clippy::too_many_arguments)]
+    fn draw_mod_export_diff(
+        ui: &mut Ui,
+        diff: &ModRowDiff,
+        names: &TagNameIndex,
+        group_tag: u32,
+        game: Option<&str>,
+        definitions_root: Option<&Path>,
+        expert_mode: bool,
+        scope: &str,
+    ) {
         if let Some(error) = diff.error.as_deref() {
             ui.label(RichText::new(error).color(removed_text()).small());
             return;
@@ -497,104 +634,83 @@ impl Baboon {
             );
             return;
         }
-        // Split what is left after the label between the two value cells.
-        let available = ui.available_width();
-        let label_width = (available * 0.34).clamp(120.0, 320.0);
-        let cell_width = ((available - label_width - 24.0) / 2.0).max(80.0);
+        let filter = Self::diff_field_filter(&diff.rows);
 
-        // Named, not just coloured: which side is which should not depend on
-        // telling red from green.
-        ui.horizontal(|ui| {
-            ui.add_space(4.0);
-            let (rect, _) = ui.allocate_exact_size(Vec2::new(label_width, 16.0), Sense::hover());
-            let _ = rect;
-            let (before, _) = ui.allocate_exact_size(Vec2::new(cell_width, 16.0), Sense::hover());
-            ui.painter().text(
-                before.left_center() + Vec2::new(5.0, 0.0),
-                Align2::LEFT_CENTER,
-                "before",
-                FontId::proportional(11.0),
-                removed_text(),
-            );
-            let (after, _) = ui.allocate_exact_size(Vec2::new(cell_width, 16.0), Sense::hover());
-            ui.painter().text(
-                after.left_center() + Vec2::new(5.0, 0.0),
-                Align2::LEFT_CENTER,
-                "after",
-                FontId::proportional(11.0),
-                added_text(),
-            );
-        });
-
-        let mut current = None;
+        // One section per changed element, in the order the tag has them.
+        let mut sections: Vec<(String, Option<String>, String)> = Vec::new();
         for row in &diff.rows {
-            let (element, field) = Self::split_element_path(&row.path);
-            if current != Some(element) {
-                current = Some(element);
-                if !element.is_empty() {
-                    ui.add_space(6.0);
-                    ui.separator();
+            let (element, _) = Self::split_element_path(&row.path);
+            let base_element = row
+                .base_path
+                .as_deref()
+                .map(|path| Self::split_element_path(path).0.to_owned());
+            let label = if Self::split_element_path(&row.path).1.is_empty() {
+                if row.b.is_empty() { row.a.clone() } else { row.b.clone() }
+            } else {
+                String::new()
+            };
+            match sections.last_mut() {
+                Some((last, _, existing)) if last == element => {
+                    if existing.is_empty() && !label.is_empty() {
+                        *existing = label;
+                    }
                 }
+                _ => sections.push((element.to_owned(), base_element, label)),
             }
-            // A row about the element itself: added, removed, moved, or naming
-            // an element whose own fields changed.
-            if field.is_empty() {
-                let (marker, color) = if row.a.is_empty() {
-                    ("+", added_text())
-                } else if row.b.is_empty() {
-                    ("-", removed_text())
-                } else {
-                    ("~", modified_text())
-                };
+        }
+
+        for (element, base_element, label) in sections {
+            ui.add_space(8.0);
+            if !element.is_empty() {
+                ui.separator();
                 ui.horizontal(|ui| {
-                    ui.label(RichText::new(marker).color(color).monospace().strong());
-                    let text = if row.b.is_empty() { &row.a } else { &row.b };
-                    ui.label(RichText::new(text).color(color).strong());
-                    ui.label(
-                        RichText::new(element)
-                            .color(subtle_dark())
-                            .monospace()
-                            .small(),
-                    );
+                    ui.label(RichText::new(&element).color(modified_text()).monospace());
+                    if !label.is_empty() {
+                        ui.label(RichText::new(&label).color(subtle_dark()).small());
+                    }
                 });
-                continue;
             }
-            ui.horizontal(|ui| {
-                ui.add_space(4.0);
-                let (rect, _) =
-                    ui.allocate_exact_size(Vec2::new(label_width, 24.0), Sense::hover());
-                ui.painter().text(
-                    rect.left_center() + Vec2::new(2.0, 0.0),
-                    Align2::LEFT_CENTER,
-                    field,
-                    FontId::proportional(12.5),
-                    text_dark(),
-                );
-                // An absent side means the value did not exist before or does
-                // not exist now; an empty cell says that more clearly than a
-                // missing one, which would misalign the pair.
-                foundation_input_cell_colored(
-                    ui,
-                    &row.a,
-                    cell_width,
-                    if row.a.is_empty() {
-                        subtle_dark()
-                    } else {
-                        removed_text()
-                    },
-                    None,
-                );
-                foundation_input_cell_colored(
-                    ui,
-                    &row.b,
-                    cell_width,
-                    if row.b.is_empty() {
-                        subtle_dark()
-                    } else {
-                        added_text()
-                    },
-                    None,
-                );
+            ui.columns(2, |columns| {
+                columns[0].push_id(("diff_before", &element), |ui| {
+                    ui.label(RichText::new("before").color(removed_text()).small());
+                    match diff.base.as_ref() {
+                        Some(base) => Self::draw_diff_side(
+                            ui,
+                            base,
+                            base_element.as_deref().unwrap_or(&element),
+                            &filter,
+                            names,
+                            group_tag,
+                            game,
+                            definitions_root,
+                            expert_mode,
+                            &format!("{scope}|before"),
+                        ),
+                        // A tag the game does not ship has no before.
+                        None => {
+                            ui.label(
+                                RichText::new("new tag").color(subtle_dark()).small(),
+                            );
+                        }
+                    }
+                });
+                columns[1].push_id(("diff_after", &element), |ui| {
+                    ui.label(RichText::new("after").color(added_text()).small());
+                    if let Some(edited) = diff.edited.as_ref() {
+                        Self::draw_diff_side(
+                            ui,
+                            edited,
+                            &element,
+                            &filter,
+                            names,
+                            group_tag,
+                            game,
+                            definitions_root,
+                            expert_mode,
+                            &format!("{scope}|after"),
+                        );
+                    }
+                });
             });
         }
         if diff.truncated {
@@ -645,6 +761,24 @@ impl Baboon {
             .unwrap_or(false);
         let included = dialog.included().count();
         let name_ok = !dialog.name.trim().is_empty();
+        // The editor needs its source's naming and definitions to render values
+        // the way the editor does.
+        let kit_index = self.kits.iter().position(|k| k.id == kit);
+        let names = kit_index
+            .map(|index| self.kits[index].names.clone())
+            .unwrap_or_default();
+        let game = kit_index
+            .and_then(|index| self.kits[index].source.as_ref())
+            .and_then(|source| source.game.clone());
+        let definitions_root = kit_index
+            .and_then(|index| self.kits[index].source.as_ref())
+            .and_then(|source| match &source.source {
+                TagSource::LooseFolder {
+                    definitions_root, ..
+                } => Some(definitions_root.clone()),
+                _ => None,
+            });
+        let expert_mode = self.expert_mode;
 
         let mut open = true;
         let mut cancel = false;
@@ -763,7 +897,16 @@ impl Baboon {
                             if expandable && expanded {
                                 ui.indent(("mod_export_diff", index), |ui| {
                                     match dialog.diffs.get(&row.identity) {
-                                        Some(diff) => Self::draw_mod_export_diff(ui, diff),
+                                        Some(diff) => Self::draw_mod_export_diff(
+                                            ui,
+                                            diff,
+                                            &names,
+                                            row.group_tag,
+                                            game.as_deref(),
+                                            definitions_root.as_deref(),
+                                            expert_mode,
+                                            &row.identity,
+                                        ),
                                         None => {
                                             ui.label(
                                                 RichText::new("Comparing...")

--- a/src/app/ui/dialogs.rs
+++ b/src/app/ui/dialogs.rs
@@ -692,61 +692,86 @@ impl Baboon {
                     }
                 });
             }
-            ui.columns(2, |columns| {
-                columns[0].push_id(("diff_before", &element), |ui| {
-                    // Tinted so which side is which is apparent at a glance
-                    // rather than only from the heading above it.
-                    Frame::none()
-                        .fill(removed_wash())
-                        .stroke(Stroke::new(1.0, removed_text().gamma_multiply(0.5)))
-                        .inner_margin(egui::Margin::symmetric(6.0, 6.0))
-                        .show(ui, |ui| {
-                    ui.label(RichText::new("before").color(removed_text()).small());
-                    match diff.base.as_ref() {
-                        Some(base) => Self::draw_diff_side(
-                            ui,
-                            base,
-                            base_element.as_deref().unwrap_or(&element),
-                            &filter,
-                            names,
-                            group_tag,
-                            game,
-                            definitions_root,
-                            expert_mode,
-                            &format!("{scope}|before"),
-                        ),
-                        // A tag the game does not ship has no before.
-                        None => {
-                            ui.label(
-                                RichText::new("new tag").color(subtle_dark()).small(),
-                            );
-                        }
-                    }
-                        });
-                });
-                columns[1].push_id(("diff_after", &element), |ui| {
-                    Frame::none()
-                        .fill(added_wash())
-                        .stroke(Stroke::new(1.0, added_text().gamma_multiply(0.5)))
-                        .inner_margin(egui::Margin::symmetric(6.0, 6.0))
-                        .show(ui, |ui| {
-                    ui.label(RichText::new("after").color(added_text()).small());
-                    if let Some(edited) = diff.edited.as_ref() {
-                        Self::draw_diff_side(
-                            ui,
-                            edited,
-                            &element,
-                            &filter,
-                            names,
-                            group_tag,
-                            game,
-                            definitions_root,
-                            expert_mode,
-                            &format!("{scope}|after"),
-                        );
-                    }
-                        });
-                });
+            // Each side is given exactly half and scrolls within itself.
+            // The editor's rows are wider than half a dialog, and a resizable
+            // window sized to its contents grows to fit them -- so without a
+            // bound the dialog widens every frame until it is off screen.
+            let available = ui.available_width();
+            let side_width = ((available - 16.0) / 2.0).max(160.0);
+            ui.horizontal_top(|ui| {
+                ui.allocate_ui_with_layout(
+                    Vec2::new(side_width, 0.0),
+                    egui::Layout::top_down(egui::Align::Min),
+                    |ui| {
+                        ui.set_width(side_width);
+                        Frame::none()
+                            .fill(removed_wash())
+                            .stroke(Stroke::new(1.0, removed_text().gamma_multiply(0.5)))
+                            .inner_margin(egui::Margin::symmetric(6.0, 6.0))
+                            .show(ui, |ui| {
+                                ui.label(RichText::new("before").color(removed_text()).small());
+                                egui::ScrollArea::horizontal()
+                                    .id_salt(("diff_before", &element))
+                                    .auto_shrink([false, false])
+                                    .show(ui, |ui| match diff.base.as_ref() {
+                                        Some(base) => Self::draw_diff_side(
+                                            ui,
+                                            base,
+                                            base_element.as_deref().unwrap_or(&element),
+                                            &filter,
+                                            names,
+                                            group_tag,
+                                            game,
+                                            definitions_root,
+                                            expert_mode,
+                                            &format!("{scope}|before"),
+                                        ),
+                                        // A tag the game does not ship has no before.
+                                        None => {
+                                            ui.label(
+                                                RichText::new("new tag")
+                                                    .color(subtle_dark())
+                                                    .small(),
+                                            );
+                                        }
+                                    });
+                            });
+                    },
+                );
+                ui.separator();
+                ui.allocate_ui_with_layout(
+                    Vec2::new(side_width, 0.0),
+                    egui::Layout::top_down(egui::Align::Min),
+                    |ui| {
+                        ui.set_width(side_width);
+                        Frame::none()
+                            .fill(added_wash())
+                            .stroke(Stroke::new(1.0, added_text().gamma_multiply(0.5)))
+                            .inner_margin(egui::Margin::symmetric(6.0, 6.0))
+                            .show(ui, |ui| {
+                                ui.label(RichText::new("after").color(added_text()).small());
+                                egui::ScrollArea::horizontal()
+                                    .id_salt(("diff_after", &element))
+                                    .auto_shrink([false, false])
+                                    .show(ui, |ui| {
+                                        if let Some(edited) = diff.edited.as_ref() {
+                                            Self::draw_diff_side(
+                                                ui,
+                                                edited,
+                                                &element,
+                                                &filter,
+                                                names,
+                                                group_tag,
+                                                game,
+                                                definitions_root,
+                                                expert_mode,
+                                                &format!("{scope}|after"),
+                                            );
+                                        }
+                                    });
+                            });
+                    },
+                );
             });
         }
         if diff.truncated {
@@ -835,8 +860,8 @@ impl Baboon {
             .open(&mut open)
             .collapsible(false)
             .resizable(true)
-            .default_width(960.0)
-            .default_height(560.0)
+            .default_width(1100.0)
+            .default_height(640.0)
             .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
             .show(ctx, |ui| {
                 let Some(dialog) = self.mod_export.as_ref() else {
@@ -867,8 +892,13 @@ impl Baboon {
                     }
                 });
                 ui.add_space(6.0);
+                // Grows with the window: the naming and buttons below need a
+                // fixed slice, and the list takes whatever is left, so making
+                // the dialog taller shows more of the diff rather than more
+                // empty space.
+                let list_height = (ui.available_height() - 120.0).max(120.0);
                 egui::ScrollArea::vertical()
-                    .max_height(340.0)
+                    .max_height(list_height)
                     .auto_shrink([false, false])
                     .show(ui, |ui| {
                         for (index, row) in dialog.rows.iter().enumerate() {

--- a/src/app/ui/dialogs.rs
+++ b/src/app/ui/dialogs.rs
@@ -1774,7 +1774,11 @@ impl Baboon {
                     if is_container {
                         ui.add(
                             egui::TextEdit::singleline(&mut self.new_tag_dialog.rel_path)
-                                .hint_text("objects/characters/foo/foo")
+                                // Prefixed, because a bare path here reads as a
+                                // filled field: the placeholder looked exactly
+                                // like a value someone had already typed, and
+                                // Create sat disabled with no explanation.
+                                .hint_text("e.g. objects/characters/foo/foo")
                                 .desired_width(440.0),
                         );
                     } else {
@@ -1840,6 +1844,15 @@ impl Baboon {
                         };
                     if ui
                         .add_enabled(can_create, egui::Button::new("Create"))
+                        .on_disabled_hover_text(if self.new_tag_dialog.groups.is_empty() {
+                            "No tag groups are available for this game"
+                        } else if is_container {
+                            "Enter a path for the new tag"
+                        } else if self.loaded_tags_root().is_none() {
+                            "Load a loose editing-kit tags folder first"
+                        } else {
+                            "Choose where to save the new tag"
+                        })
                         .clicked()
                     {
                         create = true;

--- a/src/app/ui/dialogs.rs
+++ b/src/app/ui/dialogs.rs
@@ -692,87 +692,82 @@ impl Baboon {
                     }
                 });
             }
-            // Each side is given exactly half and scrolls within itself.
-            // The editor's rows are wider than half a dialog, and a resizable
-            // window sized to its contents grows to fit them -- so without a
-            // bound the dialog widens every frame until it is off screen.
+            // Only a modified element has two sides worth comparing. An
+            // element that was added or removed exists on one side only, and a
+            // half-width pane beside an empty twin says less than one full
+            // pane in the colour of what happened.
             let available = ui.available_width();
-            let side_width = ((available - 16.0) / 2.0).max(160.0);
-            ui.horizontal_top(|ui| {
+            let half = ((available - 16.0) / 2.0).max(160.0);
+            let pane = |ui: &mut Ui, width: f32, before: bool, title: &str| {
+                let (wash, accent) = if before {
+                    (removed_wash(), removed_text())
+                } else {
+                    (added_wash(), added_text())
+                };
                 ui.allocate_ui_with_layout(
-                    Vec2::new(side_width, 0.0),
+                    Vec2::new(width, 0.0),
                     egui::Layout::top_down(egui::Align::Min),
                     |ui| {
-                        ui.set_width(side_width);
+                        ui.set_width(width);
                         Frame::none()
-                            .fill(removed_wash())
-                            .stroke(Stroke::new(1.0, removed_text().gamma_multiply(0.5)))
+                            .fill(wash)
+                            .stroke(Stroke::new(1.0, accent.gamma_multiply(0.5)))
                             .inner_margin(egui::Margin::symmetric(6.0, 6.0))
                             .show(ui, |ui| {
-                                ui.label(RichText::new("before").color(removed_text()).small());
+                                ui.label(RichText::new(title).color(accent).small());
+                                // Scrolled within its own pane: an editor row is
+                                // wider than half a dialog, and without this the
+                                // window grows to fit it every frame.
                                 egui::ScrollArea::horizontal()
-                                    .id_salt(("diff_before", &element))
-                                    .auto_shrink([false, false])
-                                    .show(ui, |ui| match diff.base.as_ref() {
-                                        Some(base) => Self::draw_diff_side(
-                                            ui,
-                                            base,
-                                            base_element.as_deref().unwrap_or(&element),
-                                            &filter,
-                                            names,
-                                            group_tag,
-                                            game,
-                                            definitions_root,
-                                            expert_mode,
-                                            &format!("{scope}|before"),
-                                        ),
-                                        // A tag the game does not ship has no before.
-                                        None => {
-                                            ui.label(
-                                                RichText::new("new tag")
-                                                    .color(subtle_dark())
-                                                    .small(),
-                                            );
-                                        }
-                                    });
-                            });
-                    },
-                );
-                ui.separator();
-                ui.allocate_ui_with_layout(
-                    Vec2::new(side_width, 0.0),
-                    egui::Layout::top_down(egui::Align::Min),
-                    |ui| {
-                        ui.set_width(side_width);
-                        Frame::none()
-                            .fill(added_wash())
-                            .stroke(Stroke::new(1.0, added_text().gamma_multiply(0.5)))
-                            .inner_margin(egui::Margin::symmetric(6.0, 6.0))
-                            .show(ui, |ui| {
-                                ui.label(RichText::new("after").color(added_text()).small());
-                                egui::ScrollArea::horizontal()
-                                    .id_salt(("diff_after", &element))
+                                    .id_salt((title, &element))
                                     .auto_shrink([false, false])
                                     .show(ui, |ui| {
-                                        if let Some(edited) = diff.edited.as_ref() {
-                                            Self::draw_diff_side(
+                                        let (tag, path, side) = if before {
+                                            (
+                                                diff.base.as_ref(),
+                                                base_element.as_deref().unwrap_or(&element),
+                                                "before",
+                                            )
+                                        } else {
+                                            (diff.edited.as_ref(), element.as_str(), "after")
+                                        };
+                                        match tag {
+                                            Some(tag) => Self::draw_diff_side(
                                                 ui,
-                                                edited,
-                                                &element,
+                                                tag,
+                                                path,
                                                 &filter,
                                                 names,
                                                 group_tag,
                                                 game,
                                                 definitions_root,
                                                 expert_mode,
-                                                &format!("{scope}|after"),
-                                            );
+                                                &format!("{scope}|{side}"),
+                                            ),
+                                            None => {
+                                                ui.label(
+                                                    RichText::new("not present")
+                                                        .color(subtle_dark())
+                                                        .small(),
+                                                );
+                                            }
                                         }
                                     });
                             });
                     },
                 );
-            });
+            };
+            match kind {
+                ModExportChange::New => pane(ui, available, false, "added"),
+                ModExportChange::Unresolved => pane(ui, available, true, "removed"),
+                ModExportChange::Modified => {
+                    ui.horizontal_top(|ui| {
+                        pane(ui, half, true, "before");
+                        ui.separator();
+                        pane(ui, half, false, "after");
+                    });
+                }
+            }
         }
         if diff.truncated {
             ui.add_space(4.0);

--- a/src/app/ui/dialogs.rs
+++ b/src/app/ui/dialogs.rs
@@ -448,6 +448,252 @@ impl Baboon {
     /// Destructive-save confirmation for Campaign Evolved container tags. Save
     /// overwrites the shipped pak files in place, so we always confirm and point
     /// the user at Export Mod as the non-destructive alternative.
+    /// Strip anything from a mod name that cannot be part of a file name.
+    ///
+    /// The name becomes three files in a folder the user does not type, so a
+    /// separator or a reserved character here is a write failure later rather
+    /// than a different path.
+    fn sanitize_mod_name(name: &str) -> String {
+        name.chars()
+            .filter(|c| !matches!(c, '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|'))
+            .collect::<String>()
+            .trim()
+            .to_owned()
+    }
+
+    /// Review what Export Mod is about to write, and where.
+    ///
+    /// The save dialog this replaces asked for one file name when the output is
+    /// three, which invited renaming -- and renaming is how a mod loses the
+    /// `_P` that gives it priority over the game's own containers. It also
+    /// guarded only the container, silently overwriting the `.ucas` and `.pak`
+    /// beside it.
+    pub(super) fn draw_mod_export_window(&mut self, ctx: &egui::Context) {
+        let Some(dialog) = self.mod_export.as_ref() else {
+            return;
+        };
+        let kit = dialog.kit;
+        let new_count = dialog
+            .rows
+            .iter()
+            .filter(|row| row.kind == ModExportChange::New)
+            .count();
+        let modified_count = dialog
+            .rows
+            .iter()
+            .filter(|row| row.kind == ModExportChange::Modified)
+            .count();
+        let unresolved_count = dialog
+            .rows
+            .iter()
+            .filter(|row| row.kind == ModExportChange::Unresolved)
+            .count();
+        let stem = dialog.stem();
+        let existing = dialog.existing_files();
+        let in_game_folder = self
+            .kits
+            .iter()
+            .find(|k| k.id == kit)
+            .and_then(|k| k.source.as_ref())
+            .map(|source| source.source.root_path() == dialog.folder)
+            .unwrap_or(false);
+        let included = dialog.included().count();
+        let name_ok = !dialog.name.trim().is_empty();
+
+        let mut open = true;
+        let mut cancel = false;
+        let mut export = false;
+        let mut browse = false;
+        let mut set_all: Option<bool> = None;
+        let mut toggled: Option<usize> = None;
+        let mut name_edit = dialog.name.clone();
+
+        egui::Window::new("Export Mod")
+            .id(egui::Id::new("mod_export"))
+            .open(&mut open)
+            .collapsible(false)
+            .resizable(true)
+            .default_width(680.0)
+            .default_height(460.0)
+            .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
+            .show(ctx, |ui| {
+                let Some(dialog) = self.mod_export.as_ref() else {
+                    return;
+                };
+                ui.horizontal(|ui| {
+                    ui.label(
+                        RichText::new(format!(
+                            "{new_count} new · {modified_count} modified"
+                        ))
+                        .color(text_dark()),
+                    );
+                    if unresolved_count > 0 {
+                        ui.label(
+                            RichText::new(format!("· {unresolved_count} excluded"))
+                                .color(egui::Color32::from_rgb(210, 120, 90)),
+                        );
+                    }
+                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                        if ui.button("Include none").clicked() {
+                            set_all = Some(false);
+                        }
+                        if ui.button("Include all").clicked() {
+                            set_all = Some(true);
+                        }
+                    });
+                });
+                ui.add_space(6.0);
+                egui::ScrollArea::vertical()
+                    .max_height(240.0)
+                    .auto_shrink([false, false])
+                    .show(ui, |ui| {
+                        for (index, row) in dialog.rows.iter().enumerate() {
+                            ui.horizontal(|ui| {
+                                let mut include = row.include;
+                                let enabled = row.kind != ModExportChange::Unresolved;
+                                if ui
+                                    .add_enabled(enabled, egui::Checkbox::new(&mut include, ""))
+                                    .changed()
+                                {
+                                    toggled = Some(index);
+                                }
+                                let (marker, color) = match row.kind {
+                                    ModExportChange::New => ("+", added_text()),
+                                    ModExportChange::Modified => ("~", modified_text()),
+                                    ModExportChange::Unresolved => {
+                                        ("!", egui::Color32::from_rgb(210, 120, 90))
+                                    }
+                                };
+                                // A marker as well as a colour: this is a
+                                // confirmation before writing files, and colour
+                                // alone excludes a good number of readers.
+                                ui.label(RichText::new(marker).color(color).monospace());
+                                ui.label(RichText::new(&row.display_path).color(color));
+                                ui.with_layout(
+                                    egui::Layout::right_to_left(egui::Align::Center),
+                                    |ui| {
+                                        ui.label(
+                                            RichText::new(format!("{} KB", row.bytes / 1024))
+                                                .color(subtle_dark())
+                                                .small(),
+                                        );
+                                        if let Some(reason) = row.reason.as_deref() {
+                                            ui.label(
+                                                RichText::new(reason).color(subtle_dark()).small(),
+                                            );
+                                        }
+                                    },
+                                );
+                            });
+                        }
+                    });
+                ui.add_space(10.0);
+                ui.horizontal(|ui| {
+                    ui.label(RichText::new("Mod name").color(text_dark()));
+                    ui.add(egui::TextEdit::singleline(&mut name_edit).desired_width(220.0));
+                    ui.label(
+                        RichText::new(format!("{stem}.utoc / .ucas / .pak"))
+                            .color(subtle_dark())
+                            .monospace()
+                            .small(),
+                    );
+                });
+                ui.horizontal(|ui| {
+                    ui.label(RichText::new("Folder").color(text_dark()));
+                    ui.label(
+                        RichText::new(dialog.folder.display().to_string())
+                            .color(subtle_dark())
+                            .monospace()
+                            .small(),
+                    );
+                    if ui.button("Browse...").clicked() {
+                        browse = true;
+                    }
+                });
+                if in_game_folder {
+                    ui.label(
+                        RichText::new("This is the game's own Paks folder — nothing to copy afterwards.")
+                            .color(subtle_dark())
+                            .small(),
+                    );
+                }
+                if !existing.is_empty() {
+                    ui.add_space(6.0);
+                    ui.label(
+                        RichText::new(format!("Overwrites: {}", existing.join(", ")))
+                            .color(egui::Color32::from_rgb(210, 120, 90)),
+                    );
+                }
+                ui.add_space(10.0);
+                ui.horizontal(|ui| {
+                    let ready = name_ok && included > 0;
+                    if ui
+                        .add_enabled(ready, egui::Button::new("Export"))
+                        .on_disabled_hover_text(if name_ok {
+                            "Nothing is selected to export"
+                        } else {
+                            "Enter a name for the mod"
+                        })
+                        .clicked()
+                    {
+                        export = true;
+                    }
+                    if ui.button("Cancel").clicked() {
+                        cancel = true;
+                    }
+                });
+            });
+
+        // Applied after the window closes its borrow of `self`.
+        if let Some(dialog) = self.mod_export.as_mut() {
+            if dialog.name != name_edit {
+                dialog.name = Self::sanitize_mod_name(&name_edit);
+                dialog.overwrite_acknowledged = false;
+            }
+            if let Some(value) = set_all {
+                for row in dialog.rows.iter_mut() {
+                    if row.kind != ModExportChange::Unresolved {
+                        row.include = value;
+                    }
+                }
+            }
+            if let Some(index) = toggled
+                && let Some(row) = dialog.rows.get_mut(index)
+            {
+                row.include = !row.include;
+            }
+        }
+        if browse
+            && let Some(folder) = rfd::FileDialog::new()
+                .set_title("Export mod into folder")
+                .pick_folder()
+            && let Some(dialog) = self.mod_export.as_mut()
+        {
+            dialog.folder = folder;
+            dialog.overwrite_acknowledged = false;
+        }
+        if !open || cancel {
+            self.mod_export = None;
+            return;
+        }
+        if export {
+            let Some(dialog) = self.mod_export.as_ref() else {
+                return;
+            };
+            let included: HashSet<String> = dialog
+                .included()
+                .map(|row| row.identity.clone())
+                .collect();
+            let output = dialog.folder.join(format!("{}.utoc", dialog.stem()));
+            let snapshot = dialog.snapshot.clone();
+            // The workspace may have been closed while this was open.
+            if self.focus_navigation_kit(kit) {
+                self.write_reviewed_mod(&snapshot, &included, output);
+            }
+            self.mod_export = None;
+        }
+    }
+
     /// What to do with a mod that was just exported.
     ///
     /// A mod is three files and only the `.pak` looks like one, so copying that
@@ -1354,5 +1600,46 @@ impl Baboon {
         } else if cancel {
             self.import_discard_confirm = None;
         }
+    }
+}
+#[cfg(test)]
+mod mod_export_tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn dialog(name: &str) -> ModExportDialog {
+        ModExportDialog {
+            kit: KitId(0),
+            snapshot: CampaignProjectSnapshot {
+                game: "haloce_evolved".to_owned(),
+                source_path: PathBuf::new(),
+                selected_identity: None,
+                tabs: Vec::new(),
+                overlays: Default::default(),
+            },
+            rows: Vec::new(),
+            name: name.to_owned(),
+            folder: PathBuf::from("/tmp"),
+            overwrite_acknowledged: false,
+        }
+    }
+
+    /// `_P` is what gives a mod priority over the game's own containers, so it
+    /// is part of the name rather than something a rename can drop -- which is
+    /// exactly how a reported mod came to build correctly and do nothing.
+    #[test]
+    fn the_stem_always_carries_the_priority_suffix() {
+        assert_eq!(dialog("h2a_magnum").stem(), "h2a_magnum_P");
+        assert_eq!(dialog("h2a_magnum_P").stem(), "h2a_magnum_P");
+        assert_eq!(dialog("  spaced  ").stem(), "spaced_P");
+    }
+
+    /// The name becomes three files in a folder the user never types, so a
+    /// separator would be a write failure rather than a different path.
+    #[test]
+    fn a_mod_name_cannot_contain_path_syntax() {
+        assert_eq!(Baboon::sanitize_mod_name("../../etc/passwd"), "....etcpasswd");
+        assert_eq!(Baboon::sanitize_mod_name("my:mod?"), "mymod");
+        assert_eq!(Baboon::sanitize_mod_name("  trimmed  "), "trimmed");
     }
 }

--- a/src/app/ui/shell.rs
+++ b/src/app/ui/shell.rs
@@ -1051,6 +1051,7 @@ impl Baboon {
         self.draw_import_discard_confirm(ctx);
         self.draw_overwrite_confirm_window(ctx);
         self.draw_clear_stash_confirm_window(ctx);
+        self.draw_exported_mod_window(ctx);
         self.draw_tag_conversion_window(ctx);
         self.draw_folder_conversion_window(ctx);
         self.draw_about_window(ctx);

--- a/src/app/ui/shell.rs
+++ b/src/app/ui/shell.rs
@@ -122,6 +122,22 @@ impl Baboon {
                                 ui.close_menu();
                                 self.defer_file_action(DeferredFileAction::ExportMod, ctx);
                             }
+                            // The same review, opened to look rather than to
+                            // export -- which is how you check what a workspace
+                            // is carrying before quitting.
+                            if ui
+                                .add_enabled(
+                                    self.kits[self.active].has_unwritten_modifications(),
+                                    egui::Button::new("Review Changes..."),
+                                )
+                                .on_hover_text(
+                                    "See every edit this workspace is holding that is not written into the game",
+                                )
+                                .clicked()
+                            {
+                                ui.close_menu();
+                                self.review_changes();
+                            }
                         }
                         if self.expert_mode {
                             if ui

--- a/src/app/ui/shell.rs
+++ b/src/app/ui/shell.rs
@@ -1051,6 +1051,7 @@ impl Baboon {
         self.draw_import_discard_confirm(ctx);
         self.draw_overwrite_confirm_window(ctx);
         self.draw_clear_stash_confirm_window(ctx);
+        self.draw_mod_export_window(ctx);
         self.draw_exported_mod_window(ctx);
         self.draw_tag_conversion_window(ctx);
         self.draw_folder_conversion_window(ctx);

--- a/src/app/ui/shell.rs
+++ b/src/app/ui/shell.rs
@@ -937,7 +937,6 @@ impl Baboon {
         }
         self.handle_block_confirm(ctx);
         self.handle_save_changes_prompt(ctx);
-        self.handle_project_checkpoint_prompt(ctx);
         self.handle_last_opened_windows_prompt(ctx);
         self.process_pending_open(ctx);
         self.apply_field_nav(ctx);

--- a/src/source/loading.rs
+++ b/src/source/loading.rs
@@ -895,3 +895,4 @@ mod mod_export_tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 }
+


### PR DESCRIPTION
Exporting a Campaign Evolved mod wrote a pak with no way to see what was going
into it. This adds a review step before the file dialog — a visual diff of every
tag the mod carries, drawn through the real tag editor.

### What it shows

Changes are arranged in the shape of the tag, not as a list of paths. For "change
two top-level fields, delete `zone set pvs[3]`, add a `zone sets` element" the
review shows exactly that:

- the changed top-level fields, before on a red wash and after on a green one
- `zone set pvs  5 → 4`, holding only element 3's removal, in red
- `zone sets  4 → 5`, holding only the added element, in green

Containers use the editor's own collapsible chrome, so a block in the review looks
like the block it is, and an unbranching chain of them collapses to one breadcrumb
(`structure bsp pvs[0] › cluster pvs[0] › cluster pvs bit vectors`) rather than
four nested boxes around one changed dword. Added and removed elements get a single
full-width pane in the colour of what happened — a half-width pane beside an empty
twin said less. Each side is filtered to the fields that actually differ.

Reachable two ways: automatically before Export Mod writes anything, and from
**File → Review Changes** at any time (`review_only`, which skips the write).

### The diff engine

`src/app/editor/diff.rs` compares the shipped tag against the edited one. Block
elements match by name first, since a name survives its contents changing; then by
a fingerprint of the element's whole contents, with a shallow fingerprint as a
second tier so an element that both moved and was edited stays paired; position is
the last resort. Reordering is reported as a property of the block via a
longest-increasing-subsequence pass, so a single insertion doesn't read as fifty
elements changing.

### Also here

Fixes found while building this, mostly post-0.2.0 report follow-ups:

- **A mod name is folded into a file-safe stem** — case-preserved kebab-case, with
  the `_P` priority suffix forced on. Without `_P` the game silently ignores the
  pak; the rule was read out of `HaloCampaignEvolved.exe`, which accepts a
  lowercase `_p` too, so the check does as well.
- **"Paks" no longer reappears in recent folders** — the install root is derived by
  matching the known layout suffixes rather than walking upward.
- **New Tag says why it is unavailable** instead of appearing greyed out for no
  reason.
- Two defects caught reviewing the dialog: a name buffer that folded per keystroke
  (you could not type a space) and an acknowledgement flag written in three places
  and read in none.

### Verification

`cargo test` — 359 pass, 19 of them new. The arrangement is pinned against a real
reported case: `tree_matches_the_reported_case` builds the tree from the rows a
user's diagnostic dump actually produced (132 rows) and asserts it reduces to the
three sections above. Alignment has its own suite covering identity matching,
content matching, the shallow-fingerprint tier, and move detection.

Checked by hand: the reported edits, and the visual gap under two short panes that
`horizontal_top`'s separator was causing.

**Not verified in-game.** Naming a mod with spaces, exporting into
`Meteorite/Content/Paks`, and confirming the game loads it has not been run
end-to-end — the folding and the suffix are tested in isolation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
