### PR TITLE
Fix Campaign Evolved collision/physics export, and unstick a restored workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,7 +483,7 @@ dependencies = [
 [[package]]
 name = "blam-tags"
 version = "0.1.0"
-source = "git+https://github.com/camden-smallwood/blam-tags?rev=95c831ea159751b59fb0ed5b4dc3ae552a90002f#95c831ea159751b59fb0ed5b4dc3ae552a90002f"
+source = "git+https://github.com/camden-smallwood/blam-tags?rev=f6639fe#f6639fe4b9926b6267da3b77aa0bf19de89a59fe"
 dependencies = [
  "anyhow",
  "bcdec_rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1"
-blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "95c831ea159751b59fb0ed5b4dc3ae552a90002f", features = ["audio", "iostore"] }
+blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "f6639fe", features = ["audio", "iostore"] }
 eframe = { version = "0.29", default-features = false, features = ["default_fonts", "glow"] }
 egui_extras = { version = "0.29", features = ["svg"] }
 # Tiling layout for the editor area (rerun-io). Targets egui 0.29 exactly, so it
@@ -46,3 +46,4 @@ debug = false
 [profile.dev.package.audiopus_sys]
 opt-level = 1
 debug = false
+

--- a/src/app/browser/tree.rs
+++ b/src/app/browser/tree.rs
@@ -128,25 +128,22 @@ fn ordered_indices<'a>(
     use std::borrow::Cow;
     match sort {
         BrowserSort::Natural => Cow::Borrowed(indices),
+        // `sort_by_cached_key`, not `sort_by`: the key is a freshly lowercased
+        // String, and computing it inside the comparator meant two allocations
+        // per comparison -- ~9,000 of them per frame for a 600-entry folder,
+        // repeated for every expanded folder. Cached, it is one per entry.
         BrowserSort::Name => {
             let mut sorted = indices.to_vec();
-            sorted.sort_by(|&a, &b| {
-                entry_filename_lower(&entries[a]).cmp(&entry_filename_lower(&entries[b]))
-            });
+            sorted.sort_by_cached_key(|&index| entry_filename_lower(&entries[index]));
             Cow::Owned(sorted)
         }
         BrowserSort::Type => {
             let mut sorted = indices.to_vec();
-            sorted.sort_by(|&a, &b| {
-                let key_a = (
-                    format_group_tag(entries[a].group_tag),
-                    entry_filename_lower(&entries[a]),
-                );
-                let key_b = (
-                    format_group_tag(entries[b].group_tag),
-                    entry_filename_lower(&entries[b]),
-                );
-                key_a.cmp(&key_b)
+            sorted.sort_by_cached_key(|&index| {
+                (
+                    format_group_tag(entries[index].group_tag),
+                    entry_filename_lower(&entries[index]),
+                )
             });
             Cow::Owned(sorted)
         }
@@ -156,12 +153,7 @@ fn ordered_indices<'a>(
 fn ordered_child_indices(children: &[TagTreeNode], sort: BrowserSort) -> Vec<usize> {
     let mut indices: Vec<usize> = (0..children.len()).collect();
     if !matches!(sort, BrowserSort::Natural) {
-        indices.sort_by(|&a, &b| {
-            children[a]
-                .label
-                .to_ascii_lowercase()
-                .cmp(&children[b].label.to_ascii_lowercase())
-        });
+        indices.sort_by_cached_key(|&index| children[index].label.to_ascii_lowercase());
     }
     indices
 }

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -991,7 +991,7 @@ impl Baboon {
                 return;
             };
             // Already open with unsaved edits → confirm discard first.
-            if self.kits[self.active].parsed_tags.get(&key).map(|d| d.dirty).unwrap_or(false) {
+            if self.kits[self.active].parsed_tags.get(&key).map(|d| d.dirty.is_set()).unwrap_or(false) {
                 self.import_discard_confirm = Some(PendingImport {
                     kit: self.active_kit_id(),
                     tag,
@@ -1857,7 +1857,7 @@ impl Baboon {
         let was_dirty = self.kits[kit]
             .parsed_tags
             .get(key)
-            .is_some_and(|document| document.dirty);
+            .is_some_and(|document| document.dirty.is_set());
         let had_overlay = self.forget_campaign_overlay(kit, key);
         if !was_dirty && !had_overlay {
             self.status = "That tag has no unsaved changes".to_owned();
@@ -1895,7 +1895,7 @@ impl Baboon {
         if self.kits[kit]
             .parsed_tags
             .get(key)
-            .is_some_and(|document| document.dirty)
+            .is_some_and(|document| document.dirty.is_set())
         {
             return true;
         }
@@ -2060,7 +2060,7 @@ impl Baboon {
             .into_iter()
             .filter_map(|key| {
                 let doc = self.kits[self.active].parsed_tags.get(&key)?;
-                if !doc.dirty {
+                if !doc.dirty.is_set() {
                     return None;
                 }
                 Some(DirtyTagEntry {
@@ -2110,7 +2110,7 @@ impl Baboon {
     pub(super) fn tag_is_dirty(&self, key: &str) -> bool {
         self.kits[self.active].parsed_tags
             .get(key)
-            .is_some_and(|document| document.dirty)
+            .is_some_and(|document| document.dirty.is_set())
     }
 
     fn execute_close_action(&mut self, action: PendingCloseAction, ctx: &egui::Context) {
@@ -2655,7 +2655,7 @@ impl Baboon {
             self.status = "A folder move/copy is already running".to_owned();
             return;
         }
-        if self.kits[self.active].parsed_tags.values().any(|doc| doc.dirty) {
+        if self.kits[self.active].parsed_tags.values().any(|doc| doc.dirty.is_set()) {
             self.status = "Save or close dirty tags before moving/copying folders".to_owned();
             return;
         }
@@ -3044,7 +3044,7 @@ impl Baboon {
             .write_atomic(&output)
             .map_err(|error| error.to_string())?;
         if let Some(doc) = self.kits[self.active].parsed_tags.get_mut(key) {
-            doc.dirty = false;
+            doc.dirty.clear();
         }
         Ok(output)
     }
@@ -3217,7 +3217,7 @@ impl Baboon {
             Err(e) => self.status = format!("Saved, but reloading the pak failed: {e}"),
         }
         if let Some(doc) = self.kits[self.active].parsed_tags.get_mut(key) {
-            doc.dirty = false;
+            doc.dirty.clear();
         }
         self.status = format!("Saved into {} (game files modified)", utoc_path.display());
     }
@@ -3283,7 +3283,7 @@ impl Baboon {
         ) {
             Ok(()) => {
                 if let Some(doc) = self.kits[self.active].parsed_tags.get_mut(key) {
-                    doc.dirty = false;
+                    doc.dirty.clear();
                 }
                 let stem = output.file_stem().and_then(|s| s.to_str()).unwrap_or("mod");
                 self.status = format!(
@@ -3554,7 +3554,7 @@ impl Baboon {
                         skipped += 1;
                         continue;
                     };
-                    overrides.push((m.archive.clone(), rel_path.clone(), overlay.bytes.clone()));
+                    overrides.push((m.archive.clone(), rel_path.clone(), overlay.bytes.as_ref().clone()));
                 }
                 TagEntryLocation::NewContainer {
                     template_container,
@@ -3570,7 +3570,7 @@ impl Baboon {
                         skipped += 1;
                         continue;
                     };
-                    new_pkgs.push((template, overlay.bytes.clone(), package.clone()));
+                    new_pkgs.push((template, overlay.bytes.as_ref().clone(), package.clone()));
                 }
                 _ => skipped += 1,
             }
@@ -3602,7 +3602,9 @@ impl Baboon {
                     .unwrap_or("mod")
                     .to_owned();
                 let sidecar = output.with_extension("baboon");
-                if let Err(error) = save_campaign_project(&sidecar, snapshot) {
+                // A sidecar written next to an exported mod may be replacing an
+                // older one, and nothing here knows what is in it.
+                if let Err(error) = save_campaign_project(&sidecar, snapshot, None) {
                     self.status = format!(
                         "Exported {count} tag(s), but the .baboon sidecar failed: {error}"
                     );
@@ -3726,7 +3728,7 @@ impl Baboon {
 
         let report = fix_tag_dependencies_in_tag(&mut doc.tag, &root, &names, &index);
         if report.fixed > 0 {
-            doc.dirty = true;
+            doc.dirty.touch();
         }
         let status = report.status();
         self.terminal
@@ -3885,7 +3887,7 @@ impl Baboon {
             self.status = "A move/rename is already running".to_owned();
             return;
         }
-        if self.kits[self.active].parsed_tags.values().any(|doc| doc.dirty) {
+        if self.kits[self.active].parsed_tags.values().any(|doc| doc.dirty.is_set()) {
             self.status = "Save or close dirty tags before renaming".to_owned();
             return;
         }
@@ -3908,7 +3910,7 @@ impl Baboon {
             self.status = "A move/rename is already running".to_owned();
             return;
         }
-        if self.kits[self.active].parsed_tags.values().any(|doc| doc.dirty) {
+        if self.kits[self.active].parsed_tags.values().any(|doc| doc.dirty.is_set()) {
             self.status = "Save or close dirty tags before moving".to_owned();
             return;
         }
@@ -5062,7 +5064,7 @@ impl Baboon {
                     Ok(tag) => {
                         if let Some(doc) = self.kits[self.active].parsed_tags.get_mut(key) {
                             doc.tag = tag;
-                            doc.dirty = true;
+                            doc.dirty.touch();
                         }
                         let active = self.active;
                         self.invalidate_tag_caches_in(active, key);
@@ -5244,7 +5246,7 @@ impl Baboon {
         let dirty = self.kits[self.active]
             .parsed_tags
             .get(key)
-            .is_some_and(|document| document.dirty);
+            .is_some_and(|document| document.dirty.is_set());
         if dirty {
             if let Err(error) = self.save_tag_by_key(key) {
                 self.status = format!("Could not save scenario before launch: {error}");
@@ -5305,7 +5307,7 @@ impl Baboon {
         let dirty = self.kits[self.active]
             .parsed_tags
             .get(key)
-            .is_some_and(|document| document.dirty);
+            .is_some_and(|document| document.dirty.is_set());
         if dirty {
             if let Err(error) = self.save_tag_by_key(key) {
                 self.status = format!("Could not save scenario before launch: {error}");
@@ -5766,7 +5768,7 @@ impl Baboon {
                             if let Some(document) =
                                 self.kits[self.active].parsed_tags.get_mut(&entry.tag_id)
                             {
-                                document.dirty = false;
+                                document.dirty.clear();
                             }
                         }
                         self.save_changes_prompt.visible = false;
@@ -5795,7 +5797,7 @@ impl Baboon {
                     .collect();
                 for tag_id in &tag_ids {
                     if let Some(doc) = self.kits[kit].parsed_tags.get_mut(tag_id) {
-                        doc.dirty = false;
+                        doc.dirty.clear();
                     }
                     // And forget anything the project stashed for it. Autosave
                     // captures a dirty tag within a second of the edit, so
@@ -8109,7 +8111,7 @@ mod field_search_tests {
     #[test]
     fn first_match_finds_a_string_id_value_and_path() {
         let mut tag = TagFile::new("definitions/halo2_mcc/model.json").unwrap();
-        let mut dirty = false;
+        let mut dirty = Dirty::default();
         apply_model_variant_ops(
             &mut tag,
             vec![ModelVariantOp::Create {

--- a/src/app/conversion.rs
+++ b/src/app/conversion.rs
@@ -3483,7 +3483,7 @@ impl Baboon {
         if dialog.running {
             return;
         }
-        if self.kits[self.active].parsed_tags.values().any(|document| document.dirty) {
+        if self.kits[self.active].parsed_tags.values().any(|document| document.dirty.is_set()) {
             if let Some(dialog) = self.folder_conversion_dialog.as_mut() {
                 dialog.error =
                     Some("Save or close dirty tags before converting a folder".to_owned());

--- a/src/app/editor/diff.rs
+++ b/src/app/editor/diff.rs
@@ -830,7 +830,7 @@ mod deletion_repro_tests {
             .expect("a zone set pvs block");
         assert!(before > 4, "need several elements to shift, got {before}");
 
-        let mut dirty = false;
+        let mut dirty = Dirty::default();
         crate::app::apply_block_ops(
             &mut edited,
             vec![BlockOp {
@@ -881,7 +881,7 @@ mod deletion_repro_tests {
             return;
         };
         let names = crate::format::TagNameIndex::default();
-        let mut dirty = false;
+        let mut dirty = Dirty::default();
         crate::app::apply_block_ops(
             &mut edited,
             vec![BlockOp {
@@ -930,7 +930,7 @@ mod deletion_repro_tests {
             return;
         };
         let names = crate::format::TagNameIndex::default();
-        let mut dirty = false;
+        let mut dirty = Dirty::default();
         crate::app::apply_block_ops(
             &mut edited,
             vec![

--- a/src/app/editor/mutations.rs
+++ b/src/app/editor/mutations.rs
@@ -17,7 +17,7 @@ pub(in crate::app) struct AppliedFieldEdits {
 pub(in crate::app) fn apply_pending_edits(
     tag: &mut TagFile,
     edits: Vec<PendingFieldEdit>,
-    dirty: &mut bool,
+    dirty: &mut Dirty,
 ) -> AppliedFieldEdits {
     let mut status = None;
     let mut outcomes = Vec::with_capacity(edits.len());
@@ -25,7 +25,7 @@ pub(in crate::app) fn apply_pending_edits(
         let result = catch_edit_unwind(|| apply_field_edit(tag, &edit.path, &edit.input));
         match &result {
             Ok(()) => {
-                *dirty = true;
+                dirty.touch();
                 status = Some(format!("Edited {}", edit.path));
             }
             Err(error) => {
@@ -44,14 +44,14 @@ pub(in crate::app) fn apply_pending_edits(
 pub(in crate::app) fn apply_block_ops(
     tag: &mut TagFile,
     ops: Vec<BlockOp>,
-    dirty: &mut bool,
+    dirty: &mut Dirty,
 ) -> Option<String> {
     let mut status = None;
     for op in ops {
         let result = apply_one_block_op(tag, &op);
         match result {
             Ok(msg) => {
-                *dirty = true;
+                dirty.touch();
 
                 status = Some(msg);
             }
@@ -66,7 +66,7 @@ pub(in crate::app) fn apply_block_ops(
 pub(in crate::app) fn apply_function_data_ops(
     tag: &mut TagFile,
     ops: Vec<FunctionDataOp>,
-    dirty: &mut bool,
+    dirty: &mut Dirty,
 ) -> Option<String> {
     let mut status = None;
     for op in ops {
@@ -74,7 +74,7 @@ pub(in crate::app) fn apply_function_data_ops(
             catch_edit_unwind(|| replace_halo2_function_byte_block(tag, &op.block_path, &op.data));
         match result {
             Ok(()) => {
-                *dirty = true;
+                dirty.touch();
                 status = Some(format!("Edited {}", op.block_path));
             }
             Err(error) => {
@@ -207,7 +207,7 @@ fn replace_halo2_wrapped_function_byte_block(
 pub(in crate::app) fn apply_h2_shader_param_ops(
     tag: &mut TagFile,
     ops: Vec<H2ShaderParamOp>,
-    dirty: &mut bool,
+    dirty: &mut Dirty,
 ) -> Option<String> {
     let mut status = None;
     for op in ops {
@@ -218,7 +218,7 @@ pub(in crate::app) fn apply_h2_shader_param_ops(
         .and_then(|result| result);
         match result {
             Ok(msg) => {
-                *dirty = true;
+                dirty.touch();
                 status = Some(msg);
             }
             Err(error) => {
@@ -540,13 +540,13 @@ fn is_subchunk_backed_field(field_type: TagFieldType) -> bool {
 pub(in crate::app) fn apply_shader_ops(
     tag: &mut TagFile,
     ops: Vec<ShaderOp>,
-    dirty: &mut bool,
+    dirty: &mut Dirty,
 ) -> Option<String> {
     let mut status = None;
     for op in ops {
         match apply_one_shader_op(tag, &op) {
             Ok(msg) => {
-                *dirty = true;
+                dirty.touch();
                 status = Some(msg);
             }
             Err(error) => {
@@ -560,13 +560,13 @@ pub(in crate::app) fn apply_shader_ops(
 pub(in crate::app) fn apply_shader_param_ops(
     tag: &mut TagFile,
     ops: Vec<ShaderParamOp>,
-    dirty: &mut bool,
+    dirty: &mut Dirty,
 ) -> Option<String> {
     let mut status = None;
     for op in ops {
         match apply_one_shader_param_op(tag, &op) {
             Ok(msg) => {
-                *dirty = true;
+                dirty.touch();
                 status = Some(msg);
             }
             Err(error) => {
@@ -580,13 +580,13 @@ pub(in crate::app) fn apply_shader_param_ops(
 pub(in crate::app) fn apply_model_variant_ops(
     tag: &mut TagFile,
     ops: Vec<ModelVariantOp>,
-    dirty: &mut bool,
+    dirty: &mut Dirty,
 ) -> Option<String> {
     let mut status = None;
     for op in ops {
         match apply_one_model_variant_op(tag, &op) {
             Ok(msg) => {
-                *dirty = true;
+                dirty.touch();
                 status = Some(msg);
             }
             Err(error) => {

--- a/src/app/editor/tests.rs
+++ b/src/app/editor/tests.rs
@@ -1337,7 +1337,7 @@ mod tests {
     #[test]
     fn euler_angle_edit_round_trips_through_tag_serialization() {
         let mut tag = TagFile::new(test_definition_path("haloreach_mcc/test_tag.json")).unwrap();
-        let mut dirty = false;
+        let mut dirty = Dirty::default();
 
         let status = apply_pending_edits(
             &mut tag,
@@ -1356,7 +1356,7 @@ mod tests {
         assert_eq!(status.outcomes[0].path, "real euler angles 3d");
         assert_eq!(status.outcomes[0].input, "-0.65, 0, 1.25");
         assert!(status.outcomes[0].result.is_ok());
-        assert!(dirty);
+        assert!(dirty.is_set());
         let bytes = tag.write_to_bytes().unwrap();
         let reopened = TagFile::read_from_bytes(&bytes).unwrap();
         let value = reopened
@@ -1432,7 +1432,7 @@ mod tests {
     #[test]
     fn block_to_tsv_exports_header_and_one_row_per_element() {
         let mut tag = TagFile::new("definitions/halo2_mcc/model.json").unwrap();
-        let mut dirty = false;
+        let mut dirty = Dirty::default();
         for name in ["alpha", "beta"] {
             apply_model_variant_ops(
                 &mut tag,
@@ -1462,7 +1462,7 @@ mod tests {
     #[test]
     fn model_variant_ops_create_update_and_drop_regions() {
         let mut tag = TagFile::new(test_definition_path("halo2_mcc/model.json")).unwrap();
-        let mut dirty = false;
+        let mut dirty = Dirty::default();
 
         let status = apply_model_variant_ops(
             &mut tag,
@@ -1476,7 +1476,7 @@ mod tests {
             &mut dirty,
         );
         assert_eq!(status.as_deref(), Some("Created model variant 'test'"));
-        assert!(dirty);
+        assert!(dirty.is_set());
         assert_variant(&tag, 0, "test", "body", "default");
 
         let status = apply_model_variant_ops(
@@ -1525,7 +1525,7 @@ mod tests {
             markers.add_element();
         }
 
-        let mut dirty = false;
+        let mut dirty = Dirty::default();
         let status = apply_pending_edits(
             &mut tag,
             vec![
@@ -1546,7 +1546,7 @@ mod tests {
             Some("Edited marker groups[0]/markers[0]/rotation")
         );
         assert!(status.outcomes.iter().all(|outcome| outcome.result.is_ok()));
-        assert!(dirty);
+        assert!(dirty.is_set());
         let root = tag.root();
         let translation = root
             .field_path("marker groups[0]/markers[0]/translation")

--- a/src/app/export/geometry.rs
+++ b/src/app/export/geometry.rs
@@ -77,6 +77,7 @@ pub(in crate::app) fn extract_model_geometry(
     let collision_ref = tag_ref_path(&root, "collision model");
     let physics_ref =
         tag_ref_path(&root, "physics_model").or_else(|| tag_ref_path(&root, "physics model"));
+    let skeleton_ref = tag_ref_path(&root, "skeleton model");
     let stem = tag_file_stem(entry);
 
     let mut emitted = Vec::new();
@@ -97,9 +98,9 @@ pub(in crate::app) fn extract_model_geometry(
             // `skeleton model` instead of a `render model`). Reconstruct the
             // high-resolution render JMS from the Unreal Nanite/skeletal meshes
             // fused onto the classic skeleton_model rig.
-            if let Some(skel_ref) = tag_ref_path(&root, "skeleton model") {
+            if let Some(skel_ref) = skeleton_ref.as_deref() {
                 match crate::app::model_preview::loading::campaign_evolved_render_jms(
-                    &model, entry, source, &skel_ref,
+                    &model, entry, source, skel_ref,
                 ) {
                     Ok(jms) => {
                         let render_dir = output.join("render");
@@ -138,9 +139,34 @@ pub(in crate::app) fn extract_model_geometry(
         .as_ref()
         .map(|tag| blam_tags::game::Game::of(tag).jms_version())
         .unwrap_or(8213);
+    // Campaign Evolved has no render_model to take a skeleton from, so collision
+    // hulls stayed in bone-local space (every limb stacked on the pelvis) and
+    // physics shapes hung off bones that were all at the origin. The
+    // `skeleton model` holds the same rest pose the render path uses.
+    let campaign_evolved_skeleton = match (render_tag.as_ref(), skeleton_ref.as_deref()) {
+        (None, Some(reference)) => {
+            match load_referenced_tag_from_source(source, reference, "skeleton_model", b"skel") {
+                Ok(tag) => Some(tag),
+                Err(error) => {
+                    skipped.push(format!("skeleton: {error}"));
+                    None
+                }
+            }
+        }
+        _ => None,
+    };
+    // Deliberately the raw rest pose, not the armature the render JMS emits:
+    // that one is reoriented, which preserves bone positions but changes almost
+    // every rotation, and geometry composed against it would be twisted off its
+    // bone. The reorientation is applied afterwards instead, once the geometry
+    // is placed.
+    let campaign_evolved_rest_pose = campaign_evolved_skeleton
+        .as_ref()
+        .and_then(|tag| JmsFile::skeleton_rest_pose(tag).ok());
     let skeleton = render_jms_for_skeleton
         .as_ref()
-        .map(|jms| jms.nodes.as_slice());
+        .map(|jms| jms.nodes.as_slice())
+        .or(campaign_evolved_rest_pose.as_deref());
 
     if let Some(tag) = render_tag.as_ref() {
         let render_dir = output.join("render");
@@ -166,11 +192,14 @@ pub(in crate::app) fn extract_model_geometry(
                 Ok(tag) => {
                     let collision_dir = output.join("collision");
                     fs::create_dir_all(&collision_dir)?;
-                    let jms = if let Some(skeleton) = skeleton {
+                    let mut jms = if let Some(skeleton) = skeleton {
                         JmsFile::from_collision_model_with_skeleton(&tag, skeleton)?
                     } else {
                         JmsFile::from_collision_model(&tag)?
                     };
+                    if let Some(skel) = campaign_evolved_skeleton.as_ref() {
+                        jms.reorient_for_campaign_evolved(skel);
+                    }
                     let path = collision_dir.join(format!("{stem}.collision.jms"));
                     let mut file = std::io::BufWriter::new(fs::File::create(&path)?);
                     jms.write(&mut file, blam_tags::game::Game::of(&tag).jms_version())?;
@@ -188,11 +217,14 @@ pub(in crate::app) fn extract_model_geometry(
                 Ok(tag) => {
                     let physics_dir = output.join("physics");
                     fs::create_dir_all(&physics_dir)?;
-                    let jms = if let Some(skeleton) = skeleton {
+                    let mut jms = if let Some(skeleton) = skeleton {
                         JmsFile::from_physics_model_with_skeleton(&tag, skeleton)?
                     } else {
                         JmsFile::from_physics_model(&tag)?
                     };
+                    if let Some(skel) = campaign_evolved_skeleton.as_ref() {
+                        jms.reorient_for_campaign_evolved(skel);
+                    }
                     let path = physics_dir.join(format!("{stem}.physics.jms"));
                     let mut file = std::io::BufWriter::new(fs::File::create(&path)?);
                     jms.write(&mut file, blam_tags::game::Game::of(&tag).jms_version())?;

--- a/src/app/foundation/containers.rs
+++ b/src/app/foundation/containers.rs
@@ -2563,7 +2563,7 @@ mod palette_repro_tests {
                 continue;
             };
             let before_len = palette_len(&tag).unwrap_or(0);
-            let mut dirty = false;
+            let mut dirty = Dirty::default();
             let status = crate::app::apply_block_ops(
                 &mut tag,
                 vec![BlockOp {
@@ -2701,7 +2701,7 @@ mod palette_repro_tests {
                 let Some((target, before)) = resolve(&tag) else {
                     continue;
                 };
-                let mut dirty = false;
+                let mut dirty = Dirty::default();
                 let status = crate::app::apply_block_ops(
                     &mut tag,
                     vec![BlockOp {
@@ -2778,7 +2778,7 @@ mod palette_repro_tests {
                 else {
                     continue;
                 };
-                let mut dirty = false;
+                let mut dirty = Dirty::default();
                 let status = crate::app::apply_block_ops(
                     &mut tag,
                     vec![BlockOp {

--- a/src/app/journal.rs
+++ b/src/app/journal.rs
@@ -25,6 +25,11 @@ pub(super) struct EditJournal {
     undo: Vec<Snapshot>,
     redo: Vec<Snapshot>,
     limit: usize,
+    /// Ceiling on the bytes one stack may hold. A snapshot is a whole
+    /// serialized tag, and Campaign Evolved ships a 105 MiB animation graph --
+    /// 64 of those is 6.7 GB. Depth still applies; whichever bound is reached
+    /// first drops the oldest entry.
+    byte_limit: usize,
     /// True while a run of consecutive edit frames is being coalesced into the
     /// single snapshot already pushed for this run.
     coalescing: bool,
@@ -36,6 +41,7 @@ impl Default for EditJournal {
             undo: Vec::new(),
             redo: Vec::new(),
             limit: 64,
+            byte_limit: 256 * 1024 * 1024,
             coalescing: false,
         }
     }
@@ -81,6 +87,7 @@ impl EditJournal {
             push_capped_into(
                 &mut self.redo,
                 self.limit,
+                self.byte_limit,
                 Snapshot {
                     bytes,
                     label: snapshot.label.clone(),
@@ -98,6 +105,7 @@ impl EditJournal {
             push_capped_into(
                 &mut self.undo,
                 self.limit,
+                self.byte_limit,
                 Snapshot {
                     bytes,
                     label: snapshot.label.clone(),
@@ -109,13 +117,17 @@ impl EditJournal {
     }
 
     fn push_capped(&mut self, snapshot: Snapshot) {
-        push_capped_into(&mut self.undo, self.limit, snapshot);
+        push_capped_into(&mut self.undo, self.limit, self.byte_limit, snapshot);
     }
 }
 
-fn push_capped_into(stack: &mut Vec<Snapshot>, limit: usize, snapshot: Snapshot) {
+fn push_capped_into(stack: &mut Vec<Snapshot>, limit: usize, byte_limit: usize, snapshot: Snapshot) {
     stack.push(snapshot);
-    if stack.len() > limit {
+    // Always keep the newest entry, even on its own over budget: dropping it
+    // would mean an edit that cannot be undone at all.
+    while stack.len() > 1
+        && (stack.len() > limit || stack.iter().map(|s| s.bytes.len()).sum::<usize>() > byte_limit)
+    {
         stack.remove(0);
     }
 }
@@ -129,7 +141,7 @@ mod tests {
     }
 
     fn add_variant(tag: &mut TagFile) {
-        let mut dirty = false;
+        let mut dirty = Dirty::default();
         apply_model_variant_ops(
             tag,
             vec![ModelVariantOp::Create {
@@ -141,6 +153,37 @@ mod tests {
             }],
             &mut dirty,
         );
+    }
+
+    /// A snapshot is a whole serialized tag, and Campaign Evolved ships a
+    /// 105 MiB animation graph. Depth alone let the journal reach gigabytes, so
+    /// the byte budget evicts first -- but never the newest entry, or the edit
+    /// just made could not be undone.
+    #[test]
+    fn the_journal_evicts_on_bytes_before_depth() {
+        let mut stack = Vec::new();
+        let budget = 1000;
+        for i in 0..5 {
+            push_capped_into(
+                &mut stack,
+                64,
+                budget,
+                Snapshot { bytes: vec![0; 400], label: format!("edit {i}") },
+            );
+        }
+        assert_eq!(stack.len(), 2, "400 x 2 fits in 1000, 400 x 3 does not");
+        assert_eq!(stack.last().unwrap().label, "edit 4", "the newest survives");
+
+        // One entry over budget on its own is still kept: losing it would mean
+        // an edit with no way back.
+        let mut lone = Vec::new();
+        push_capped_into(
+            &mut lone,
+            64,
+            budget,
+            Snapshot { bytes: vec![0; budget * 4], label: "huge".to_owned() },
+        );
+        assert_eq!(lone.len(), 1);
     }
 
     #[test]

--- a/src/app/kit.rs
+++ b/src/app/kit.rs
@@ -192,7 +192,7 @@ impl Kit {
     /// computed separately and drifted apart — closing the last stashed tag
     /// left the dot showing while the colour went back to clean.
     pub(super) fn has_unwritten_modifications(&self) -> bool {
-        self.parsed_tags.values().any(|document| document.dirty)
+        self.parsed_tags.values().any(|document| document.dirty.is_set())
             || self
                 .campaign_project
                 .as_ref()
@@ -419,7 +419,7 @@ impl Baboon {
 }
 
 fn kit_has_dirty_documents(kit: &Kit) -> bool {
-    kit.parsed_tags.values().any(|document| document.dirty)
+    kit.parsed_tags.values().any(|document| document.dirty.is_set())
 }
 
 /// Label for a kit in the kit strip: the game's display name where one was

--- a/src/app/project.rs
+++ b/src/app/project.rs
@@ -52,7 +52,21 @@ pub(super) struct CampaignProjectOverlay {
     pub(super) logical_path: String,
     pub(super) kind: CampaignProjectTagKind,
     pub(super) package: Option<String>,
-    pub(super) bytes: Vec<u8>,
+    /// Shared, not owned: the overlay map is cloned two or three times per
+    /// autosave tick, and a workspace stashing a 105 MiB tag paid a full copy
+    /// each time.
+    pub(super) bytes: Arc<Vec<u8>>,
+    /// Hashed once, where the bytes are produced. The project fingerprint is
+    /// taken over these rather than over the bytes themselves: a workspace
+    /// holding a 105 MiB animation graph cost 230 ms a tick to re-hash, twice a
+    /// second, purely to learn nothing had changed.
+    pub(super) digest: [u8; 32],
+}
+
+pub(super) fn overlay_digest(bytes: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hasher.finalize().into()
 }
 
 #[derive(Clone, Debug)]
@@ -65,6 +79,15 @@ pub(super) struct CampaignProjectSnapshot {
 }
 
 impl CampaignProjectSnapshot {
+    /// Each overlay's digest, by identity — what the overlays table holds once
+    /// this snapshot has been written.
+    pub(super) fn digests(&self) -> HashMap<String, [u8; 32]> {
+        self.overlays
+            .iter()
+            .map(|(identity, overlay)| (identity.clone(), overlay.digest))
+            .collect()
+    }
+
     pub(super) fn fingerprint(&self) -> Vec<u8> {
         let mut hasher = Sha256::new();
         hasher.update(self.game.as_bytes());
@@ -80,7 +103,7 @@ impl CampaignProjectSnapshot {
         overlays.sort_by(|a, b| a.identity.cmp(&b.identity));
         for overlay in overlays {
             hasher.update(overlay.identity.as_bytes());
-            hasher.update(&overlay.bytes);
+            hasher.update(overlay.digest);
         }
         hasher.finalize().to_vec()
     }
@@ -89,6 +112,15 @@ impl CampaignProjectSnapshot {
 pub(super) struct ActiveCampaignProject {
     pub(super) path: PathBuf,
     pub(super) overlays: HashMap<String, CampaignProjectOverlay>,
+    /// Document key -> the `Dirty` revision its overlay bytes were written
+    /// from, so an untouched document is never serialized twice.
+    pub(super) captured_revisions: HashMap<String, u64>,
+    /// What is actually on disk, by identity, so a save writes only the rows
+    /// whose bytes changed instead of replacing every overlay.
+    pub(super) saved_digests: HashMap<String, [u8; 32]>,
+    /// What an in-flight write will leave on disk, promoted to `saved_digests`
+    /// once it reports success.
+    pub(super) pending_digests: Option<HashMap<String, [u8; 32]>>,
     pub(super) last_saved_fingerprint: Vec<u8>,
     pub(super) next_autosave_at: f64,
     pub(super) revision: u64,
@@ -102,6 +134,9 @@ impl ActiveCampaignProject {
         Self {
             path,
             overlays: HashMap::new(),
+            captured_revisions: HashMap::new(),
+            saved_digests: HashMap::new(),
+            pending_digests: None,
             last_saved_fingerprint: Vec::new(),
             next_autosave_at: now + CAMPAIGN_PROJECT_AUTOSAVE_SECS,
             revision: 0,
@@ -118,7 +153,16 @@ impl ActiveCampaignProject {
     ) -> Self {
         Self {
             path,
+            // Restored overlays came off disk, so that is exactly what is
+            // stored there.
+            saved_digests: snapshot
+                .overlays
+                .iter()
+                .map(|(identity, overlay)| (identity.clone(), overlay.digest))
+                .collect(),
             overlays: snapshot.overlays.clone(),
+            captured_revisions: HashMap::new(),
+            pending_digests: None,
             last_saved_fingerprint: snapshot.fingerprint(),
             next_autosave_at: now + CAMPAIGN_PROJECT_AUTOSAVE_SECS,
             revision: 0,
@@ -151,9 +195,17 @@ pub(super) fn campaign_recovery_path(source_root: Option<&Path>) -> PathBuf {
     crate::storage::data_path(&format!("campaign_evolved_recovery-{tag}.baboon"))
 }
 
+/// Write the project to `path`.
+///
+/// `on_disk` is what the last successful save left in the overlays table, by
+/// identity and digest; overlay rows whose bytes are unchanged are then left
+/// alone. Rewriting every overlay meant editing a 4 MiB scenario also rewrote
+/// the 105 MiB animation graph stashed beside it. Pass `None` when the file's
+/// contents are unknown — every overlay is replaced, as before.
 pub(super) fn save_campaign_project(
     path: &Path,
     snapshot: &CampaignProjectSnapshot,
+    on_disk: Option<&HashMap<String, [u8; 32]>>,
 ) -> Result<(), String> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)
@@ -197,8 +249,27 @@ pub(super) fn save_campaign_project(
     transaction
         .execute("DELETE FROM project", [])
         .and_then(|_| transaction.execute("DELETE FROM tabs", []))
-        .and_then(|_| transaction.execute("DELETE FROM overlays", []))
         .map_err(|error| format!("Could not reset project database: {error}"))?;
+    // Overlays are reconciled rather than replaced: drop the ones that are gone,
+    // rewrite only the ones whose bytes differ.
+    match on_disk {
+        Some(on_disk) => {
+            for identity in on_disk.keys() {
+                if !snapshot.overlays.contains_key(identity) {
+                    transaction
+                        .execute("DELETE FROM overlays WHERE identity = ?1", params![identity])
+                        .map_err(|error| {
+                            format!("Could not drop project tag {identity}: {error}")
+                        })?;
+                }
+            }
+        }
+        None => {
+            transaction
+                .execute("DELETE FROM overlays", [])
+                .map_err(|error| format!("Could not reset project overlays: {error}"))?;
+        }
+    }
     transaction
         .execute(
             "INSERT INTO project (id, version, game, source_path, selected_identity)
@@ -231,9 +302,12 @@ pub(super) fn save_campaign_project(
             .map_err(|error| format!("Could not write project tab {}: {error}", tab.label))?;
     }
     for overlay in snapshot.overlays.values() {
+        if on_disk.is_some_and(|on_disk| on_disk.get(&overlay.identity) == Some(&overlay.digest)) {
+            continue;
+        }
         transaction
             .execute(
-                "INSERT INTO overlays
+                "INSERT OR REPLACE INTO overlays
                  (identity, group_tag, logical_path, kind, package, bytes)
                  VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
                 params![
@@ -242,7 +316,7 @@ pub(super) fn save_campaign_project(
                     overlay.logical_path,
                     overlay.kind.as_str(),
                     overlay.package,
-                    overlay.bytes,
+                    overlay.bytes.as_slice(),
                 ],
             )
             .map_err(|error| {
@@ -343,7 +417,8 @@ pub(super) fn load_campaign_project(path: &Path) -> Result<CampaignProjectSnapsh
                     logical_path,
                     kind,
                     package,
-                    bytes,
+                    digest: overlay_digest(&bytes),
+                    bytes: Arc::new(bytes),
                 },
             ))
         })
@@ -478,8 +553,19 @@ impl Baboon {
             .map(|project| project.overlays.clone())
             .unwrap_or_default();
 
+        // What each dirty document's bytes were captured from last time, so a
+        // document nobody has touched since is carried over instead of being
+        // serialized again. Autosave runs twice a second whether or not
+        // anything was edited, and a stashed 105 MiB animation graph costs
+        // ~100 ms to write out.
+        let captured = self.kits[kit]
+            .campaign_project
+            .as_ref()
+            .map(|project| project.captured_revisions.clone())
+            .unwrap_or_default();
+        let mut now_captured: HashMap<String, u64> = HashMap::new();
         for (key, document) in &self.kits[kit].parsed_tags {
-            if !document.dirty {
+            if !document.dirty.is_set() {
                 continue;
             }
             let Some(entry) = self.entry_for_key_in(kit, key) else {
@@ -489,6 +575,11 @@ impl Baboon {
             else {
                 continue;
             };
+            let revision = document.dirty.revision();
+            now_captured.insert(key.clone(), revision);
+            if captured.get(key) == Some(&revision) && overlays.contains_key(&identity) {
+                continue;
+            }
             let bytes = document
                 .tag
                 .write_to_bytes()
@@ -501,7 +592,8 @@ impl Baboon {
                     logical_path,
                     kind,
                     package,
-                    bytes,
+                    digest: overlay_digest(&bytes),
+                    bytes: Arc::new(bytes),
                 },
             );
         }
@@ -534,7 +626,8 @@ impl Baboon {
                 .map(|(identity, _, _, _)| identity)
         });
         if let Some(project) = self.kits[kit].campaign_project.as_mut() {
-            project.overlays = overlays.clone();
+            project.overlays.clone_from(&overlays);
+            project.captured_revisions = now_captured;
         }
         Ok(Some(CampaignProjectSnapshot {
             game,
@@ -556,7 +649,7 @@ impl Baboon {
         let mut signature: Vec<String> = self.kits[kit]
             .parsed_tags
             .iter()
-            .filter(|(_, document)| document.dirty)
+            .filter(|(_, document)| document.dirty.is_set())
             .map(|(key, _)| key.clone())
             .collect();
         if let Some(project) = self.kits[kit].campaign_project.as_ref() {
@@ -570,7 +663,7 @@ impl Baboon {
         let dirty_keys: Vec<String> = self.kits[kit]
             .parsed_tags
             .iter()
-            .filter(|(_, document)| document.dirty)
+            .filter(|(_, document)| document.dirty.is_set())
             .map(|(key, _)| key.clone())
             .collect();
         for key in dirty_keys {
@@ -695,7 +788,9 @@ impl Baboon {
         let _write_guard = write_lock
             .lock()
             .map_err(|_| "Campaign project writer lock was poisoned".to_owned())?;
-        save_campaign_project(&project.path, &snapshot)?;
+        let on_disk = project.saved_digests.clone();
+        save_campaign_project(&project.path, &snapshot, Some(&on_disk))?;
+        project.saved_digests = snapshot.digests();
         project.last_saved_fingerprint = fingerprint;
         project.next_autosave_at = now + CAMPAIGN_PROJECT_AUTOSAVE_SECS;
         if let Some(session) = self.current_session_state() {
@@ -723,6 +818,21 @@ impl Baboon {
             .campaign_project
             .as_ref()
             .is_some_and(|project| now >= project.next_autosave_at);
+        // A save already running means this tick's work would be thrown away, so
+        // do not do it. The check used to sit *after* the capture, which is the
+        // expensive part.
+        if due
+            && self.kits[kit]
+                .campaign_project
+                .as_ref()
+                .is_some_and(|project| project.save_in_flight.is_some())
+        {
+            if let Some(project) = self.kits[kit].campaign_project.as_mut() {
+                project.next_autosave_at = now + CAMPAIGN_PROJECT_AUTOSAVE_SECS;
+            }
+            ctx.request_repaint_after(std::time::Duration::from_millis(750));
+            return;
+        }
         if due {
             let snapshot = match self.capture_campaign_project(kit, now) {
                 Ok(Some(snapshot)) => snapshot,
@@ -736,9 +846,7 @@ impl Baboon {
             let Some(project) = self.kits[kit].campaign_project.as_mut() else {
                 return;
             };
-            if project.save_in_flight.is_some() {
-                project.next_autosave_at = now + CAMPAIGN_PROJECT_AUTOSAVE_SECS;
-            } else if fingerprint == project.last_saved_fingerprint && project.path.is_file() {
+            if fingerprint == project.last_saved_fingerprint && project.path.is_file() {
                 project.next_autosave_at = now + CAMPAIGN_PROJECT_AUTOSAVE_SECS;
             } else {
                 project.revision = project.revision.wrapping_add(1);
@@ -749,6 +857,9 @@ impl Baboon {
                 latest_write_revision.store(revision, Ordering::SeqCst);
                 project.save_in_flight = Some(revision);
                 project.next_autosave_at = now + CAMPAIGN_PROJECT_AUTOSAVE_SECS;
+                // What this write will leave on disk, held until it succeeds.
+                let on_disk = project.saved_digests.clone();
+                project.pending_digests = Some(snapshot.digests());
                 let tx = self.tx.clone();
                 let repaint = ctx.clone();
                 thread::spawn(move || {
@@ -759,7 +870,7 @@ impl Baboon {
                             if latest_write_revision.load(Ordering::SeqCst) != revision {
                                 Ok(())
                             } else {
-                                save_campaign_project(&path, &snapshot)
+                                save_campaign_project(&path, &snapshot, Some(&on_disk))
                             }
                         });
                     let _ = tx.send(WorkerMessage::CampaignProjectSaved {
@@ -796,9 +907,16 @@ impl Baboon {
             return true;
         };
         project.save_in_flight = None;
+        let pending = project.pending_digests.take();
         match result {
             Ok(()) => {
                 project.last_saved_fingerprint = fingerprint;
+                // Only now is this what the file holds; a failed write leaves
+                // the previous belief in place, so the next save reconciles
+                // against what actually got there.
+                if let Some(digests) = pending {
+                    project.saved_digests = digests;
+                }
                 if let Some(session) = self.current_session_state() {
                     let _ = save_last_session(&session);
                 }
@@ -881,6 +999,7 @@ impl Baboon {
         }
 
         let mut identity_to_key = HashMap::<String, String>::new();
+        let mut restored_revisions = HashMap::<String, u64>::new();
         let mut missing = 0usize;
 
         // Recreate new project tags first, including ones that are currently
@@ -954,8 +1073,13 @@ impl Baboon {
             };
             if let Some(overlay) = pending.snapshot.overlays.get(&tab.identity) {
                 if let Ok(tag) = TagFile::read_from_bytes(&overlay.bytes) {
-                    self.kits[kit].parsed_tags
-                        .insert(key.clone(), TagDocument::modified(tag));
+                    let document = TagDocument::modified(tag);
+                    // The document was parsed from the overlay's own bytes, so
+                    // the project already holds its serialization. Recording
+                    // that spares the first autosave after a restore from
+                    // writing every stashed tag out again.
+                    restored_revisions.insert(key.clone(), document.dirty.revision());
+                    self.kits[kit].parsed_tags.insert(key.clone(), document);
                 } else {
                     missing += 1;
                     continue;
@@ -977,11 +1101,9 @@ impl Baboon {
         if let Some(key) = self.kits[kit].selected_key.clone() {
             self.kits[kit].open_tag_pane(&key);
         }
-        self.kits[kit].campaign_project = Some(ActiveCampaignProject::from_snapshot(
-            pending.path,
-            &pending.snapshot,
-            now,
-        ));
+        let mut project = ActiveCampaignProject::from_snapshot(pending.path, &pending.snapshot, now);
+        project.captured_revisions = restored_revisions;
+        self.kits[kit].campaign_project = Some(project);
         self.status = if missing == 0 {
             format!(
                 "Restored Campaign Evolved project ({} tab(s), {} modified tag(s))",
@@ -1015,8 +1137,14 @@ impl Baboon {
         };
         match TagFile::read_from_bytes(&overlay.bytes) {
             Ok(tag) => {
-                self.kits[kit].parsed_tags
-                    .insert(key.to_owned(), TagDocument::modified(tag));
+                // Same as a restore: the stashed bytes are this document's
+                // serialization already, so autosave need not redo it.
+                let document = TagDocument::modified(tag);
+                let revision = document.dirty.revision();
+                self.kits[kit].parsed_tags.insert(key.to_owned(), document);
+                if let Some(project) = self.kits[kit].campaign_project.as_mut() {
+                    project.captured_revisions.insert(key.to_owned(), revision);
+                }
                 true
             }
             Err(error) => {
@@ -1030,6 +1158,95 @@ impl Baboon {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The revision has to keep climbing across a save, or a cache that saw
+    /// revision 1, watched the document be saved and then edited again, would
+    /// see revision 1 once more and skip work it needed to do.
+    #[test]
+    fn a_dirty_revision_never_repeats() {
+        let mut dirty = Dirty::default();
+        assert!(!dirty.is_set());
+        dirty.touch();
+        let first = dirty.revision();
+        dirty.clear();
+        assert!(!dirty.is_set());
+        dirty.touch();
+        assert!(dirty.is_set());
+        assert_ne!(dirty.revision(), first);
+    }
+
+    fn overlay(identity: &str, bytes: &[u8]) -> CampaignProjectOverlay {
+        CampaignProjectOverlay {
+            identity: identity.to_owned(),
+            group_tag: 0x1234_5678,
+            logical_path: identity.to_owned(),
+            kind: CampaignProjectTagKind::Existing,
+            package: None,
+            digest: overlay_digest(bytes),
+            bytes: Arc::new(bytes.to_vec()),
+        }
+    }
+
+    fn snapshot_of(overlays: Vec<CampaignProjectOverlay>) -> CampaignProjectSnapshot {
+        CampaignProjectSnapshot {
+            game: "haloce_evolved".to_owned(),
+            source_path: PathBuf::from("Paks"),
+            selected_identity: None,
+            tabs: Vec::new(),
+            overlays: overlays
+                .into_iter()
+                .map(|overlay| (overlay.identity.clone(), overlay))
+                .collect(),
+        }
+    }
+
+    /// A save must rewrite only the overlays whose bytes changed. Stashing a
+    /// 105 MiB animation graph alongside a 4 MiB scenario meant every edit to
+    /// the scenario rewrote both.
+    #[test]
+    fn a_save_rewrites_only_the_overlays_whose_bytes_changed() {
+        let path = std::env::temp_dir().join(format!(
+            "baboon-project-diff-{}-{}.baboon",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let first = snapshot_of(vec![overlay("a", b"one"), overlay("b", b"two")]);
+        save_campaign_project(&path, &first, None).unwrap();
+
+        // "a" is unchanged, "b" is gone, "c" is new. The claim that "a" is
+        // already on disk is honoured by digest, so passing different bytes
+        // under its old digest proves the row really was skipped.
+        let mut stale = overlay("a", b"REWRITTEN");
+        stale.digest = overlay_digest(b"one");
+        let second = snapshot_of(vec![stale, overlay("c", b"three")]);
+        save_campaign_project(&path, &second, Some(&first.digests())).unwrap();
+
+        let loaded = load_campaign_project(&path).unwrap();
+        let mut identities: Vec<&String> = loaded.overlays.keys().collect();
+        identities.sort();
+        assert_eq!(identities, vec!["a", "c"], "b was dropped, c was added");
+        assert_eq!(
+            loaded.overlays["a"].bytes.as_slice(),
+            b"one",
+            "a's row was left alone"
+        );
+        assert_eq!(loaded.overlays["c"].bytes.as_slice(), b"three");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// The fingerprint is what autosave compares to decide whether to write, so
+    /// it has to notice a changed overlay while never touching its bytes.
+    #[test]
+    fn the_fingerprint_follows_the_digest() {
+        let before = snapshot_of(vec![overlay("a", b"one")]);
+        let same = snapshot_of(vec![overlay("a", b"one")]);
+        let changed = snapshot_of(vec![overlay("a", b"other")]);
+        assert_eq!(before.fingerprint(), same.fingerprint());
+        assert_ne!(before.fingerprint(), changed.fingerprint());
+    }
 
     #[test]
     fn campaign_project_round_trips_binary_overlays_and_tab_order() {
@@ -1047,7 +1264,8 @@ mod tests {
             logical_path: "objects/test".to_owned(),
             kind: CampaignProjectTagKind::Existing,
             package: None,
-            bytes: vec![0, 1, 2, 0xff],
+            digest: overlay_digest(&[0, 1, 2, 0xff]),
+            bytes: Arc::new(vec![0, 1, 2, 0xff]),
         };
         let snapshot = CampaignProjectSnapshot {
             game: "haloce_evolved".to_owned(),
@@ -1064,7 +1282,7 @@ mod tests {
             }],
             overlays: HashMap::from([(overlay.identity.clone(), overlay.clone())]),
         };
-        save_campaign_project(&path, &snapshot).unwrap();
+        save_campaign_project(&path, &snapshot, None).unwrap();
         let loaded = load_campaign_project(&path).unwrap();
         assert_eq!(loaded.tabs.len(), 1);
         assert_eq!(loaded.tabs[0].identity, overlay.identity);
@@ -1141,3 +1359,4 @@ mod tests {
         );
     }
 }
+

--- a/src/app/state/documents.rs
+++ b/src/app/state/documents.rs
@@ -3,12 +3,47 @@
 
 use super::*;
 
+/// Whether a document diverges from its last save, and how many times it has
+/// been changed.
+///
+/// The count exists so anything that caches a document's serialized bytes can
+/// tell "still the same tag" from "edited again" without serializing it. The
+/// Campaign Evolved autosave used to re-serialize every dirty document twice a
+/// second purely to discover nothing had changed — 100 ms a tick with a 105 MiB
+/// animation graph open.
+#[derive(Default)]
+pub(in crate::app) struct Dirty {
+    set: bool,
+    revision: u64,
+}
+
+impl Dirty {
+    pub(in crate::app) fn is_set(&self) -> bool {
+        self.set
+    }
+
+    /// Monotonic across saves: clearing the flag must not let a later edit
+    /// reuse a revision some cache has already seen.
+    pub(in crate::app) fn revision(&self) -> u64 {
+        self.revision
+    }
+
+    pub(in crate::app) fn touch(&mut self) {
+        self.set = true;
+        self.revision = self.revision.wrapping_add(1);
+    }
+
+    pub(in crate::app) fn clear(&mut self) {
+        self.set = false;
+    }
+}
+
 /// Parsed tag plus its unsaved-state and byte-snapshot edit history.
 /// `dirty` reflects divergence from the last successful save, while journal
 /// entries may still exist after saving to support later undo operations.
 pub(in crate::app) struct TagDocument {
     pub(in crate::app) tag: TagFile,
-    pub(in crate::app) dirty: bool,
+    pub(in crate::app) dirty: Dirty,
     pub(in crate::app) journal: EditJournal,
 }
 
@@ -16,7 +51,7 @@ impl TagDocument {
     pub(in crate::app) fn clean(tag: TagFile) -> Self {
         Self {
             tag,
-            dirty: false,
+            dirty: Dirty::default(),
             journal: EditJournal::default(),
         }
     }
@@ -26,9 +61,11 @@ impl TagDocument {
     /// payload on disk or in a pak), so closing it prompts to save and it feeds
     /// Export Mod as a modified tag.
     pub(in crate::app) fn modified(tag: TagFile) -> Self {
+        let mut dirty = Dirty::default();
+        dirty.touch();
         Self {
             tag,
-            dirty: true,
+            dirty,
             journal: EditJournal::default(),
         }
     }

--- a/src/app/ui.rs
+++ b/src/app/ui.rs
@@ -410,7 +410,7 @@ impl Baboon {
                 let unsaved = self.kits[self.active]
                     .parsed_tags
                     .values()
-                    .filter(|document| document.dirty)
+                    .filter(|document| document.dirty.is_set())
                     .count();
                 let anything = !stashed.is_empty() || unsaved > 0;
                 let icon = button_icon_image(ui, ButtonIcon::Garbage, text_dark(), 16.0);

--- a/src/app/ui/shell.rs
+++ b/src/app/ui/shell.rs
@@ -107,7 +107,7 @@ impl Baboon {
                         if self.current_source_is_container() {
                             if ui
                                 .add_enabled(
-                                    self.kits[self.active].parsed_tags.values().any(|d| d.dirty)
+                                    self.kits[self.active].parsed_tags.values().any(|d| d.dirty.is_set())
                                         || self.kits[self.active]
                                             .campaign_project
                                             .as_ref()
@@ -301,7 +301,7 @@ impl Baboon {
                             let unsaved = self.kits[self.active]
                                 .parsed_tags
                                 .values()
-                                .filter(|document| document.dirty)
+                                .filter(|document| document.dirty.is_set())
                                 .count();
                             if ui
                                 .add_enabled(

--- a/src/app/ui/tag_tiles.rs
+++ b/src/app/ui/tag_tiles.rs
@@ -82,7 +82,7 @@ impl egui_tiles::Behavior<String> for TagPaneBehavior<'_> {
         let dirty = self.app.kits[self.kit_index]
             .parsed_tags
             .get(pane)
-            .is_some_and(|document| document.dirty);
+            .is_some_and(|document| document.dirty.is_set());
         let label = self
             .app
             .kits[self.kit_index]
@@ -297,7 +297,7 @@ impl egui_tiles::Behavior<String> for TagPaneBehavior<'_> {
             if self.app.kits[self.kit_index]
                 .parsed_tags
                 .get(key)
-                .is_some_and(|document| document.dirty));
+                .is_some_and(|document| document.dirty.is_set()));
         if dirty {
             tint_toward(base, Color32::from_rgb(184, 134, 11), 0.20)
         } else {

--- a/src/app/ui/tag_tiles.rs
+++ b/src/app/ui/tag_tiles.rs
@@ -13,6 +13,12 @@ use super::*;
 struct TagPaneBehavior<'a> {
     app: &'a mut Baboon,
     kit_index: usize,
+    /// Tab label and group tag for each open key, resolved in one pass before
+    /// the tree is walked. `egui_tiles` asks for both once per tab per frame,
+    /// and each answer used to be a linear scan of the source's entry lists --
+    /// two scans per tab, ~0.4 ms a frame across six tabs of a 12,291-tag
+    /// Campaign Evolved source, and worse the more tabs are open.
+    tab_labels: HashMap<String, (String, u32)>,
     ctx: egui::Context,
     close_requests: Vec<String>,
     focused: Option<String>,
@@ -84,18 +90,9 @@ impl egui_tiles::Behavior<String> for TagPaneBehavior<'_> {
             .get(pane)
             .is_some_and(|document| document.dirty.is_set());
         let label = self
-            .app
-            .kits[self.kit_index]
-            .source
-            .as_ref()
-            .and_then(|source| {
-                source
-                    .entries
-                    .iter()
-                    .chain(source.all_entries.iter())
-                    .find(|entry| &entry.key == pane)
-            })
-            .map(tag_tab_label)
+            .tab_labels
+            .get(pane)
+            .map(|(label, _)| label.clone())
             .unwrap_or_else(|| pane.clone());
         let text = if dirty {
             format!("• {label}")
@@ -318,17 +315,51 @@ impl egui_tiles::Behavior<String> for TagPaneBehavior<'_> {
 
 impl TagPaneBehavior<'_> {
     fn group_tag_for_key(&self, key: &str) -> Option<u32> {
-        let source = self.app.kits[self.kit_index].source.as_ref()?;
-        source
-            .entries
-            .iter()
-            .chain(source.all_entries.iter())
-            .find(|entry| entry.key == key)
-            .map(|entry| entry.group_tag)
+        self.tab_labels.get(key).map(|(_, group_tag)| *group_tag)
     }
 }
 
 impl Baboon {
+    /// Resolve every open pane's tab label and group tag in a single pass over
+    /// the source, keyed by tag key.
+    fn tab_labels_for_open_panes(
+        &self,
+        kit_index: usize,
+        tree: &egui_tiles::Tree<String>,
+    ) -> HashMap<String, (String, u32)> {
+        let mut labels = HashMap::new();
+        let kit = &self.kits[kit_index];
+        // One targeted scan per open pane. Iterating the entries instead and
+        // testing each against a set of the open keys was measurably *slower*:
+        // it hashes all 24,000 keys rather than comparing a few thousand that
+        // mostly differ early.
+        for tile in tree.tiles.tiles() {
+            let egui_tiles::Tile::Pane(key) = tile else { continue };
+            if labels.contains_key(key) {
+                continue;
+            }
+            let found = kit
+                .source
+                .as_ref()
+                .and_then(|source| {
+                    source
+                        .entries
+                        .iter()
+                        .chain(source.all_entries.iter())
+                        .find(|entry| &entry.key == key)
+                })
+                .or_else(|| {
+                    kit.active_favorite_entries
+                        .iter()
+                        .find(|entry| &entry.key == key)
+                });
+            if let Some(entry) = found {
+                labels.insert(key.clone(), (tag_tab_label(entry), entry.group_tag));
+            }
+        }
+        labels
+    }
+
     /// Draw one kit's open tags as a tiled layout.
     pub(super) fn draw_tag_tiles(&mut self, ui: &mut Ui, ctx: &egui::Context, kit_index: usize) {
         if self.kits[kit_index].tag_tree.is_empty() {
@@ -345,9 +376,11 @@ impl Baboon {
         // and the tree lives on a kit inside it.
         let placeholder = egui_tiles::Tree::empty(tag_tree_id(self.kits[kit_index].id));
         let mut tree = std::mem::replace(&mut self.kits[kit_index].tag_tree, placeholder);
+        let tab_labels = self.tab_labels_for_open_panes(kit_index, &tree);
         let mut behavior = TagPaneBehavior {
             app: self,
             kit_index,
+            tab_labels,
             ctx: ctx.clone(),
             close_requests: Vec::new(),
             focused: None,
@@ -405,3 +438,4 @@ impl Baboon {
         }
     }
 }
+


### PR DESCRIPTION
Three Campaign Evolved reports. Requires blam-tags **`f6639fe`** (bumped in `Cargo.toml`).

## Collision and physics JMS export

Two independent faults, both met on the Pelican's `physics_model`.

**A rigid body may name a container, not a leaf shape.** Either a Havok list, or a
MOPP tree wrapping one. `build_phmo_parent_lookup` recorded only the
`(shape type, shape index)` pairs written directly on rigid bodies, so every shape
reachable through a list exported unparented — written into the JMS as
`<parent> -1`. That is the common case, not an edge: the Pelican's entire hull is
38 polyhedra behind one MOPP, and 4039 of Halo Reach's 5022 polyhedra sit behind a
list.

Containers are now expanded, slicing the flat `list shapes` block by the running
sum of each list's child count. No list stores a start index, so that tiling is an
assumption — I checked it rather than assumed it: of the 68 physics models across
Reach and Halo 3 with more than one list, none fails to tile the block that way.

| kit | JMS shapes with `parent = -1`, before | after |
|---|---|---|
| Halo Reach MCC | 4039+ | 39 |
| Halo 3 MCC | 1726+ | 423 |
| Pelican | 38 | **0** |

The Halo 3 remainder is not this bug — traced it: `banshee.physics_model` has 13
rigid bodies, every one with `node = -1` in the tag itself.

**CE models have no `render_model`.** The rig lives in a `skeleton model`, and the
export only ever derived its skeleton from a render_model. With none to hand,
collision hulls stayed in bone-local space — on the Pelican every limb stacked on
the fuselage centre, a 32×51×26 bounding box for a craft spanning 28×65×80 — and
physics shapes hung off bones that were all at the origin.

The skeleton_model's rest pose is now used, with the render path's reorientation
applied *afterwards*. That order is load-bearing: reorienting first would twist
every hull off its bone, because it changes 123 of a character's 131 bone
rotations while preserving their positions. Node-local physics shapes are
counter-rotated so nothing moves.

A collision JMS also never posed its emitted armature even when handed a skeleton,
on any game (Reach `brute`: 0/63 bones posed). It now shares one
`overlay_skeleton` with the physics builder, which always did this.

Across Campaign Evolved: **80 of 439** models exported collision geometry in the
wrong place, **61 of 431** put physics shapes there.

Written Pelican output: `58/62` nodes posed, `5/5` boxes and `38/38` hull pieces
parented, doors at `[42.2, 0, 47.8]` and `[65.9, ±111.9, 88.1]` instead of the
origin.

## A restored workspace ran at ~1 fps

Every 0.75 s, on the UI thread, the Campaign Evolved autosave decided whether
anything had changed by first doing all the work: `write_to_bytes` on every dirty
document, SHA-256 over every overlay's bytes, and two full clones of the overlay
map — then compared the fingerprint and usually discarded it. It checked
`save_in_flight` only after paying for all of it.

Measured on the reported workspace, whose six stashed tags include a **105 MiB**
`spartans.model_animation_graph`:

```
write_to_bytes  101 ms   (95.8 of it the animation graph)
SHA-256         229 ms   over 112 MiB
map clones      ~16 ms
                ------
                ~340 ms of blocked UI thread per 750 ms
```

delivered as one stall twice a second. Opening the same tags fresh was fine
precisely because with nothing dirty and no overlays, every one of those steps
does nothing.

- `Dirty` replaces the document's `dirty: bool` with a flag plus a monotonic
  revision, so a capture can tell "same tag" from "edited again" without
  serializing. Unchanged documents reuse their stashed bytes; a restored workspace
  records the revision its overlays came from, so even the first tick after
  loading writes nothing.
- Overlays carry a digest taken where their bytes are made. The fingerprint is
  over digests, and a save reconciles the overlays table against what the last
  write left there instead of replacing every row — editing a 4 MiB scenario no
  longer rewrites the 105 MiB graph beside it.
- Overlay bytes are shared rather than copied; the in-flight check moved ahead of
  the capture.
- Undo snapshots are whole serialized tags capped at 64 deep — 6.7 GB for that
  graph. They now carry a 256 MiB budget per stack as well, evicting oldest-first
  but always keeping the newest entry, since dropping that would mean an edit with
  no way back.

Per tick for an idle restored workspace: **~354 ms → effectively nothing.**

## A per-frame sweep afterwards

Measured at CE scale (12,291 tags): tab-bar entry lookups 0.46 ms/frame,
`subtree_has_modified` 0.34 ms, name-sorting a 600-entry folder 0.18 ms, and the
field-search filter 0.0–0.1 ms — that last one looks alarming in the source but
descends only `element(0)` of each block, so it walks the schema, not the data.
About 1 ms total; the autosave really was the whole problem.

Two were worth taking: the tab bar resolves each pane once instead of scanning the
entry lists twice per tab, and the browser's Name/Type sorts use
`sort_by_cached_key` instead of building two Strings per comparison (~9,000
allocations a frame for a 600-entry folder).

Iterating the entries and testing each against a set of open keys — the obvious
tab-bar fix — measured **slower** (0.71 ms): it hashes all ~24,000 long,
shared-prefix keys instead of comparing a few thousand that differ early. Recorded
in the commit so nobody re-derives it. A source-wide key index was left alone
deliberately: 0.4 ms of win against invalidation on every rename, move, new tag,
delete and scan completion, where a stale entry resolves to the wrong tag.

## Verification

`cargo test` — 363 pass, 8 new. Engine side, 261 lib tests pass with 4 new,
including three against the real Pelican that skip when the game isn't installed;
one asserts point-by-point that the armature reorientation moves nothing.

Project-persistence tests write a real SQLite project and prove the differential
save skips unchanged rows, drops removed identities, and adds new ones.

**Not verified:** the Pelican fixes are measured against the real tags, not looked
at in Blender. The workspace performance fix is measured on the tags, not observed
in the reporter's session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
