### PR TITLE
Play referenced Campaign Evolved sounds and list mod containers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,7 +483,7 @@ dependencies = [
 [[package]]
 name = "blam-tags"
 version = "0.1.0"
-source = "git+https://github.com/camden-smallwood/blam-tags?rev=f6639fe#f6639fe4b9926b6267da3b77aa0bf19de89a59fe"
+source = "git+https://github.com/camden-smallwood/blam-tags?rev=cb0e6a1#cb0e6a14cdb35ac6d8292cc03215ed005895f540"
 dependencies = [
  "anyhow",
  "bcdec_rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1"
-blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "f6639fe", features = ["audio", "iostore"] }
+blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "cb0e6a1", features = ["audio", "iostore"] }
 eframe = { version = "0.29", default-features = false, features = ["default_fonts", "glow"] }
 egui_extras = { version = "0.29", features = ["svg"] }
 # Tiling layout for the editor area (rerun-io). Targets egui 0.29 exactly, so it
@@ -46,4 +46,3 @@ debug = false
 [profile.dev.package.audiopus_sys]
 opt-level = 1
 debug = false
-

--- a/src/app.rs
+++ b/src/app.rs
@@ -280,6 +280,10 @@ pub struct Baboon {
     ce_usmap: Option<Arc<blam_tags::iostore::usmap::Usmap>>,
     /// Pending sound-extraction batch (decode + write), drained by the audio layer.
     pending_sound_extract: Option<ExtractRequest>,
+    /// Pending play/extract of a `.sound` a container-source tag only refers to,
+    /// stamped with the kit that raised it. Resolved after rendering, since the
+    /// referenced tag's audio has to be walked out to Wwise first.
+    pending_ce_sound_ref: Option<(KitId, CeSoundRefRequest)>,
     /// Pending "open referenced tag in a new tab" request.
     pending_open: Option<OpenTagRequest>,
     /// Movable Campaign Evolved tag-reference picker, when one is open.
@@ -474,6 +478,7 @@ impl Baboon {
             audio: audio::AudioState::default(),
             ce_usmap: None,
             pending_sound_extract: None,
+            pending_ce_sound_ref: None,
             pending_open: None,
             tag_reference_picker: None,
             pending_tool_import: None,

--- a/src/app/audio.rs
+++ b/src/app/audio.rs
@@ -246,7 +246,9 @@ pub(super) struct AudioState {
     event_cache: HashMap<String, Arc<DecodedPcm>>,
     /// Campaign Evolved's legacy `.pak` set, opened on first playback. CE media
     /// is not in IoStore, so this is a separate store from `wwise` above.
-    ce_media: crate::source::ce_audio::CeMediaStore,
+    /// `pub(super)` because binding resolution also needs it: an event whose
+    /// media lives inside a SoundBank is only readable through the pak set.
+    pub(super) ce_media: crate::source::ce_audio::CeMediaStore,
     /// Current playback volume (linear, 0.0..=1.0). Held here so it survives
     /// before the engine is lazily created and seeds it on first play.
     volume: Volume,

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -176,6 +176,45 @@ impl Baboon {
             return None;
         };
         let package = ce_audio::tag_package_for_rel_path(rel_path)?;
+        self.ce_binding_for_package(kit_index, tag_key, &package)
+    }
+
+    /// The Wwise binding of a `sound` tag reached by *reference* rather than by
+    /// browser entry — a `sound_looping` track's component, a dialogue
+    /// vocalization. Resolves the reference against the mounted containers and
+    /// then follows the same walk, memoized under the same per-kit cache.
+    pub(in crate::app) fn ce_sound_binding_for_ref(
+        &mut self,
+        kit_index: usize,
+        group_tag: u32,
+        reference: &str,
+    ) -> Option<std::sync::Arc<crate::source::ce_audio::CeSoundBinding>> {
+        use crate::source::ce_audio;
+
+        let Some(TagSource::IoStoreContainerSet { index, .. }) =
+            self.kits[kit_index].source.as_ref().map(|s| &s.source)
+        else {
+            return None;
+        };
+        let (_, rel_path) = index.lookup(group_tag, reference)?;
+        let package = ce_audio::tag_package_for_rel_path(rel_path)?;
+        let cache_key = format!("ref:{package}");
+        self.ce_binding_for_package(kit_index, &cache_key, &package)
+    }
+
+    /// Walk one cooked package out to its Wwise media, memoized under
+    /// `cache_key` in this kit. Shared by both entry points above.
+    fn ce_binding_for_package(
+        &mut self,
+        kit_index: usize,
+        cache_key: &str,
+        package: &str,
+    ) -> Option<std::sync::Arc<crate::source::ce_audio::CeSoundBinding>> {
+        use crate::source::ce_audio;
+
+        if let Some(hit) = self.kits[kit_index].ce_sound_bindings.get(cache_key) {
+            return Some(hit.clone());
+        }
 
         // Checked before the usmap is parsed, as it always has been: a non-CE
         // source must bail out without paying for the bundled reflection data.
@@ -199,6 +238,7 @@ impl Baboon {
         let usmap = self.ce_usmap.clone()?;
 
         let Some(TagSource::IoStoreContainerSet {
+            root,
             containers,
             packages,
             ..
@@ -207,13 +247,89 @@ impl Baboon {
             return None;
         };
 
+        // `kits` and `audio` are disjoint fields, so the pak set can be handed
+        // to the walk while the container borrow is live. It is needed for
+        // events whose media is cooked inside a SoundBank.
         let binding = std::sync::Arc::new(ce_audio::resolve_sound_binding(
-            containers, packages, &usmap, &package,
+            containers,
+            packages,
+            &usmap,
+            package,
+            Some((root.as_path(), &mut self.audio.ce_media)),
         ));
         self.kits[kit_index]
             .ce_sound_bindings
-            .insert(tag_key.to_owned(), binding.clone());
+            .insert(cache_key.to_owned(), binding.clone());
         Some(binding)
+    }
+
+    /// Drain a queued referenced-sound click from a container source: resolve
+    /// the reference's own Wwise binding, then queue the same playback or
+    /// extraction the primary sound player would.
+    pub(super) fn process_ce_sound_ref(&mut self) {
+        let Some((kit_id, request)) = self.pending_ce_sound_ref.take() else {
+            return;
+        };
+        let Some(kit_index) = self.kit_index(kit_id) else {
+            return;
+        };
+        let paks_root = match self.kits[kit_index].source.as_ref().map(|s| &s.source) {
+            Some(TagSource::IoStoreContainerSet { root, .. }) => root.clone(),
+            _ => return,
+        };
+        let Some(binding) =
+            self.ce_sound_binding_for_ref(kit_index, request.group_tag, &request.reference)
+        else {
+            self.status = format!("{} not found in mounted containers", request.label);
+            return;
+        };
+        if binding.is_empty() {
+            self.status = format!("{} has no audio bound", request.label);
+            return;
+        }
+
+        let language = binding.language_to_show(self.audio.language.as_deref());
+        let media: Vec<crate::source::ce_audio::CeSoundMedia> = binding
+            .media_for_language(&language)
+            .into_iter()
+            .cloned()
+            .collect();
+        if !request.extract {
+            // Play the first permutation, matching the loose-folder player.
+            let Some(first) = media.into_iter().next() else {
+                return;
+            };
+            self.audio.pending = Some(crate::app::audio::SoundAction::PlayCeMedia {
+                paks_root,
+                label: format!("{} \u{00B7} {}", request.label, first.display_name()),
+                media: Box::new(first),
+            });
+            return;
+        }
+        let Some(base) = rfd::FileDialog::new()
+            .set_title(format!("Extract {}", request.label))
+            .pick_folder()
+        else {
+            return;
+        };
+        let items = media
+            .into_iter()
+            .map(|m| crate::app::sound_extract::ExtractItem {
+                out_path: base.join(format!(
+                    "{}.wav",
+                    crate::app::sound_extract::sanitize_component(&m.display_name())
+                )),
+                source: crate::app::sound_extract::ExtractSource::CeMedia {
+                    paks_root: paks_root.clone(),
+                    media: Box::new(m),
+                },
+            })
+            .collect();
+        self.pending_sound_extract = Some(crate::app::sound_extract::ExtractRequest {
+            items,
+            tags_root: None,
+            label: request.label,
+        });
     }
 
     fn push_terminal_line(&mut self, line: String) {

--- a/src/app/editor/sound.rs
+++ b/src/app/editor/sound.rs
@@ -899,6 +899,29 @@ fn draw_wwise_event_player(
     });
 }
 
+/// Stand-in for a Campaign Evolved `sound` tag that reaches no Wwise event.
+///
+/// About a tenth of the game's sound tags are like this — Reach metadata kept
+/// for the simulation with no audio asset behind them. Saying so is the whole
+/// point: the alternative is a player that looks playable and never is.
+fn draw_ce_unbound_note(ui: &mut Ui) {
+    egui::CollapsingHeader::new(
+        RichText::new("Sound \u{2014} no audio bound").color(text_dark()),
+    )
+    .default_open(true)
+    .show(ui, |ui| {
+        ui.label(
+            RichText::new(
+                "This tag's permutation table is inherited Reach metadata. Campaign \
+                 Evolved plays audio through Wwise, and no event is wired to this tag, \
+                 so there is nothing to audition or extract.",
+            )
+            .color(subtle_dark()),
+        );
+    });
+    ui.add_space(6.0);
+}
+
 /// Render the Campaign Evolved player.
 ///
 /// CE `sound` tags hold no sample data and — unlike Halo 4 — name no event
@@ -1044,7 +1067,7 @@ fn draw_ce_wwise_player(
                     ui.label(RichText::new(m.display_name()).color(text_dark()))
                         .on_hover_text(&m.source_name);
                     ui.label(RichText::new(&m.event_name).color(subtle_dark()));
-                    ui.label(RichText::new(m.media_path.clone()).color(subtle_dark()));
+                    ui.label(RichText::new(m.location_label()).color(subtle_dark()));
                     ui.end_row();
                 }
             });
@@ -1057,13 +1080,18 @@ pub(in crate::app) fn draw_sound_player(
     edit: &mut FieldEditContext<'_>,
 ) {
     // Campaign Evolved: audio is reached through package imports, not the tag.
-    // An empty binding means the tag is one of the many unbound stubs, which
-    // has no player at all rather than an empty one.
-    if let Some(binding) = edit.ce_sound
-        && !binding.is_empty()
-    {
-        let binding = binding.clone();
-        draw_ce_wwise_player(ui, &binding, edit);
+    // `Some` means this is a CE sound tag, whatever it resolved to — so the
+    // fall-through below (which reads the Reach permutation table and plays it
+    // out of an FMOD bank that does not exist here) must never be reached. It
+    // rendered a working-looking player whose every button said "no source
+    // loaded".
+    if let Some(binding) = edit.ce_sound {
+        if binding.is_empty() {
+            draw_ce_unbound_note(ui);
+        } else {
+            let binding = binding.clone();
+            draw_ce_wwise_player(ui, &binding, edit);
+        }
         return;
     }
     // Halo 4: Wwise event reference, no inline pitch-range audio.
@@ -1392,9 +1420,51 @@ fn referenced_sound_extract_items(
     build_extract_items(tag, &rows, h2_params, base, false, sound_rel)
 }
 
+/// What a click on a referenced-sound row produced. A container source can only
+/// yield `ce_ref`: the referenced tag holds no samples, so the app resolves its
+/// Wwise binding after the frame.
+#[derive(Default)]
+struct ReferencedSoundClick {
+    open: Option<OpenTagRequest>,
+    play: Option<super::audio::SoundAction>,
+    extract: Option<ExtractRequest>,
+    ce_ref: Option<CeSoundRefRequest>,
+}
+
+impl ReferencedSoundClick {
+    /// Fold another row's click into this one. Only one button can be pressed
+    /// per frame, so a later row's `Some` simply wins.
+    fn take_from(&mut self, other: Self) {
+        self.open = other.open.or(self.open.take());
+        self.play = other.play.or(self.play.take());
+        self.extract = other.extract.or(self.extract.take());
+        self.ce_ref = other.ce_ref.or(self.ce_ref.take());
+    }
+
+    /// Hand every collected request to the app.
+    fn apply(self, edit: &mut FieldEditContext<'_>) {
+        if self.open.is_some() {
+            *edit.open_request = self.open;
+        }
+        if self.play.is_some() {
+            *edit.sound_play_request = self.play;
+        }
+        if self.extract.is_some() {
+            *edit.sound_extract_request = self.extract;
+        }
+        if self.ce_ref.is_some() {
+            *edit.ce_sound_ref_request = self.ce_ref;
+        }
+    }
+}
+
 /// Render a set of `.sound` refs with a ▶ Play, ⬇ Extract, and the clickable
 /// open-label per ref. Shared by the dialogue and sound_looping players; kept out
 /// of `edit` so the grid closure needn't borrow it mutably.
+///
+/// `container_source` marks a Campaign Evolved mount, where there is no tags
+/// root to load the referenced tag from — and nothing worth loading if there
+/// were, since CE sound tags carry no samples.
 fn draw_referenced_sound_cell(
     ui: &mut Ui,
     refs: &[(u32, String)],
@@ -1402,62 +1472,77 @@ fn draw_referenced_sound_cell(
     tags_root: Option<&std::path::Path>,
     definitions_root: Option<&std::path::Path>,
     language: Option<&str>,
-) -> (
-    Option<OpenTagRequest>,
-    Option<super::audio::SoundAction>,
-    Option<ExtractRequest>,
-) {
-    let (mut open, mut play, mut extract) = (None, None, None);
+    container_source: bool,
+) -> ReferencedSoundClick {
+    let mut click = ReferencedSoundClick::default();
     if refs.is_empty() {
         ui.label(RichText::new("(none)").color(subtle_dark()));
-        return (open, play, extract);
+        return click;
     }
     ui.vertical(|ui| {
         for (group, path) in refs {
             ui.horizontal(|ui| {
                 let is_sound = &group.to_be_bytes() == b"snd!";
+                let label = path.rsplit(['\\', '/']).next().unwrap_or(path).to_owned();
                 if is_sound
                     && ui
                         .small_button("\u{25B6}")
                         .on_hover_text("Play this referenced sound")
                         .clicked()
                 {
-                    if let Some((sound, _)) =
+                    if container_source {
+                        click.ce_ref = Some(CeSoundRefRequest {
+                            group_tag: *group,
+                            reference: path.clone(),
+                            label: label.clone(),
+                            extract: false,
+                        });
+                    } else if let Some((sound, _)) =
                         load_referenced_sound(game, tags_root, definitions_root, path, *group)
                     {
-                        play = referenced_sound_play_action(&sound, Some(path.as_str()));
+                        click.play = referenced_sound_play_action(&sound, Some(path.as_str()));
                     }
                 }
+                // Deliberately a second `if`: chaining these would skip drawing
+                // the extract button on the frame Play is clicked.
                 if is_sound
                     && ui
                         .small_button("\u{2B07}")
-                        .on_hover_text("Extract this referenced sound to its data\\ folder")
+                        .on_hover_text(if container_source {
+                            "Extract this referenced sound's permutations to a folder"
+                        } else {
+                            "Extract this referenced sound to its data\\ folder"
+                        })
                         .clicked()
                 {
-                    if let Some((sound, abs)) =
+                    if container_source {
+                        click.ce_ref = Some(CeSoundRefRequest {
+                            group_tag: *group,
+                            reference: path.clone(),
+                            label,
+                            extract: true,
+                        });
+                    } else if let Some((sound, abs)) =
                         load_referenced_sound(game, tags_root, definitions_root, path, *group)
-                    {
-                        if let Some(base) =
+                        && let Some(base) =
                             tags_root.and_then(|root| reimport_base_dir_lang(root, &abs, language))
-                        {
-                            let items =
-                                referenced_sound_extract_items(&sound, &base, Some(path.as_str()));
-                            let label = path.rsplit(['\\', '/']).next().unwrap_or(path).to_owned();
-                            extract = Some(ExtractRequest {
-                                items,
-                                tags_root: tags_root.map(std::path::Path::to_path_buf),
-                                label,
-                            });
-                        }
+                    {
+                        let items =
+                            referenced_sound_extract_items(&sound, &base, Some(path.as_str()));
+                        click.extract = Some(ExtractRequest {
+                            items,
+                            tags_root: tags_root.map(std::path::Path::to_path_buf),
+                            label,
+                        });
                     }
                 }
                 if let Some(request) = ref_open_label(ui, *group, path) {
-                    open = Some(request);
+                    click.open = Some(request);
                 }
             });
         }
     });
-    (open, play, extract)
+    click
 }
 
 pub(in crate::app) fn draw_dialogue_summary(
@@ -1512,14 +1597,13 @@ pub(in crate::app) fn draw_dialogue_summary(
         rows.push(DialogueRow { name, sounds });
     }
 
-    let mut to_open: Option<OpenTagRequest> = None;
-    let mut to_play: Option<super::audio::SoundAction> = None;
-    let mut to_extract: Option<ExtractRequest> = None;
+    let mut clicked = ReferencedSoundClick::default();
     // Copies so the grid closure needn't borrow `edit`.
     let game = edit.game;
     let tags_root = edit.tags_root;
     let defs = edit.definitions_root;
     let language = edit.sound_language;
+    let container_source = edit.ce_paks_root.is_some();
     egui::CollapsingHeader::new(
         RichText::new(format!(
             "Dialogue Overview ({total} vocalizations, {total_sounds} sounds)"
@@ -1550,23 +1634,16 @@ pub(in crate::app) fn draw_dialogue_summary(
                         ui.end_row();
                         for row in &rows {
                             ui.label(RichText::new(&row.name).color(text_dark()));
-                            let (open, play, extract) = draw_referenced_sound_cell(
+                            let click = draw_referenced_sound_cell(
                                 ui,
                                 &row.sounds,
                                 game,
                                 tags_root,
                                 defs,
                                 language,
+                                container_source,
                             );
-                            if open.is_some() {
-                                to_open = open;
-                            }
-                            if play.is_some() {
-                                to_play = play;
-                            }
-                            if extract.is_some() {
-                                to_extract = extract;
-                            }
+                            clicked.take_from(click);
 
                             ui.end_row();
                         }
@@ -1582,15 +1659,7 @@ pub(in crate::app) fn draw_dialogue_summary(
                 }
             });
     });
-    if to_open.is_some() {
-        *edit.open_request = to_open;
-    }
-    if to_play.is_some() {
-        *edit.sound_play_request = to_play;
-    }
-    if to_extract.is_some() {
-        *edit.sound_extract_request = to_extract;
-    }
+    clicked.apply(edit);
     ui.add_space(6.0);
 }
 
@@ -1647,13 +1716,12 @@ pub(in crate::app) fn draw_sound_looping_player(
     if refs.is_empty() {
         return;
     }
-    let mut to_open: Option<OpenTagRequest> = None;
-    let mut to_play: Option<super::audio::SoundAction> = None;
-    let mut to_extract: Option<ExtractRequest> = None;
+    let mut clicked = ReferencedSoundClick::default();
     let game = edit.game;
     let tags_root = edit.tags_root;
     let defs = edit.definitions_root;
     let language = edit.sound_language;
+    let container_source = edit.ce_paks_root.is_some();
     egui::CollapsingHeader::new(
         RichText::new(format!(
             "Sound Looping \u{2014} {} component sound(s)",
@@ -1674,32 +1742,21 @@ pub(in crate::app) fn draw_sound_looping_player(
                         for (label, group, path) in &refs {
                             ui.label(RichText::new(label).color(subtle_dark()));
                             let one = [(*group, path.clone())];
-                            let (open, play, extract) = draw_referenced_sound_cell(
-                                ui, &one, game, tags_root, defs, language,
-                            );
-                            if open.is_some() {
-                                to_open = open;
-                            }
-                            if play.is_some() {
-                                to_play = play;
-                            }
-                            if extract.is_some() {
-                                to_extract = extract;
-                            }
+                            clicked.take_from(draw_referenced_sound_cell(
+                                ui,
+                                &one,
+                                game,
+                                tags_root,
+                                defs,
+                                language,
+                                container_source,
+                            ));
                             ui.end_row();
                         }
                     });
             });
     });
-    if to_open.is_some() {
-        *edit.open_request = to_open;
-    }
-    if to_play.is_some() {
-        *edit.sound_play_request = to_play;
-    }
-    if to_extract.is_some() {
-        *edit.sound_extract_request = to_extract;
-    }
+    clicked.apply(edit);
     ui.add_space(6.0);
 }
 

--- a/src/app/editor/tests.rs
+++ b/src/app/editor/tests.rs
@@ -78,6 +78,7 @@ mod tests {
             &packages,
             &usmap,
             "/Game/Tags/sound/scripted/vo_scr_m02halo/m02_00040_cortana-sound",
+            None,
         );
         assert!(!binding.is_empty(), "no media resolved");
 

--- a/src/app/foundation/tests.rs
+++ b/src/app/foundation/tests.rs
@@ -169,6 +169,7 @@ mod tests {
             sound_extract_request: &mut sound_extract_request,
             sound_language: None,
             ce_sound: None,
+            ce_sound_ref_request: &mut None,
             ce_paks_root: None,
             tool_import: &mut tool_import,
             bitmap_reimport: &mut bitmap_reimport,

--- a/src/app/shader/widgets.rs
+++ b/src/app/shader/widgets.rs
@@ -511,6 +511,7 @@ pub(in crate::app) fn draw_shader_grid_row_readonly(
         sound_extract_request: &mut sound_extract_request,
         sound_language: None,
         ce_sound: None,
+        ce_sound_ref_request: &mut None,
         ce_paks_root: None,
         tool_import: &mut tool_import,
         bitmap_reimport: &mut bitmap_reimport,

--- a/src/app/state/editing.rs
+++ b/src/app/state/editing.rs
@@ -244,6 +244,25 @@ pub(in crate::app) struct OpenTagRequest {
     pub(in crate::app) float: bool,
 }
 
+/// A request to play or extract a `.sound` a container-source tag only *refers*
+/// to (`sound_looping` tracks, dialogue vocalizations).
+///
+/// On a loose folder the player loads the referenced tag and reads its samples
+/// on the spot. A Campaign Evolved tag has no samples to read: the audio is
+/// reached by walking the referenced tag's own package imports out to Wwise,
+/// which is the app's job, not the field renderer's. So the click is recorded
+/// here and resolved after the frame.
+#[derive(Clone)]
+pub(in crate::app) struct CeSoundRefRequest {
+    pub(in crate::app) group_tag: u32,
+    /// The reference as stored in the tag (Halo-relative, `\`-separated).
+    pub(in crate::app) reference: String,
+    /// Label for the player's status line.
+    pub(in crate::app) label: String,
+    /// Extract every permutation to a chosen folder instead of playing one.
+    pub(in crate::app) extract: bool,
+}
+
 /// Read-only tag catalog exposed to reference pickers for sources whose tags do
 /// not exist as ordinary files. The group tree's indices address `entries`.
 #[derive(Clone, Copy)]
@@ -437,6 +456,11 @@ pub(in crate::app) struct FieldEditContext<'a> {
     /// The container source's `Paks` directory, where the legacy `.pak`
     /// containers holding Campaign Evolved's Wwise media live.
     pub(in crate::app) ce_paks_root: Option<&'a Path>,
+    /// Set when a player that only holds a `.sound` *reference* (sound_looping,
+    /// dialogue) is asked to play or extract one on a container source. The
+    /// referenced tag carries no audio itself, so the app resolves the
+    /// reference's own Wwise binding after rendering rather than here.
+    pub(in crate::app) ce_sound_ref_request: &'a mut Option<CeSoundRefRequest>,
     /// Set when the user clicks "Import" on a geometry tag-reference row.
     pub(in crate::app) tool_import: &'a mut Option<ToolImportRequest>,
     /// Set when the user clicks "Reimport" on a bitmap tag.

--- a/src/app/ui/dialogs.rs
+++ b/src/app/ui/dialogs.rs
@@ -724,6 +724,7 @@ impl Baboon {
             sound_extract_request: &mut sound_extract_request,
             sound_language: None,
             ce_sound: None,
+            ce_sound_ref_request: &mut None,
             ce_paks_root: None,
             tool_import: &mut tool_import,
             bitmap_reimport: &mut bitmap_reimport,

--- a/src/app/ui/shell.rs
+++ b/src/app/ui/shell.rs
@@ -971,6 +971,10 @@ impl Baboon {
         self.handle_last_opened_windows_prompt(ctx);
         self.process_pending_open(ctx);
         self.apply_field_nav(ctx);
+        // A referenced sound on a container source resolves to its own Wwise
+        // binding first, and queues an ordinary play/extract from there — so it
+        // must run before both drains below, not after.
+        self.process_ce_sound_ref();
         // Drain queued sound-player actions: resolve the permutation against the
         // FMOD banks, decode (cached), and play/stop. Runs every frame so voices
         // are reaped even when idle; the tags root is only cloned when acting.

--- a/src/app/ui/tag_pane.rs
+++ b/src/app/ui/tag_pane.rs
@@ -74,6 +74,7 @@ impl Baboon {
         let mut block_clip_request = None;
         let mut bitmap_reimport = None;
         let mut tsv_paste_request = None;
+        let mut ce_sound_ref_request = None;
 
         // Taken rather than read: it is a one-shot, and egui remembers the
         // state each container lands in, so forcing it for a single frame is
@@ -130,6 +131,7 @@ impl Baboon {
             sound_extract_request: &mut self.pending_sound_extract,
             sound_language: self.audio.language.as_deref(),
             ce_sound: ce_sound.as_deref(),
+            ce_sound_ref_request: &mut ce_sound_ref_request,
             ce_paks_root,
             tool_import: &mut self.pending_tool_import,
             bitmap_reimport: &mut bitmap_reimport,
@@ -264,6 +266,12 @@ impl Baboon {
         if let Some(popup) = function_request {
             self.function_popup = Some(popup);
             self.function_popup_kit = Some(kit_id);
+        }
+        // A referenced sound was played/extracted from a container source. It
+        // is stamped with this kit because resolving it needs that kit's
+        // containers, not whichever one happens to be active by the drain.
+        if let Some(request) = ce_sound_ref_request {
+            self.pending_ce_sound_ref = Some((kit_id, request));
         }
         // The reference picker is opened from inside the field renderer rather
         // than hoisted here, so it is stamped by noticing it appear.

--- a/src/source/ce_audio.rs
+++ b/src/source/ce_audio.rs
@@ -18,14 +18,16 @@
 //! so playback needs both indexes: [`ContainerPackageIndex`] to walk the
 //! imports and a `PakSet` to fetch the bytes.
 
-use std::collections::{BTreeSet, VecDeque};
+use std::collections::{BTreeSet, HashMap, VecDeque};
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use anyhow::{Context, Result, anyhow};
+use blam_tags::audio::wwise::{Bnk, HircIndex, SoundSource};
 use blam_tags::iostore::container_header::EIoContainerHeaderVersion;
 use blam_tags::iostore::pak::PakSet;
-use blam_tags::iostore::ue_types::EIoStoreTocVersion;
+use blam_tags::iostore::ue_types::{EIoStoreTocVersion, FPackageObjectIndex};
 use blam_tags::iostore::usmap::Usmap;
 use blam_tags::iostore::wwise_event::{EventCookedData, read_event_cooked_data};
 use blam_tags::iostore::zen::FZenPackageHeader;
@@ -43,6 +45,21 @@ const WWISE_MOUNT: &str = "Meteorite/Content/WwiseAudio";
 /// Guard against a pathological import graph; the real chains are 3–4 deep.
 const MAX_PACKAGE_VISITS: usize = 512;
 
+/// Where one permutation's bytes sit inside the pak set.
+///
+/// Roughly a tenth of the game's sounds are cooked with their media *inside* a
+/// SoundBank rather than staged as loose `.wem` — for those, the event's cooked
+/// data lists banks and no media at all, and the permutations only become
+/// visible after reading the bank's own event graph.
+#[derive(Clone, Debug)]
+pub enum CeMediaLocation {
+    /// A loose `.wem` under the Wwise mount, e.g. `Media/43/43030714.wem`.
+    Loose(String),
+    /// Embedded in a SoundBank's `DATA` chunk, e.g. `772982525.bnk`, keyed by
+    /// [`CeSoundMedia::media_id`].
+    Bank(String),
+}
+
 /// One playable permutation resolved from a CE sound tag.
 #[derive(Clone, Debug)]
 pub struct CeSoundMedia {
@@ -50,18 +67,30 @@ pub struct CeSoundMedia {
     pub event_name: String,
     /// Wwise language: `SFX` for non-localized, else e.g. `English(US)`.
     pub language: String,
-    /// Wwise short id (also the file stem).
+    /// Wwise short id (also the file stem, and the key into a bank's media).
     pub media_id: u32,
-    /// Path within the pak set's Wwise mount, e.g. `Media/43/43030714.wem`.
-    pub media_path: String,
-    /// Authoring `.wav` name — the closest thing to a permutation name.
+    /// Where the bytes live within the pak set's Wwise mount.
+    pub location: CeMediaLocation,
+    /// Authoring `.wav` name — the closest thing to a permutation name. Empty
+    /// for bank-embedded media, which carries no debug name.
     pub source_name: String,
 }
 
 impl CeSoundMedia {
-    /// Path to look up in the pak set.
+    /// Path to look up in the pak set — the `.wem` itself, or the bank holding it.
     pub fn mounted_path(&self) -> String {
-        format!("{WWISE_MOUNT}/{}", self.media_path)
+        let rel = match &self.location {
+            CeMediaLocation::Loose(path) | CeMediaLocation::Bank(path) => path,
+        };
+        format!("{WWISE_MOUNT}/{rel}")
+    }
+
+    /// Where the audio comes from, for the player's provenance column.
+    pub fn location_label(&self) -> String {
+        match &self.location {
+            CeMediaLocation::Loose(path) => path.clone(),
+            CeMediaLocation::Bank(bank) => format!("{bank} \u{2192} {}", self.media_id),
+        }
     }
 
     /// Short label for the UI: the source `.wav` stem when known, else the id.
@@ -164,11 +193,29 @@ fn read_package(
     Some((header, bytes))
 }
 
-/// Whether a package name is one of the two Wwise event roots. SFX events live
-/// under `/Game/Wwise/Events`, systemic voice under `/Game/WwiseAudio/Events`;
-/// missing the second silently resolves nothing for all dialogue.
-fn is_event_package(lower: &str) -> bool {
-    lower.starts_with("/game/wwise/events/") || lower.starts_with("/game/wwiseaudio/events/")
+/// Whether a package is a Wwise event, decided by the class it exports rather
+/// than where it sits.
+///
+/// Path prefixes do not work: events are spread over at least three roots
+/// (`/Game/Wwise/Events`, `/Game/WwiseAudio/Events`, and `/Game/Audio/Audio_FI/…`
+/// mixed in among the `BlamAudioSound` assets), and each root missed silently
+/// unbinds every tag that reaches through it. The export class is the thing
+/// that actually defines an event.
+fn exports_ak_audio_event(header: &FZenPackageHeader) -> bool {
+    header.exports_class(FPackageObjectIndex::create_script_import(AK_AUDIO_EVENT_CLASS))
+}
+
+/// The native `AkAudioEvent` UClass, as it appears in a cooked package's
+/// `class_index` (a `ScriptImport` hash of this path).
+const AK_AUDIO_EVENT_CLASS: &str = "/Script/AkAudio.AkAudioEvent";
+
+/// Whether a package is worth walking into while looking for events. The audio
+/// graph is confined to these roots; without a bound the walk would wander the
+/// whole cooked package graph.
+fn is_audio_package(lower: &str) -> bool {
+    lower.starts_with("/game/audio/")
+        || lower.starts_with("/game/wwise/")
+        || lower.starts_with("/game/wwiseaudio/")
 }
 
 /// Walk package imports from a CE sound tag to the Wwise media it plays.
@@ -176,16 +223,22 @@ fn is_event_package(lower: &str) -> bool {
 /// `tag_package` is the tag's cooked package name (`/Game/Tags/sound/...`).
 /// Returns an empty binding for the many `sound` tags that are unbound stubs
 /// with no imports at all — that is a normal state, not an error.
+///
+/// `banks` gives access to the pak set, needed only for events whose media is
+/// cooked *inside* a SoundBank: those name no media in the package at all, so
+/// the permutations have to be read out of the bank's own event graph. Pass
+/// `None` to resolve package-staged media only.
 pub fn resolve_sound_binding(
     containers: &[MountedContainer],
     packages: &ContainerPackageIndex,
     usmap: &Usmap,
     tag_package: &str,
+    banks: Option<(&Path, &mut CeMediaStore)>,
 ) -> CeSoundBinding {
     let mut binding = CeSoundBinding::default();
     let mut seen: BTreeSet<String> = BTreeSet::new();
     let mut queue: VecDeque<String> = VecDeque::new();
-    let mut event_packages: Vec<String> = Vec::new();
+    let mut event_packages: Vec<(FZenPackageHeader, Vec<u8>)> = Vec::new();
 
     seen.insert(tag_package.to_ascii_lowercase());
     queue.push_back(tag_package.to_string());
@@ -196,23 +249,30 @@ pub fn resolve_sound_binding(
         if visits > MAX_PACKAGE_VISITS {
             break;
         }
-        let Some((header, _)) = read_package(containers, packages, &package) else { continue };
+        let Some((header, bytes)) = read_package(containers, packages, &package) else { continue };
+        // An event is a leaf: it holds the media, and nothing further to walk.
+        if exports_ak_audio_event(&header) {
+            event_packages.push((header, bytes));
+            continue;
+        }
         for import in &header.imported_package_names {
             let lower = import.to_ascii_lowercase();
             if !seen.insert(lower.clone()) {
                 continue;
             }
-            if is_event_package(&lower) {
-                event_packages.push(import.clone());
-            } else if lower.starts_with("/game/audio/") {
+            if is_audio_package(&lower) {
                 queue.push_back(import.clone());
             }
         }
     }
 
-    for package in &event_packages {
-        let Some((header, bytes)) = read_package(containers, packages, package) else { continue };
-        let Some(export) = header.export_map.first() else { continue };
+    let mut banks = banks;
+    for (header, bytes) in &event_packages {
+        let Some(export) = header
+            .find_export_of_class(FPackageObjectIndex::create_script_import(AK_AUDIO_EVENT_CLASS))
+        else {
+            continue;
+        };
         let start = header.summary.header_size as usize + export.cooked_serial_offset as usize;
         let end = start + export.cooked_serial_size as usize;
         let Some(body) = bytes.get(start..end) else { continue };
@@ -224,13 +284,65 @@ pub fn resolve_sound_binding(
                 event_name: cooked.event_name.clone(),
                 language: m.language.clone(),
                 media_id: m.media_id,
-                media_path: m.path.clone(),
+                location: CeMediaLocation::Loose(m.path.clone()),
                 source_name: m.source_name.clone(),
             });
+        }
+        // Media-less event: the audio is inside the banks it lists, reachable
+        // only through their event graph.
+        if cooked.media.is_empty()
+            && let Some((paks_root, store)) = banks.as_mut()
+        {
+            binding.media.extend(bank_embedded_media(paks_root, store, &cooked));
         }
         binding.events.push(cooked);
     }
     binding
+}
+
+/// Resolve an event whose media lives inside its SoundBanks: read each bank,
+/// ask its event graph what `Play_…` triggers, and turn every source id into a
+/// permutation. Streamed sources still resolve to a loose `.wem` when the pak
+/// set actually stages one.
+fn bank_embedded_media(
+    paks_root: &Path,
+    store: &mut CeMediaStore,
+    event: &EventCookedData,
+) -> Vec<CeSoundMedia> {
+    let mut out = Vec::new();
+    let mut seen: BTreeSet<(String, u32)> = BTreeSet::new();
+    for bank in &event.banks {
+        let Ok(sources) = store.bank_event_sources(paks_root, &bank.path, event.event_id) else {
+            continue;
+        };
+        for source in sources {
+            if !seen.insert((bank.language.clone(), source.source_id)) {
+                continue;
+            }
+            let loose = loose_media_path(source.source_id);
+            let location = if source.streamed && store.has_media(paks_root, &loose) {
+                CeMediaLocation::Loose(loose)
+            } else {
+                CeMediaLocation::Bank(bank.path.clone())
+            };
+            out.push(CeSoundMedia {
+                event_name: event.event_name.clone(),
+                language: bank.language.clone(),
+                media_id: source.source_id,
+                location,
+                source_name: String::new(),
+            });
+        }
+    }
+    out
+}
+
+/// Where a streamed `.wem` is staged: `Media/<first two digits of id>/<id>.wem`,
+/// the layout the cooked media paths use.
+fn loose_media_path(media_id: u32) -> String {
+    let id = media_id.to_string();
+    let bucket = &id[..id.len().min(2)];
+    format!("Media/{bucket}/{id}.wem")
 }
 
 /// The legacy `.pak` set holding Wwise media, opened lazily.
@@ -245,6 +357,10 @@ pub struct CeMediaStore {
     /// second Campaign Evolved install reused the first one's containers and
     /// played its audio, or reported the media missing.
     paks: Option<(PathBuf, PakSet)>,
+    /// Parsed event graph per bank path, keyed within the open pak set. Banks
+    /// are shared by hundreds of tags (one per character, weapon, level), so
+    /// re-parsing per tag would dominate the panel's frame cost.
+    hirc: HashMap<String, Arc<HircIndex>>,
 }
 
 impl CeMediaStore {
@@ -258,8 +374,47 @@ impl CeMediaStore {
                 return Err(anyhow!("no readable .pak containers in {}", paks_root.display()));
             }
             self.paks = Some((paks_root.to_path_buf(), set));
+            self.hirc.clear(); // the cache is only valid for the open set
         }
         Ok(&mut self.paks.as_mut().expect("just populated").1)
+    }
+
+    /// Whether the pak set stages a file at this Wwise-mount-relative path.
+    fn has_media(&mut self, paks_root: &Path, rel_path: &str) -> bool {
+        let path = format!("{WWISE_MOUNT}/{rel_path}");
+        self.paks(paks_root).is_ok_and(|set| set.contains(&path))
+    }
+
+    /// The media sources one event triggers, according to a bank's own event
+    /// graph. Used for events whose cooked data names banks but no media.
+    fn bank_event_sources(
+        &mut self,
+        paks_root: &Path,
+        bank_path: &str,
+        event_id: u32,
+    ) -> Result<Vec<SoundSource>> {
+        if let Some(index) = self.hirc.get(bank_path) {
+            return Ok(index.resolve_event_id(event_id));
+        }
+        let bnk = self.read_bank(paks_root, bank_path)?;
+        let mut index = HircIndex::new();
+        if let Some(hirc) = bnk.hirc_bytes() {
+            index.add_hirc(hirc, bnk.version);
+        }
+        index.finalize();
+        let index = Arc::new(index);
+        self.hirc.insert(bank_path.to_owned(), index.clone());
+        Ok(index.resolve_event_id(event_id))
+    }
+
+    /// Read and parse one SoundBank out of the pak set.
+    fn read_bank(&mut self, paks_root: &Path, bank_path: &str) -> Result<Bnk> {
+        let path = format!("{WWISE_MOUNT}/{bank_path}");
+        let bytes = self
+            .paks(paks_root)?
+            .read(&path)
+            .with_context(|| format!("reading {path} from the pak set"))?;
+        Bnk::parse(bytes).map_err(|e| anyhow!("parsing {path}: {e}"))
     }
 
     /// Fetch and decode one media entry to PCM.
@@ -268,13 +423,24 @@ impl CeMediaStore {
         paks_root: &Path,
         media: &CeSoundMedia,
     ) -> Result<blam_tags::audio::DecodedPcm> {
-        let path = media.mounted_path();
-        let bytes = self
-            .paks(paks_root)?
-            .read(&path)
-            .with_context(|| format!("reading {path} from the pak set"))?;
+        let bytes = match &media.location {
+            CeMediaLocation::Loose(_) => {
+                let path = media.mounted_path();
+                self.paks(paks_root)?
+                    .read(&path)
+                    .with_context(|| format!("reading {path} from the pak set"))?
+            }
+            CeMediaLocation::Bank(bank_path) => {
+                let bnk = self.read_bank(paks_root, bank_path)?;
+                bnk.embedded_wem(media.media_id)
+                    .ok_or_else(|| {
+                        anyhow!("{} holds no media {}", bank_path, media.media_id)
+                    })?
+                    .to_vec()
+            }
+        };
         blam_tags::audio::wwise::decode_wem(&bytes)
-            .map_err(|e| anyhow!("decoding {path}: {e}"))
+            .map_err(|e| anyhow!("decoding {}: {e}", media.location_label()))
     }
 }
 
@@ -288,7 +454,7 @@ mod tests {
             event_name: "Play_X".into(),
             language: "SFX".into(),
             media_id: 43030714,
-            media_path: "Media/43/43030714.wem".into(),
+            location: CeMediaLocation::Loose("Media/43/43030714.wem".into()),
             source_name: String::new(),
         };
         assert_eq!(m.mounted_path(), "Meteorite/Content/WwiseAudio/Media/43/43030714.wem");
@@ -302,7 +468,7 @@ mod tests {
             event_name: "Play_X".into(),
             language: "SFX".into(),
             media_id: 1,
-            media_path: "Media/1/1.wem".into(),
+            location: CeMediaLocation::Loose("Media/1/1.wem".into()),
             source_name: r"000_Olympus\006_Character\Foo_AR_ReloadMagHit_02.wav".into(),
         };
         assert_eq!(m.display_name(), "Foo_AR_ReloadMagHit_02");
@@ -314,7 +480,7 @@ mod tests {
             event_name: "Play_X".into(),
             language: "SFX".into(),
             media_id: 1,
-            media_path: "Media/1/1.wem".into(),
+            location: CeMediaLocation::Loose("Media/1/1.wem".into()),
             source_name: String::new(),
         };
         let binding = CeSoundBinding { events: Vec::new(), media: vec![sfx] };
@@ -329,7 +495,7 @@ mod tests {
             event_name: "Play_X".into(),
             language: language.into(),
             media_id: id,
-            media_path: format!("Media/{language}/{id}.wem"),
+            location: CeMediaLocation::Loose(format!("Media/{language}/{id}.wem")),
             source_name: String::new(),
         }
     }
@@ -370,11 +536,15 @@ mod tests {
         assert_eq!(binding.media_for_language("German").len(), 1);
     }
 
+    /// Every root the audio graph reaches through has to stay walkable. Events
+    /// themselves are found by class, but the walk still needs to *get* to them.
     #[test]
-    fn both_event_roots_are_recognized() {
-        assert!(is_event_package("/game/wwise/events/play_foo"));
-        assert!(is_event_package("/game/wwiseaudio/events/systemic/vo/play_bar"));
-        assert!(!is_event_package("/game/audio/systemic/vo_thing"));
+    fn every_audio_root_is_walkable() {
+        assert!(is_audio_package("/game/audio/characters/elite/shield_pop_elite"));
+        assert!(is_audio_package("/game/audio/audio_fi/character/elites/shield/play_x"));
+        assert!(is_audio_package("/game/wwise/events/play_foo"));
+        assert!(is_audio_package("/game/wwiseaudio/events/systemic/vo/play_bar"));
+        assert!(!is_audio_package("/game/tags/sound/x-sound"));
     }
 
     /// End-to-end against a real Campaign Evolved install: mount the
@@ -446,8 +616,8 @@ mod tests {
         let usmap = Usmap::meteorite().expect("bundled usmap");
         let mut store = CeMediaStore::default();
 
-        // A non-localized SFX tag and a localized dialogue tag: the two shapes
-        // that reach different event roots.
+        // One tag per shape the resolution has to handle. Each was silent at
+        // some point because the walk assumed the previous one's shape.
         let cases = [
             "/Game/Tags/sound/005_sandbox/006_character/006_character_movement/\
              006_chm_ge_weaanim/006_chm_ge_weaanim_ar_reloadmaghit-sound",
@@ -455,11 +625,23 @@ mod tests {
             // Scripted mission dialogue — the shape that rendered an empty
             // player because it carries no SFX entry.
             "/Game/Tags/sound/scripted/vo_scr_m02halo/m02_00040_cortana-sound",
+            // Its event sits under `/Game/Audio/Audio_FI/…` rather than either
+            // `Events` root, so a path-prefix test never finds it.
+            "/Game/Tags/sound/characters/elite/shield_pop_elite-sound",
+            // Media cooked inside a SoundBank: the event names banks and no
+            // media, so the permutations come from the bank's own event graph.
+            "/Game/Tags/sound/characters/bodyfalls/brute_bodyfalls/brute_bodyfall_dirt-sound",
         ];
 
         for tag in cases {
             let tag = tag.replace(char::is_whitespace, "");
-            let binding = resolve_sound_binding(&containers, &packages, &usmap, &tag);
+            let binding = resolve_sound_binding(
+                &containers,
+                &packages,
+                &usmap,
+                &tag,
+                Some((root.as_path(), &mut store)),
+            );
             assert!(!binding.is_empty(), "no media resolved for {tag}");
             println!(
                 "{tag}\n  events={} media={} languages={:?}",
@@ -491,17 +673,92 @@ mod tests {
             // And the media has to actually decode to non-silent audio.
             for m in binding.media_for_language(&shown) {
                 let pcm = store.decode(&root, m).expect("decode media");
-                assert!(!pcm.samples.is_empty(), "{} decoded to nothing", m.media_path);
+                assert!(!pcm.samples.is_empty(), "{} decoded to nothing", m.location_label());
                 let peak = pcm.samples.iter().map(|s| s.unsigned_abs()).max().unwrap_or(0);
-                assert!(peak > 0, "{} decoded to silence", m.media_path);
+                assert!(peak > 0, "{} decoded to silence", m.location_label());
                 println!(
-                    "  {} [{}] {} ch {} Hz peak {peak}",
+                    "  {} [{}] {} ch {} Hz peak {peak}  ({})",
                     m.display_name(),
                     m.language,
                     pcm.channels,
-                    pcm.sample_rate
+                    pcm.sample_rate,
+                    m.location_label()
                 );
             }
         }
+    }
+
+    /// Coverage over every mounted sound tag. Most of the game's audio was
+    /// invisible to three separate assumptions in turn (one event root, one
+    /// package layout, one bank version), each of which failed silently — so
+    /// the guard is a floor on how much of the game resolves, not a spot check.
+    ///
+    /// Run with:
+    ///   CE_PAKS=/path/to/Meteorite/Content/Paks cargo test ce_audio -- --ignored --nocapture
+    #[test]
+    #[ignore = "requires a Campaign Evolved install; set CE_PAKS"]
+    fn most_sound_tags_resolve_to_media() {
+        use blam_tags::iostore::IoStoreArchive;
+        use std::path::PathBuf;
+        use std::sync::Arc;
+
+        let root =
+            PathBuf::from(std::env::var("CE_PAKS").expect("set CE_PAKS to the game's Content/Paks"));
+        let mut utocs: Vec<PathBuf> = std::fs::read_dir(&root)
+            .expect("read paks dir")
+            .filter_map(|e| e.ok().map(|e| e.path()))
+            .filter(|p| p.extension().is_some_and(|x| x.eq_ignore_ascii_case("utoc")))
+            .filter(|p| !p.file_name().is_some_and(|n| n.eq_ignore_ascii_case("global.utoc")))
+            .collect();
+        utocs.sort();
+
+        let mut containers = Vec::new();
+        let mut packages = ContainerPackageIndex::default();
+        let mut tag_packages: Vec<String> = Vec::new();
+        for utoc in utocs {
+            let Ok(archive) = IoStoreArchive::open(&utoc) else { continue };
+            let idx = containers.len();
+            for e in archive.entries() {
+                if let Some(pkg) = super::super::container_package_name(&e.path) {
+                    packages.insert(pkg, idx, e.path.clone());
+                }
+            }
+            for e in archive.ublock_entries() {
+                if e.path.to_ascii_lowercase().ends_with("-sound.ubulk")
+                    && let Some(pkg) = tag_package_for_rel_path(&e.path)
+                {
+                    tag_packages.push(pkg);
+                }
+            }
+            containers.push(MountedContainer {
+                utoc_path: utoc.clone(),
+                chunk_label: utoc.file_stem().unwrap().to_string_lossy().into_owned(),
+                archive: Arc::new(archive),
+            });
+        }
+        tag_packages.sort();
+        tag_packages.dedup();
+
+        let usmap = Usmap::meteorite().expect("bundled usmap");
+        let mut store = CeMediaStore::default();
+        let mut bound = 0usize;
+        let mut from_banks = 0usize;
+        for pkg in &tag_packages {
+            let binding =
+                resolve_sound_binding(&containers, &packages, &usmap, pkg, Some((root.as_path(), &mut store)));
+            if binding.is_empty() {
+                continue;
+            }
+            bound += 1;
+            if binding.media.iter().any(|m| matches!(m.location, CeMediaLocation::Bank(_))) {
+                from_banks += 1;
+            }
+        }
+        let total = tag_packages.len();
+        println!("{bound}/{total} sound tags resolved media ({from_banks} out of SoundBanks)");
+        // Measured 5332/5895 on the 2026.06.26 build; the rest are stubs with
+        // no audio asset behind them at all.
+        assert!(bound * 100 / total >= 88, "only {bound}/{total} sound tags resolved");
+        assert!(from_banks > 400, "bank-embedded media stopped resolving ({from_banks})");
     }
 }

--- a/src/source/loading.rs
+++ b/src/source/loading.rs
@@ -183,6 +183,22 @@ pub fn load_iostore_container(
     build_container_set(root, vec![utoc], fallback_names, definitions_root)
 }
 
+/// Sibling `.utoc`s in `root` that aren't already mounted, opened purely so an
+/// index-less container's chunk ids can be resolved back to paths. Only ones
+/// that carry a directory index are any use as a reference.
+fn sibling_reference_archives(root: &Path, mounted: &[PathBuf]) -> Vec<IoStoreArchive> {
+    let Ok(dir) = std::fs::read_dir(root) else {
+        return Vec::new();
+    };
+    dir.filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.extension().is_some_and(|x| x.eq_ignore_ascii_case("utoc")))
+        .filter(|p| !p.file_name().is_some_and(|n| n.eq_ignore_ascii_case("global.utoc")))
+        .filter(|p| !mounted.contains(p))
+        .filter_map(|p| IoStoreArchive::open(&p).ok())
+        .filter(|archive| !archive.entries().is_empty())
+        .collect()
+}
+
 fn build_container_set(
     root: PathBuf,
     utocs: Vec<PathBuf>,
@@ -202,12 +218,47 @@ fn build_container_set(
     let mut packages = ContainerPackageIndex::default();
     let mut opened_any = false;
 
+    // Open every container up front. A mod/override container addresses its
+    // chunks by id and so ships with no directory index at all; naming its
+    // contents needs the containers it overrides as reference, which may not
+    // have been opened yet at its turn in the list.
+    let mut opened: Vec<(PathBuf, Option<IoStoreArchive>)> = Vec::new();
     for utoc in utocs {
-        let archive = match IoStoreArchive::open(&utoc) {
-            Ok(a) => a,
-            // Skip containers we can't parse (e.g. index-less globals).
-            Err(_) => continue,
-        };
+        // Skip containers we can't parse (e.g. index-less globals).
+        if let Ok(archive) = IoStoreArchive::open(&utoc) {
+            opened.push((utoc, Some(archive)));
+        }
+    }
+    let needs_recovery = |slot: &Option<IoStoreArchive>| {
+        matches!(slot, Some(archive) if archive.entries().is_empty())
+    };
+    // Naming an index-less container's chunks means resolving their ids against
+    // the containers it overrides. On the "open one chunk" path — a mod sitting
+    // in the game's own Paks folder — those aren't in the set, so pull the
+    // siblings in as references. They name chunks and contribute no tags.
+    let references: Vec<IoStoreArchive> = if opened.iter().any(|(_, a)| needs_recovery(a)) {
+        let mounted: Vec<PathBuf> = opened.iter().map(|(p, _)| p.clone()).collect();
+        sibling_reference_archives(&root, &mounted)
+    } else {
+        Vec::new()
+    };
+    for i in 0..opened.len() {
+        if !needs_recovery(&opened[i].1) {
+            continue;
+        }
+        // Lift the target out so the rest can be borrowed as its references.
+        let Some(mut archive) = opened[i].1.take() else { continue };
+        let bases: Vec<&IoStoreArchive> = opened
+            .iter()
+            .filter_map(|(_, a)| a.as_ref())
+            .chain(references.iter())
+            .collect();
+        archive.recover_entries(&bases, None);
+        opened[i].1 = Some(archive);
+    }
+
+    for (utoc, archive) in opened {
+        let Some(archive) = archive else { continue };
         opened_any = true;
         let chunk_label = utoc
             .file_stem()
@@ -893,6 +944,76 @@ mod mod_export_tests {
         assert_ne!(served, original, "the exported container carried the base bytes");
         eprintln!("override verified for {rel_path} ({} bytes)", served.len());
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// An exported mod opens EMPTY in the browser: an override container is
+    /// addressed by chunk id and ships with no directory index, so the file list
+    /// it advertises is nothing at all. Assert on what the tag browser actually
+    /// derives — the mounted entries — not on the raw chunks, which were already
+    /// fine while the UI showed an empty tree.
+    #[test]
+    fn a_mod_container_lists_its_tags_when_opened_on_its_own() {
+        if !Path::new(PAKS).exists() {
+            eprintln!("skipping: {PAKS} not present");
+            return;
+        }
+        let defs = Path::new(env!("CARGO_MANIFEST_DIR")).join("definitions");
+        let names = TagNameIndex::load_from_definitions(&defs);
+        let loaded =
+            load_iostore_container_set(PathBuf::from(PAKS), &names, &defs).expect("mount");
+        let TagSource::IoStoreContainerSet { ref containers, .. } = loaded.source else {
+            panic!("expected a container set");
+        };
+        let (container, rel_path, original) = loaded
+            .entries
+            .iter()
+            .find_map(|entry| match &entry.location {
+                TagEntryLocation::Container { container, rel_path } => {
+                    let archive = &containers.get(*container)?.archive;
+                    let bytes = archive.read(rel_path).ok()?;
+                    (bytes.len() > 64).then(|| (*container, rel_path.clone(), bytes))
+                }
+                _ => None,
+            })
+            .expect("a readable container tag");
+
+        let mut edited = original.clone();
+        let last = edited.len() - 1;
+        edited[last] ^= 0xFF;
+
+        // Write the mod into the game's own Paks folder, which is where mods
+        // live and therefore where they get opened from.
+        let out = PathBuf::from(PAKS).join(format!("baboon-listing-test-{}_P.utoc", std::process::id()));
+        let archive = containers[container].archive.clone();
+        blam_tags::iostore::writer::write_mod_container_ex(
+            &[(archive.as_ref(), rel_path.as_str(), edited.as_slice())],
+            &[],
+            &out,
+        )
+        .expect("write override container");
+
+        let opened = load_iostore_container(out.clone(), &names, &defs);
+        for ext in ["utoc", "ucas", "pak"] {
+            let _ = std::fs::remove_file(out.with_extension(ext));
+        }
+        let opened = opened.expect("mount the exported mod on its own");
+
+        assert!(
+            !opened.entries.is_empty(),
+            "opening a mod container listed no tags at all"
+        );
+        let listed = opened
+            .entries
+            .iter()
+            .any(|entry| match &entry.location {
+                TagEntryLocation::Container { rel_path: p, .. } => *p == rel_path,
+                _ => false,
+            });
+        assert!(listed, "the overridden tag {rel_path} was not listed");
+        eprintln!(
+            "mod container listed {} tag(s); found {rel_path}",
+            opened.entries.len()
+        );
     }
 }
 


### PR DESCRIPTION
Two related fixes on the Campaign Evolved container path, plus the engine bump that carries them.

## Play the sounds a tag only refers to

A `sound_looping` track or a dialogue vocalization is a tag *reference*, not inline sample data. On a loose folder the player loads the referenced tag and reads its samples on the spot. A Campaign Evolved tag has no samples — the audio is reached by walking that tag's own package imports out to Wwise, which needs the kit's containers and so can't happen inside the field renderer.

The click is now recorded as a request and resolved after the frame, stamped with the kit that raised it rather than whichever kit happens to be active by the time the queue drains. Resolution runs before the play and extract drains, since it queues into them.

This also reaches media embedded in a SoundBank rather than staged loose in a pak.

## List a mod container's tags

A mod `.utoc` addresses its chunks by `FIoChunkId` and ships with `directory index size = 0`, and `entries()` is built from that index — so opening one on its own listed **zero tags**, even though every chunk was present and read back correctly.

Writing a directory index would be the wrong fix: UE gates the index parse on size > 0 and resolves bulk/package chunks by id, never by path, so emitting one switches on a parse path the engine currently skips — and a malformed tree fails container init outright, which means the mod silently stops loading. retoc writes nothing here either. The fix is reader-side: recover the entry list from the chunk ids after mounting, using the other mounted containers as naming references.

## Engine

Bumps blam-tags to `cb0e6a1` (mod-container entry recovery, HIRC-embedded Wwise media) and drops the local dev patch so the build resolves from the pushed rev.

## Testing

`cargo test` green on the rebased tree: 367 passed, 0 failed. Includes `a_mod_container_lists_its_tags_when_opened_on_its_own` covering the listing fix.
