### PR TITLE
Choose between stable releases and development builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,7 +405,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "baboon"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "blam-tags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ default-members = ["."]
 
 [package]
 name = "baboon"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 build = "build.rs"
 default-run = "Baboon"

--- a/build.rs
+++ b/build.rs
@@ -5,6 +5,7 @@ use std::env;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 const RT_ICON: u16 = 3;
 const RT_GROUP_ICON: u16 = 14;
@@ -30,6 +31,7 @@ fn main() {
 
     copy_definitions_for_build().expect("copy blam-tags definitions");
     copy_docs_for_build().expect("copy Baboon docs");
+    emit_build_commit();
 
     if env::var_os("CARGO_CFG_WINDOWS").is_none() {
         return;
@@ -42,6 +44,58 @@ fn main() {
 
     write_icon_resource(&ico_path, &res_path).expect("write Baboon icon resource");
     println!("cargo:rustc-link-arg-bin=Baboon={}", res_path.display());
+}
+
+/// Bakes the commit this binary was built from into `BABOON_BUILD_COMMIT`.
+///
+/// The rolling development release is republished under the same `dev` tag on
+/// every push, so its tag says nothing about which build it is — the commit is
+/// the only identity it has. Comparing that against this value is how the
+/// development update channel decides whether the running build is current.
+///
+/// A working tree with uncommitted changes gets a `-dirty` suffix, which marks
+/// the build as local and unmanaged. Git being absent is not an error: the
+/// value is left empty and the channel reports the local commit as unknown.
+fn emit_build_commit() {
+    let manifest_dir = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
+    let commit = git_output(&manifest_dir, &["rev-parse", "HEAD"]).unwrap_or_default();
+    let commit = if commit.is_empty() {
+        String::new()
+    } else if git_output(&manifest_dir, &["status", "--porcelain"]).is_some_and(|s| !s.is_empty()) {
+        format!("{commit}-dirty")
+    } else {
+        commit
+    };
+    println!("cargo:rustc-env=BABOON_BUILD_COMMIT={commit}");
+
+    // Watch the files that change when HEAD moves. Only existing paths are
+    // listed: naming a missing file makes Cargo rebuild on every invocation,
+    // and a ref living in `packed-refs` has no file of its own.
+    let Some(git_dir) = git_output(&manifest_dir, &["rev-parse", "--absolute-git-dir"]) else {
+        return;
+    };
+    let git_dir = PathBuf::from(git_dir);
+    let mut watched = vec![git_dir.join("HEAD"), git_dir.join("packed-refs")];
+    if let Some(head_ref) = git_output(&manifest_dir, &["symbolic-ref", "--quiet", "HEAD"]) {
+        watched.push(git_dir.join(head_ref));
+    }
+    for path in watched.iter().filter(|path| path.is_file()) {
+        println!("cargo:rerun-if-changed={}", path.display());
+    }
+}
+
+/// Runs `git` in `dir` and returns its trimmed stdout, or `None` when git is
+/// missing, the directory is not a repository, or the command failed.
+fn git_output(dir: &Path, args: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .current_dir(dir)
+        .args(args)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).trim().to_owned())
 }
 
 fn copy_definitions_for_build() -> io::Result<()> {

--- a/src/app.rs
+++ b/src/app.rs
@@ -47,9 +47,20 @@ use crate::source::{
 };
 
 pub(super) const BABOON_GITHUB_URL: &str = "https://github.com/Zoephie/Baboon";
-pub(super) const BABOON_LATEST_RELEASE_API: &str =
+/// The newest `v*` release. GitHub never returns a prerelease here, so this
+/// endpoint is the stable channel by definition.
+pub(super) const BABOON_STABLE_RELEASE_API: &str =
     "https://api.github.com/repos/Zoephie/Baboon/releases/latest";
+/// The rolling development build. `release.yml` deletes and recreates this
+/// prerelease on every push to `main`, always under the same `dev` tag.
+pub(super) const BABOON_DEV_RELEASE_API: &str =
+    "https://api.github.com/repos/Zoephie/Baboon/releases/tags/dev";
 pub(super) const BABOON_RELEASES_URL: &str = "https://github.com/Zoephie/Baboon/releases";
+
+/// The commit this binary was built from, baked in by `build.rs`. Empty when
+/// the build happened outside a git checkout; suffixed `-dirty` when the
+/// working tree had uncommitted changes.
+pub(super) const BABOON_BUILD_COMMIT: &str = env!("BABOON_BUILD_COMMIT");
 
 mod game_assets;
 use game_assets::*;
@@ -162,6 +173,17 @@ pub struct Baboon {
     /// Persisted policy controlling whether prior windows are restored, asked
     /// about, or deliberately ignored at startup.
     session_restore: SessionRestore,
+    /// Which build track update checks look at — stable releases or the
+    /// rolling development build.
+    update_channel: UpdateChannel,
+    check_updates_on_startup: bool,
+    /// The most recent check's result, kept only while it is actually an
+    /// update. The status line expires on a timer, so this is what keeps the
+    /// news reachable after a silent startup check.
+    available_update: Option<UpdateCheckResult>,
+    /// The most recent successful check, update or not, so Settings can report
+    /// the outcome after the status line has expired.
+    last_update_check: Option<UpdateCheckResult>,
     show_block_sizes: bool,
     scroll_to_cycle_dropdowns: bool,
     /// Warn before Save overwrites Campaign Evolved pak files in place.
@@ -379,6 +401,10 @@ impl Baboon {
             folders_before_tags: prefs.folders_before_tags,
             double_click_to_open_tags: prefs.double_click_to_open_tags,
             session_restore: prefs.session_restore,
+            update_channel: prefs.update_channel,
+            check_updates_on_startup: prefs.check_updates_on_startup,
+            available_update: None,
+            last_update_check: None,
             show_block_sizes: prefs.show_block_sizes,
             scroll_to_cycle_dropdowns: prefs.scroll_to_cycle_dropdowns,
             confirm_container_overwrite: prefs.confirm_container_overwrite,
@@ -518,6 +544,9 @@ impl Baboon {
         };
         if let Some(kits) = auto_restore_session {
             app.begin_last_session_restore(kits, cc.egui_ctx.clone());
+        }
+        if app.should_check_updates_on_startup() {
+            app.begin_check_for_updates(cc.egui_ctx.clone(), true);
         }
         app
     }

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -344,8 +344,8 @@ impl Baboon {
                 WorkerMessage::TerminalLine(line) => self.handle_terminal_line(line),
                 WorkerMessage::TerminalLogError(error) => self.handle_terminal_log_error(error),
                 WorkerMessage::TerminalDone { run_id } => self.handle_terminal_done(run_id),
-                WorkerMessage::UpdateCheckFinished(result) => {
-                    self.handle_update_check_finished(result)
+                WorkerMessage::UpdateCheckFinished { silent, result } => {
+                    self.handle_update_check_finished(silent, result)
                 }
                 WorkerMessage::FieldValueSearchFinished {
                     stamp,
@@ -1701,14 +1701,26 @@ impl Baboon {
     }
 
     /// Starts the non-blocking release lookup and returns its result through `WorkerMessage`.
-    pub(super) fn begin_check_for_updates(&mut self, ctx: egui::Context) {
-        self.status = "Checking for updates...".to_owned();
+    ///
+    /// A `silent` check announces neither its start nor an uneventful result —
+    /// that is the automatic startup check, which must not spend the status
+    /// line on "up to date" or on a failure the user never asked about.
+    pub(super) fn begin_check_for_updates(&mut self, ctx: egui::Context, silent: bool) {
+        if !silent {
+            self.status = "Checking for updates...".to_owned();
+        }
+        let channel = self.update_channel;
         let tx = self.tx.clone();
         thread::spawn(move || {
-            let result = fetch_latest_release();
-            let _ = tx.send(WorkerMessage::UpdateCheckFinished(result));
+            let result = fetch_latest_release(channel);
+            let _ = tx.send(WorkerMessage::UpdateCheckFinished { silent, result });
             ctx.request_repaint();
         });
+    }
+
+    /// Whether the automatic startup check should run.
+    pub(super) fn should_check_updates_on_startup(&self) -> bool {
+        self.check_updates_on_startup
     }
 
     pub(super) fn begin_terminal_command(&mut self, ctx: egui::Context) {
@@ -5236,6 +5248,8 @@ impl Baboon {
             folders_before_tags: self.folders_before_tags,
             double_click_to_open_tags: self.double_click_to_open_tags,
             session_restore: self.session_restore,
+            update_channel: self.update_channel,
+            check_updates_on_startup: self.check_updates_on_startup,
             show_block_sizes: self.show_block_sizes,
             scroll_to_cycle_dropdowns: self.scroll_to_cycle_dropdowns,
             confirm_container_overwrite: self.confirm_container_overwrite,

--- a/src/app/controller/updates.rs
+++ b/src/app/controller/updates.rs
@@ -5,34 +5,86 @@ use super::*;
 
 impl Baboon {
     /// Applies `WorkerMessage::UpdateCheckFinished` to the application status.
+    ///
+    /// A found update reports itself through the status bar's own notification,
+    /// so the status line never repeats it — but a check the user asked for
+    /// still has to clear the "Checking for updates..." it put there. Only news
+    /// that has nowhere else to go, like "up to date" or a failure, is written
+    /// here, and a `silent` startup check does not write even that.
     pub(super) fn handle_update_check_finished(
         &mut self,
+        silent: bool,
         result: Result<UpdateCheckResult, String>,
     ) -> bool {
-        self.status = match result {
-            Ok(result) => update_check_status(&result),
-            Err(error) if error == NO_PUBLIC_RELEASE_MESSAGE => error,
-            Err(error) => format!("Update check failed: {error}"),
-        };
+        match result {
+            Ok(result) => {
+                let outdated = is_update_available(&result);
+                if !silent {
+                    self.status = if outdated {
+                        String::new()
+                    } else {
+                        update_check_status(&result)
+                    };
+                }
+                self.available_update = outdated.then(|| result.clone());
+                self.last_update_check = Some(result);
+            }
+            Err(error) => {
+                self.available_update = None;
+                self.last_update_check = None;
+                if !silent {
+                    self.status = update_check_error_status(self.update_channel, &error);
+                }
+            }
+        }
         false
+    }
+
+    /// One sentence on where this build stands: the last check's verdict when
+    /// there has been one, otherwise a description of what is running.
+    pub(in crate::app) fn update_check_summary(&self) -> String {
+        match self.last_update_check.as_ref() {
+            Some(result) => update_check_status(result),
+            None => format!("This build: {}", running_build_description()),
+        }
     }
 }
 
-pub(super) fn fetch_latest_release() -> Result<UpdateCheckResult, String> {
+/// Names the running build the way the active channel identifies builds — by
+/// version, and by commit too once one is baked in.
+fn running_build_description() -> String {
+    let version = env!("CARGO_PKG_VERSION");
+    if BABOON_BUILD_COMMIT.is_empty() {
+        format!("Baboon {version}")
+    } else {
+        format!("Baboon {version} ({})", short_commit(BABOON_BUILD_COMMIT))
+    }
+}
+
+pub(super) fn fetch_latest_release(channel: UpdateChannel) -> Result<UpdateCheckResult, String> {
+    let api_url = match channel {
+        UpdateChannel::Stable => BABOON_STABLE_RELEASE_API,
+        UpdateChannel::Development => BABOON_DEV_RELEASE_API,
+    };
     #[cfg(target_os = "windows")]
     {
-        fetch_latest_release_powershell()
+        fetch_latest_release_powershell(channel, api_url)
     }
     #[cfg(not(target_os = "windows"))]
     {
-        fetch_latest_release_curl()
+        fetch_latest_release_curl(channel, api_url)
     }
 }
 
-pub(super) const NO_PUBLIC_RELEASE_MESSAGE: &str = "No public Baboon releases found yet";
+/// Sentinel returned by the fetchers when the channel's release does not exist
+/// (HTTP 404). The handler turns it into channel-specific wording.
+pub(super) const NO_PUBLIC_RELEASE_MESSAGE: &str = "__baboon_no_release__";
 
 #[cfg(target_os = "windows")]
-fn fetch_latest_release_powershell() -> Result<UpdateCheckResult, String> {
+fn fetch_latest_release_powershell(
+    channel: UpdateChannel,
+    api_url: &str,
+) -> Result<UpdateCheckResult, String> {
     use std::os::windows::process::CommandExt;
 
     const CREATE_NO_WINDOW: u32 = 0x0800_0000;
@@ -40,9 +92,10 @@ fn fetch_latest_release_powershell() -> Result<UpdateCheckResult, String> {
         "$ErrorActionPreference = 'Stop'; \
          $headers = @{{ 'User-Agent' = 'Baboon' }}; \
          try {{ \
-             $release = Invoke-RestMethod -UseBasicParsing -Headers $headers -Uri '{}'; \
+             $release = Invoke-RestMethod -UseBasicParsing -Headers $headers -Uri '{api_url}'; \
              [Console]::Out.WriteLine($release.tag_name); \
              [Console]::Out.WriteLine($release.html_url); \
+             [Console]::Out.WriteLine($release.target_commitish); \
          }} catch {{ \
              $statusCode = $null; \
              if ($_.Exception.Response -ne $null) {{ \
@@ -54,8 +107,7 @@ fn fetch_latest_release_powershell() -> Result<UpdateCheckResult, String> {
              }} \
              [Console]::Error.WriteLine($_.Exception.Message); \
              exit 1; \
-         }}",
-        BABOON_LATEST_RELEASE_API
+         }}"
     );
     let output = Command::new("powershell.exe")
         .creation_flags(CREATE_NO_WINDOW)
@@ -68,11 +120,19 @@ fn fetch_latest_release_powershell() -> Result<UpdateCheckResult, String> {
         ])
         .output()
         .map_err(|error| format!("Could not run PowerShell: {error}"))?;
-    parse_latest_release_lines(&output.stdout, &output.stderr, output.status.success())
+    parse_latest_release_lines(
+        channel,
+        &output.stdout,
+        &output.stderr,
+        output.status.success(),
+    )
 }
 
 #[cfg(not(target_os = "windows"))]
-fn fetch_latest_release_curl() -> Result<UpdateCheckResult, String> {
+fn fetch_latest_release_curl(
+    channel: UpdateChannel,
+    api_url: &str,
+) -> Result<UpdateCheckResult, String> {
     let output = Command::new("curl")
         .args([
             "-sSL",
@@ -80,7 +140,7 @@ fn fetch_latest_release_curl() -> Result<UpdateCheckResult, String> {
             "\n%{http_code}",
             "-H",
             "User-Agent: Baboon",
-            BABOON_LATEST_RELEASE_API,
+            api_url,
         ])
         .output()
         .map_err(|error| format!("Could not run curl: {error}"))?;
@@ -114,14 +174,23 @@ fn fetch_latest_release_curl() -> Result<UpdateCheckResult, String> {
         .filter(|url| !url.trim().is_empty())
         .unwrap_or(BABOON_RELEASES_URL)
         .to_owned();
+    let commit = value
+        .get("target_commitish")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .trim()
+        .to_owned();
     Ok(UpdateCheckResult {
+        channel,
         latest_tag,
         release_url,
+        commit,
     })
 }
 
 #[cfg(target_os = "windows")]
 fn parse_latest_release_lines(
+    channel: UpdateChannel,
     stdout: &[u8],
     stderr: &[u8],
     success: bool,
@@ -143,9 +212,12 @@ fn parse_latest_release_lines(
         .filter(|url| !url.is_empty())
         .unwrap_or(BABOON_RELEASES_URL)
         .to_owned();
+    let commit = lines.next().unwrap_or_default().to_owned();
     Ok(UpdateCheckResult {
+        channel,
         latest_tag,
         release_url,
+        commit,
     })
 }
 
@@ -158,15 +230,79 @@ fn command_error(stderr: &[u8]) -> String {
     }
 }
 
+/// Whether `result` describes a build newer than the running one.
+///
+/// The two channels answer this from different evidence. A stable release
+/// carries a version to compare against `CARGO_PKG_VERSION`. A development
+/// release is republished under the same `dev` tag every time, so its only
+/// identity is its commit — anything other than an exact match with the commit
+/// this binary was built from means a different build is on offer, including
+/// the case where our own commit is unknown.
+pub(super) fn is_update_available(result: &UpdateCheckResult) -> bool {
+    match result.channel {
+        UpdateChannel::Stable => is_newer_release(&result.latest_tag, env!("CARGO_PKG_VERSION")),
+        UpdateChannel::Development => !is_same_commit(BABOON_BUILD_COMMIT, &result.commit),
+    }
+}
+
+/// Whether two commit strings name the same build.
+///
+/// The `-dirty` marker is ignored: a working-tree build sitting on the same
+/// commit as the published one has nothing to download. Comparing it literally
+/// would instead announce an update on every single launch of every local
+/// build. An empty value is unknown, and unknown never counts as a match.
+fn is_same_commit(left: &str, right: &str) -> bool {
+    let left = base_commit(left);
+    let right = base_commit(right);
+    !left.is_empty() && !right.is_empty() && left.eq_ignore_ascii_case(right)
+}
+
+/// A commit without its working-tree marker.
+fn base_commit(commit: &str) -> &str {
+    commit.strip_suffix("-dirty").unwrap_or(commit)
+}
+
+/// Describes what a check found, in prose.
+///
+/// No release URL: wherever an available update is shown, it is shown as a
+/// link, and a bare URL in a sentence would only duplicate it.
 pub(super) fn update_check_status(result: &UpdateCheckResult) -> String {
     let current = env!("CARGO_PKG_VERSION");
-    if is_newer_release(&result.latest_tag, current) {
-        format!(
-            "Update available: {} (current {}). {}",
-            result.latest_tag, current, result.release_url
-        )
-    } else {
-        format!("Baboon is up to date ({current})")
+    match result.channel {
+        UpdateChannel::Stable => {
+            if is_update_available(result) {
+                format!(
+                    "Update available: {} (current {current})",
+                    result.latest_tag
+                )
+            } else {
+                format!("Baboon is up to date ({current})")
+            }
+        }
+        UpdateChannel::Development => {
+            let offered = short_commit(&result.commit);
+            if !is_update_available(result) {
+                return format!("Running the latest development build ({offered})");
+            }
+            let running = if BABOON_BUILD_COMMIT.is_empty() {
+                "this build's commit is unknown".to_owned()
+            } else {
+                format!("built from {}", short_commit(BABOON_BUILD_COMMIT))
+            };
+            format!("Development build available: {offered} (current {current}, {running})")
+        }
+    }
+}
+
+/// Turns a fetch failure into a sentence, giving the "no such release" sentinel
+/// wording that names the channel it came from.
+pub(super) fn update_check_error_status(channel: UpdateChannel, error: &str) -> String {
+    if error != NO_PUBLIC_RELEASE_MESSAGE {
+        return format!("Update check failed: {error}");
+    }
+    match channel {
+        UpdateChannel::Stable => "No public Baboon releases found yet".to_owned(),
+        UpdateChannel::Development => "No development builds have been published yet".to_owned(),
     }
 }
 
@@ -193,3 +329,7 @@ fn version_numbers(version: &str) -> Vec<u64> {
         .filter_map(|part| part.parse::<u64>().ok())
         .collect()
 }
+
+#[cfg(test)]
+#[path = "../tests/updates.rs"]
+mod tests;

--- a/src/app/prefs.rs
+++ b/src/app/prefs.rs
@@ -48,6 +48,10 @@ fn first_run_complete_from_text(text: Option<&str>) -> bool {
 #[path = "tests/prefs_first_run.rs"]
 mod first_run_tests;
 
+#[cfg(test)]
+#[path = "tests/prefs_update_channel.rs"]
+mod update_channel_tests;
+
 pub(super) fn load_gui_prefs() -> GuiPrefs {
     let Some(text) = read_prefs_text() else {
         return GuiPrefs::default();
@@ -55,10 +59,17 @@ pub(super) fn load_gui_prefs() -> GuiPrefs {
     let Ok(value) = serde_json::from_str::<Value>(&text) else {
         return GuiPrefs::default();
     };
-    let browser_mode =
-        browser_mode_from_str(value.get("browser_mode").and_then(Value::as_str)).unwrap_or_default();
-    let browser_sort =
-        browser_sort_from_str(value.get("browser_sort").and_then(Value::as_str)).unwrap_or_default();
+    prefs_from_value(&value)
+}
+
+/// Decodes stored preferences, falling back to the default for anything the
+/// file does not carry — which is how a file written before a preference
+/// existed keeps working.
+fn prefs_from_value(value: &Value) -> GuiPrefs {
+    let browser_mode = browser_mode_from_str(value.get("browser_mode").and_then(Value::as_str))
+        .unwrap_or_default();
+    let browser_sort = browser_sort_from_str(value.get("browser_sort").and_then(Value::as_str))
+        .unwrap_or_default();
     GuiPrefs {
         browser_mode,
         browser_sort,
@@ -92,6 +103,15 @@ pub(super) fn load_gui_prefs() -> GuiPrefs {
                     _ => SessionRestore::Ask,
                 }
             }),
+        update_channel: value
+            .get("update_channel")
+            .and_then(Value::as_str)
+            .and_then(UpdateChannel::from_str)
+            .unwrap_or_default(),
+        check_updates_on_startup: value
+            .get("check_updates_on_startup")
+            .and_then(Value::as_bool)
+            .unwrap_or(true),
         show_block_sizes: value
             .get("show_block_sizes")
             .and_then(Value::as_bool)
@@ -471,6 +491,20 @@ pub(super) fn save_gui_prefs(
         fs::create_dir_all(parent)
             .map_err(|error| format!("Could not create preferences folder: {error}"))?;
     }
+    let value = prefs_to_value(prefs, terminal_open_games, first_run_complete);
+    let text = serde_json::to_string_pretty(&value)
+        .map_err(|error| format!("Could not encode preferences: {error}"))?;
+    write_text_atomic(&path, &text)
+}
+
+/// Encodes preferences as the JSON stored in `prefs.json`.
+/// Split out from [`save_gui_prefs`] so the encoding can be exercised against
+/// [`prefs_from_value`] without touching the filesystem.
+fn prefs_to_value(
+    prefs: &GuiPrefs,
+    terminal_open_games: &HashSet<String>,
+    first_run_complete: bool,
+) -> Value {
     let mut games: Vec<&String> = terminal_open_games.iter().collect();
     games.sort();
     let mut collapsed_tool_categories: Vec<&String> =
@@ -485,7 +519,7 @@ pub(super) fn save_gui_prefs(
             }
         }
     }
-    let value = json!({
+    json!({
         "browser_mode": browser_mode_str(prefs.browser_mode),
         "browser_sort": browser_sort_str(prefs.browser_sort),
         "nested_default": nested_default_str(prefs.nested_default),
@@ -493,6 +527,8 @@ pub(super) fn save_gui_prefs(
         "folders_before_tags": prefs.folders_before_tags,
         "double_click_to_open_tags": prefs.double_click_to_open_tags,
         "session_restore": prefs.session_restore.as_str(),
+        "update_channel": prefs.update_channel.as_str(),
+        "check_updates_on_startup": prefs.check_updates_on_startup,
         "show_block_sizes": prefs.show_block_sizes,
         "scroll_to_cycle_dropdowns": prefs.scroll_to_cycle_dropdowns,
         "confirm_container_overwrite": prefs.confirm_container_overwrite,
@@ -527,10 +563,7 @@ pub(super) fn save_gui_prefs(
         "storage_mode": crate::storage::active_mode().map(crate::storage::StorageMode::as_str),
         "first_run_complete": first_run_complete,
         "terminal_open_games": games,
-    });
-    let text = serde_json::to_string_pretty(&value)
-        .map_err(|error| format!("Could not encode preferences: {error}"))?;
-    write_text_atomic(&path, &text)
+    })
 }
 
 fn write_text_atomic(path: &Path, text: &str) -> Result<(), String> {

--- a/src/app/state/prefs.rs
+++ b/src/app/state/prefs.rs
@@ -259,6 +259,59 @@ impl SessionRestore {
     }
 }
 
+/// Which build track Baboon checks against and points people at.
+///
+/// The two tracks are what `release.yml` publishes: `v*` tags, and a `dev`
+/// prerelease that is deleted and recreated on every push to `main`. Because
+/// the development release always carries the same tag, the two are compared
+/// against different things — a version number for [`UpdateChannel::Stable`],
+/// the build commit for [`UpdateChannel::Development`].
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub(in crate::app) enum UpdateChannel {
+    #[default]
+    Stable,
+    Development,
+}
+
+impl UpdateChannel {
+    pub(in crate::app) const ALL: [UpdateChannel; 2] =
+        [UpdateChannel::Stable, UpdateChannel::Development];
+
+    pub(in crate::app) fn as_str(self) -> &'static str {
+        match self {
+            UpdateChannel::Stable => "stable",
+            UpdateChannel::Development => "development",
+        }
+    }
+
+    pub(in crate::app) fn from_str(value: &str) -> Option<Self> {
+        match value {
+            "stable" => Some(UpdateChannel::Stable),
+            "development" => Some(UpdateChannel::Development),
+            _ => None,
+        }
+    }
+
+    pub(in crate::app) fn label(self) -> &'static str {
+        match self {
+            UpdateChannel::Stable => "Stable releases",
+            UpdateChannel::Development => "Development builds",
+        }
+    }
+
+    pub(in crate::app) fn help(self) -> &'static str {
+        match self {
+            UpdateChannel::Stable => {
+                "Only published, versioned releases — the tested build most people want"
+            }
+            UpdateChannel::Development => {
+                "The rolling build from the latest commit, rebuilt on every change — \
+                 newer features, less testing"
+            }
+        }
+    }
+}
+
 /// Memoized search results for the tag browser.
 ///
 /// Filtering the full tag set (100k+ entries) and lowercasing each name is far
@@ -281,6 +334,8 @@ pub(in crate::app) struct GuiPrefs {
     pub(in crate::app) folders_before_tags: bool,
     pub(in crate::app) double_click_to_open_tags: bool,
     pub(in crate::app) session_restore: SessionRestore,
+    pub(in crate::app) update_channel: UpdateChannel,
+    pub(in crate::app) check_updates_on_startup: bool,
     pub(in crate::app) show_block_sizes: bool,
     pub(in crate::app) scroll_to_cycle_dropdowns: bool,
     /// Warn before Save overwrites Campaign Evolved pak files in place.
@@ -322,6 +377,8 @@ impl Default for GuiPrefs {
             blender_path: None,
             editing_kit_paths: HashMap::new(),
             session_restore: SessionRestore::Ask,
+            update_channel: UpdateChannel::default(),
+            check_updates_on_startup: true,
             ek_folder_aliases: Vec::new(),
             custom_editing_kit_profiles: Vec::new(),
             tool_commands_window_pos: None,
@@ -364,6 +421,15 @@ mod tests {
                 ("Campaign Evolved", "haloce_evolved"),
             ]
         );
+    }
+
+    #[test]
+    fn update_channel_round_trips_through_its_stored_string() {
+        for channel in UpdateChannel::ALL {
+            assert_eq!(UpdateChannel::from_str(channel.as_str()), Some(channel));
+        }
+        assert_eq!(UpdateChannel::from_str("nightly"), None);
+        assert_eq!(UpdateChannel::default(), UpdateChannel::Stable);
     }
 }
 

--- a/src/app/state/worker.rs
+++ b/src/app/state/worker.rs
@@ -80,8 +80,12 @@ pub(in crate::app) enum WorkerMessage {
     TerminalDone {
         run_id: u64,
     },
-    // GitHub latest-release lookup finished.
-    UpdateCheckFinished(Result<UpdateCheckResult, String>),
+    // GitHub release lookup finished. `silent` marks the automatic check made
+    // at startup, which stays quiet unless it actually found an update.
+    UpdateCheckFinished {
+        silent: bool,
+        result: Result<UpdateCheckResult, String>,
+    },
     // Background field-value search finished; the stamp discards results for
     // a kit that has since closed or reloaded.
     FieldValueSearchFinished {
@@ -156,9 +160,36 @@ pub(in crate::app) struct FolderConversionProgress {
     pub(in crate::app) failed: usize,
 }
 
+#[derive(Clone, Debug)]
 pub(in crate::app) struct UpdateCheckResult {
+    pub(in crate::app) channel: UpdateChannel,
     pub(in crate::app) latest_tag: String,
     pub(in crate::app) release_url: String,
+    /// The release's `target_commitish`. The only thing that distinguishes one
+    /// development build from the next, since they share the `dev` tag.
+    pub(in crate::app) commit: String,
+}
+
+impl UpdateCheckResult {
+    /// A short, human-sized name for this release: the tag for a stable
+    /// release, the abbreviated commit for a development build.
+    pub(in crate::app) fn short_name(&self) -> String {
+        match self.channel {
+            UpdateChannel::Stable => self.latest_tag.clone(),
+            UpdateChannel::Development => short_commit(&self.commit),
+        }
+    }
+}
+
+/// Abbreviates a commit hash for display, leaving anything that is not one
+/// (an empty string, a branch name) alone.
+pub(in crate::app) fn short_commit(commit: &str) -> String {
+    let (hash, dirty) = match commit.strip_suffix("-dirty") {
+        Some(hash) => (hash, "-dirty"),
+        None => (commit, ""),
+    };
+    let short = hash.get(..7).unwrap_or(hash);
+    format!("{short}{dirty}")
 }
 
 #[derive(Clone, Debug)]

--- a/src/app/style.rs
+++ b/src/app/style.rs
@@ -301,6 +301,17 @@ pub(super) fn subtle_dark() -> Color32 {
     }
 }
 
+/// Green for good news worth noticing in passing — an available update sitting
+/// in the status bar. Darkened for the light theme so it stays legible against
+/// a pale background.
+pub(super) fn good_news() -> Color32 {
+    if is_dark_mode() {
+        Color32::from_rgb(126, 205, 133)
+    } else {
+        Color32::from_rgb(22, 116, 51)
+    }
+}
+
 pub(super) fn function_plot_bg() -> Color32 {
     if is_dark_mode() {
         Color32::from_rgb(64, 64, 62)

--- a/src/app/tests/prefs_update_channel.rs
+++ b/src/app/tests/prefs_update_channel.rs
@@ -1,0 +1,48 @@
+use super::*;
+
+fn stored(prefs: &GuiPrefs) -> GuiPrefs {
+    prefs_from_value(&prefs_to_value(prefs, &HashSet::new(), true))
+}
+
+#[test]
+fn the_stable_channel_is_the_default() {
+    let prefs = prefs_from_value(&json!({}));
+    assert_eq!(prefs.update_channel, UpdateChannel::Stable);
+    assert!(prefs.check_updates_on_startup);
+}
+
+#[test]
+fn preferences_written_before_this_setting_existed_load_as_stable() {
+    // No `update_channel` key, but plenty of other settings: an existing user's
+    // file must not silently move them onto development builds.
+    let prefs = prefs_from_value(&json!({
+        "session_restore": "always",
+        "dark_mode": true,
+    }));
+    assert_eq!(prefs.update_channel, UpdateChannel::Stable);
+    assert!(prefs.check_updates_on_startup);
+    assert_eq!(prefs.session_restore, SessionRestore::Always);
+}
+
+#[test]
+fn the_chosen_channel_survives_a_save_and_load() {
+    let mut prefs = GuiPrefs::default();
+    prefs.update_channel = UpdateChannel::Development;
+    prefs.check_updates_on_startup = false;
+
+    let reloaded = stored(&prefs);
+    assert_eq!(reloaded.update_channel, UpdateChannel::Development);
+    assert!(!reloaded.check_updates_on_startup);
+
+    prefs.update_channel = UpdateChannel::Stable;
+    prefs.check_updates_on_startup = true;
+    let reloaded = stored(&prefs);
+    assert_eq!(reloaded.update_channel, UpdateChannel::Stable);
+    assert!(reloaded.check_updates_on_startup);
+}
+
+#[test]
+fn an_unrecognised_channel_falls_back_to_stable() {
+    let prefs = prefs_from_value(&json!({"update_channel": "nightly"}));
+    assert_eq!(prefs.update_channel, UpdateChannel::Stable);
+}

--- a/src/app/tests/updates.rs
+++ b/src/app/tests/updates.rs
@@ -1,0 +1,115 @@
+use super::*;
+
+fn release(channel: UpdateChannel, tag: &str, commit: &str) -> UpdateCheckResult {
+    UpdateCheckResult {
+        channel,
+        latest_tag: tag.to_owned(),
+        release_url: "https://example.invalid/release".to_owned(),
+        commit: commit.to_owned(),
+    }
+}
+
+#[test]
+fn stable_channel_compares_release_tags_against_the_package_version() {
+    let current = env!("CARGO_PKG_VERSION");
+    assert!(!is_update_available(&release(
+        UpdateChannel::Stable,
+        current,
+        ""
+    )));
+    assert!(is_update_available(&release(
+        UpdateChannel::Stable,
+        "v999.0.0",
+        ""
+    )));
+    assert!(!is_update_available(&release(
+        UpdateChannel::Stable,
+        "v0.0.1",
+        ""
+    )));
+}
+
+#[test]
+fn stable_channel_ignores_the_release_commit() {
+    // A stable release's identity is its tag; whatever commit it points at
+    // must not change the verdict.
+    let up_to_date = release(UpdateChannel::Stable, env!("CARGO_PKG_VERSION"), "deadbeef");
+    assert!(!is_update_available(&up_to_date));
+}
+
+#[test]
+fn development_channel_is_current_only_when_the_commit_matches() {
+    // The development release always carries the `dev` tag, so a version
+    // comparison would call every build current — the commit is the only
+    // thing that separates one from the next.
+    let matching = release(UpdateChannel::Development, "dev", BABOON_BUILD_COMMIT);
+    assert_eq!(
+        is_update_available(&matching),
+        BABOON_BUILD_COMMIT.is_empty(),
+        "a development release built from this very commit is not an update"
+    );
+
+    let different = release(
+        UpdateChannel::Development,
+        "dev",
+        "0123456789abcdef0123456789abcdef01234567",
+    );
+    assert!(is_update_available(&different));
+}
+
+#[test]
+fn an_unknown_build_commit_never_counts_as_current() {
+    assert!(!is_same_commit("", "0123456"));
+    assert!(!is_same_commit("0123456", ""));
+    assert!(!is_same_commit("", ""));
+    assert!(is_same_commit("0123ABC", "0123abc"));
+}
+
+#[test]
+fn development_status_names_the_offered_commit_and_the_running_one() {
+    let offered = "0123456789abcdef0123456789abcdef01234567";
+    let status = update_check_status(&release(UpdateChannel::Development, "dev", offered));
+    assert!(status.contains("0123456"), "{status}");
+    assert!(
+        !status.contains(offered),
+        "the full hash is too long for a status line: {status}"
+    );
+    // The release is reached through the status bar's link, so repeating the
+    // URL in prose would only duplicate it.
+    assert!(!status.contains("http"), "{status}");
+}
+
+#[test]
+fn a_missing_release_reads_differently_per_channel() {
+    let stable = update_check_error_status(UpdateChannel::Stable, NO_PUBLIC_RELEASE_MESSAGE);
+    let development =
+        update_check_error_status(UpdateChannel::Development, NO_PUBLIC_RELEASE_MESSAGE);
+    assert_ne!(stable, development);
+    assert!(development.contains("development"), "{development}");
+    // The sentinel is internal plumbing and must never reach the status line.
+    assert!(!stable.contains(NO_PUBLIC_RELEASE_MESSAGE));
+    assert!(!development.contains(NO_PUBLIC_RELEASE_MESSAGE));
+
+    let failure = update_check_error_status(UpdateChannel::Stable, "connection refused");
+    assert_eq!(failure, "Update check failed: connection refused");
+}
+
+#[test]
+fn a_modified_working_tree_is_not_an_update_over_the_commit_it_sits_on() {
+    // Otherwise every launch of every local build announces an update.
+    assert!(is_same_commit("0123456789abcdef-dirty", "0123456789abcdef"));
+    assert!(is_same_commit("0123456789abcdef", "0123456789abcdef-dirty"));
+    // A dirty build on an older commit really is behind, and still says so.
+    assert!(!is_same_commit(
+        "0123456789abcdef-dirty",
+        "fedcba9876543210"
+    ));
+}
+
+#[test]
+fn short_commit_abbreviates_hashes_and_keeps_the_dirty_marker() {
+    assert_eq!(short_commit("0123456789abcdef"), "0123456");
+    assert_eq!(short_commit("0123456789abcdef-dirty"), "0123456-dirty");
+    assert_eq!(short_commit(""), "");
+    assert_eq!(short_commit("main"), "main");
+}

--- a/src/app/ui/first_run.rs
+++ b/src/app/ui/first_run.rs
@@ -91,9 +91,12 @@ impl Baboon {
     }
 
     fn draw_first_run_interface(&mut self, ui: &mut Ui) {
-        ui.heading("Blender and interface");
+        ui.heading("Updates and interface");
         ui.label("Blender is optional. You can change any of these settings later.");
         ui.add_space(10.0);
+        ui.label(RichText::new("Updates").strong());
+        self.draw_update_channel_picker(ui);
+        ui.add_space(12.0);
         ui.label(RichText::new("Blender executable").strong());
         ui.horizontal(|ui| {
             if ui

--- a/src/app/ui/settings.rs
+++ b/src/app/ui/settings.rs
@@ -112,6 +112,64 @@ impl Baboon {
             .color(subtle_dark())
             .small(),
         );
+
+        ui.add_space(10.0);
+        ui.separator();
+        ui.label(RichText::new("Updates").color(text_dark()).strong());
+        ui.add_space(4.0);
+        self.draw_update_channel_picker(ui);
+        ui.add_space(6.0);
+        ui.horizontal(|ui| {
+            if ui.button("Check now").clicked() {
+                let ctx = ui.ctx().clone();
+                self.begin_check_for_updates(ctx, false);
+            }
+            self.draw_update_check_result(ui);
+        });
+    }
+
+    /// Radio rows for which build track update checks follow, plus whether the
+    /// check runs at startup.
+    /// Shared by Settings and the first-run wizard so the two cannot drift.
+    pub(super) fn draw_update_channel_picker(&mut self, ui: &mut Ui) {
+        ui.label(RichText::new("Check for updates on").color(text_dark()));
+        for option in UpdateChannel::ALL {
+            if ui
+                .radio_value(&mut self.update_channel, option, option.label())
+                .on_hover_text(option.help())
+                .changed()
+            {
+                // The previous channel's verdict says nothing about this one.
+                self.available_update = None;
+                self.last_update_check = None;
+            }
+        }
+        ui.add_space(4.0);
+        ui.checkbox(
+            &mut self.check_updates_on_startup,
+            "Check for updates when Baboon starts",
+        );
+    }
+
+    /// One line describing what the last check concluded, with a link when
+    /// there is something to go and get.
+    fn draw_update_check_result(&self, ui: &mut Ui) {
+        if let Some(update) = self.available_update.as_ref() {
+            ui.horizontal(|ui| {
+                ui.label(
+                    RichText::new("Update available:")
+                        .color(text_dark())
+                        .strong(),
+                );
+                ui.hyperlink_to(update.short_name(), &update.release_url);
+            });
+            return;
+        }
+        ui.label(
+            RichText::new(self.update_check_summary())
+                .color(subtle_dark())
+                .small(),
+        );
     }
 
     /// Radio row for how nested containers in the tag editor start out.

--- a/src/app/ui/shell.rs
+++ b/src/app/ui/shell.rs
@@ -506,8 +506,16 @@ impl Baboon {
                             ui.close_menu();
                         }
                         if ui.button("Check for updates").clicked() {
-                            self.begin_check_for_updates(ctx.clone());
+                            self.begin_check_for_updates(ctx.clone(), false);
                             ui.close_menu();
+                        }
+                        if let Some(update) = self.available_update.as_ref() {
+                            let label = format!("Update available: {}...", update.short_name());
+                            let url = update.release_url.clone();
+                            if ui.button(label).clicked() {
+                                ctx.open_url(egui::OpenUrl::new_tab(url));
+                                ui.close_menu();
+                            }
                         }
                     });
                     ui.menu_button("Editing Kits", |ui| {
@@ -669,6 +677,36 @@ impl Baboon {
                             .text(RichText::new(&progress.phase).color(text_dark()));
                         ui.add(bar);
                         ctx.request_repaint();
+                    }
+                    // Anchored to the right edge, out of the way of the status
+                    // text and the progress bars that share this row. The
+                    // status line expires on a timer, so an update found by the
+                    // silent startup check would otherwise scroll past unread;
+                    // this link stays until the next check clears it.
+                    if let Some(update) = self.available_update.as_ref() {
+                        let label = format!("Update available: {}", update.short_name());
+                        let url = update.release_url.clone();
+                        let hover = match update.channel {
+                            UpdateChannel::Stable => "Open the release page on GitHub",
+                            UpdateChannel::Development => {
+                                "Open the latest development build on GitHub"
+                            }
+                        };
+                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                            // An explicit colour beats the app-wide
+                            // `override_text_color`, which would otherwise
+                            // flatten both this and the link colour to
+                            // ordinary body text. `strong()` only brightens;
+                            // the weight comes from the bold family, at the
+                            // body size of the row it sits in.
+                            ui.hyperlink_to(
+                                RichText::new(label)
+                                    .font(bold_font(12.0))
+                                    .color(good_news()),
+                                &url,
+                            )
+                            .on_hover_text(hover);
+                        });
                     }
                 });
             });


### PR DESCRIPTION
Baboon only ever asked GitHub for `/releases/latest`, which by definition never returns a prerelease — so the rolling `dev` build that `release.yml` publishes on every push to `main` was unreachable from inside the app, and anyone running one was told they were up to date forever.

## Update channel

A channel setting now decides which release the check looks at, and how "newer" is judged:

- **Stable** (the default) compares the release tag against the package version, as before.
- **Development** follows the rolling build. It is republished under the same `dev` tag every time, so it has no version to compare — `build.rs` bakes the build's commit into the binary (`BABOON_BUILD_COMMIT`) and the check compares that against the release's `target_commitish`. The `-dirty` marker is ignored, so a working-tree build sitting on the published commit reads as current instead of nagging on every launch.

CI needs no change: `actions/checkout` leaves a real `.git`, so release artifacts carry their true commit. Git being absent is not an error — the commit is left empty and the channel says the local commit is unknown.

## Checking and reporting

The check now also runs at startup, silently: it writes to the status line only when it has something to say, so launching offline or already-current produces no message the user did not ask for.

A found update is reported as a bold green link at the right of the status bar and as an entry in the Help menu — both outlive the status line's expiry timer, which a startup discovery would otherwise scroll past unread. The status line itself no longer repeats it.

## Settings

The channel and a "check at startup" toggle live in Settings under Startup, and again on the first-run setup page so it is a deliberate choice rather than a buried default. Both use one shared picker so the two cannot drift. A preferences file written before this existed loads as Stable.

Version bumped to 0.2.1.

## Testing

- `cargo test --all-targets`: 392 passed, 18 ignored. 12 are new — channel comparison per track, the dirty-build rule, the prefs round-trip, and that a pre-existing preferences file migrates to Stable.
- `cargo build --release`: clean.
- Verified the embedded commit matches `git rev-parse HEAD`, and that the live `releases/tags/dev` endpoint returns the SHA in `target_commitish`.