### PR TITLE
Make new Campaign Evolved tags editable, renameable, and referenceable

### DIFF
--- a/src/app/browser/tree.rs
+++ b/src/app/browser/tree.rs
@@ -1046,10 +1046,7 @@ pub(in crate::app) fn draw_entry(
     response.context_menu(|ui| {
         style_tag_context_menu(ui);
 
-        let rename_enabled = matches!(
-            entry.location,
-            TagEntryLocation::LooseFile(_) | TagEntryLocation::Container { .. }
-        );
+        let rename_enabled = supports_rename_menu(entry);
         let extract_enabled = supports_tag_extract_menu(entry.group_tag);
         ui.horizontal(|ui| {
             if context_menu_primary_button(ui, "Rename", rename_enabled).clicked() {
@@ -1225,6 +1222,19 @@ pub(in crate::app) fn is_embedded_tag_entry(entry: &TagEntry) -> bool {
     matches!(
         entry.location,
         TagEntryLocation::Monolithic { .. } | TagEntryLocation::Container { .. }
+    )
+}
+
+/// Whether the tag can be renamed or moved. A loose tag moves on disk, a
+/// container tag writes a renamed override container, and a brand-new container
+/// tag rewrites its in-memory entry — the only way to correct a path typed into
+/// the New Tag dialog. A monolithic cache tag has no writable path at all.
+pub(in crate::app) fn supports_rename_menu(entry: &TagEntry) -> bool {
+    matches!(
+        entry.location,
+        TagEntryLocation::LooseFile(_)
+            | TagEntryLocation::Container { .. }
+            | TagEntryLocation::NewContainer { .. }
     )
 }
 

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -96,6 +96,23 @@ fn normalize_container_tag_rel(input: &str) -> String {
     segments.join("/")
 }
 
+/// The UE package path a brand-new tag will be written at, from its normalized
+/// container-relative path and group name (`objects/foo/bar` + `camera_track`
+/// → `/Game/Tags/objects/foo/bar-camera_track`).
+///
+/// Shared by creation and rename on purpose: the entry key derives from this,
+/// and a rename that derived either differently would produce an entry the save
+/// and project-overlay paths no longer recognize as the same tag.
+fn new_container_package(logical: &str, group_name: &str) -> String {
+    format!("/Game/Tags/{logical}-{group_name}")
+}
+
+/// The browser/document key for a new tag at `package`. Prefixed so it cannot
+/// collide with a mounted container tag's key.
+fn new_container_key(package: &str) -> String {
+    format!("newtag:{package}")
+}
+
 fn container_rel_to_package_path(rel: &str) -> Option<String> {
     let no_ext = rel.strip_suffix(".ubulk").unwrap_or(rel);
     let after = no_ext.strip_prefix("Meteorite/Content/").unwrap_or(no_ext);
@@ -919,8 +936,8 @@ impl Baboon {
                 "No existing {group_name} tag in the mounted paks to use as a template"
             ));
         };
-        let package = format!("/Game/Tags/{logical}-{group_name}");
-        let key = format!("newtag:{package}");
+        let package = new_container_package(logical, group_name);
+        let key = new_container_key(&package);
         if self.kits[self.active].parsed_tags.contains_key(&key)
             || self.source().is_some_and(|s| {
                 s.entries
@@ -945,6 +962,107 @@ impl Baboon {
         };
         self.register_in_memory_tag(entry, tag);
         Ok(())
+    }
+
+    /// Rename/move (`duplicate == false`) or copy (`duplicate == true`) a
+    /// brand-new container tag to `new_rel`. Nothing is written: a new tag lives
+    /// only in its document until Save/Export Mod, so this rewrites the entry
+    /// (and re-homes the document under the new key) in memory. Returns the
+    /// status line to show.
+    fn apply_new_container_rename(
+        &mut self,
+        key: &str,
+        new_rel: &str,
+        duplicate: bool,
+    ) -> Result<String, String> {
+        let Some(entry) = self.entry_for_key(key).cloned() else {
+            return Err("Tag is no longer in the source".to_owned());
+        };
+        let TagEntryLocation::NewContainer {
+            template_container,
+            template_rel,
+            group_tag,
+            ..
+        } = &entry.location
+        else {
+            return Err("Not a new Campaign Evolved tag".to_owned());
+        };
+        let (template_container, template_rel, group_tag) =
+            (*template_container, template_rel.clone(), *group_tag);
+        if new_rel.is_empty() {
+            return Err("Enter a tag path (e.g. objects/foo/bar)".to_owned());
+        }
+        let group_name = entry
+            .group_name
+            .clone()
+            .unwrap_or_else(|| format_group_tag(entry.group_tag));
+        let extension = entry
+            .display_path
+            .rsplit_once('.')
+            .map(|(_, ext)| ext.to_owned())
+            .unwrap_or_else(|| group_name.clone());
+
+        if duplicate {
+            // `TagFile` is not `Clone`; a round-trip through its own bytes is
+            // how a document is copied, and it is exactly what Save would have
+            // written anyway.
+            let bytes = self.kits[self.active]
+                .parsed_tags
+                .get(key)
+                .ok_or("Load the tag before copying it")?
+                .tag
+                .write_to_bytes()
+                .map_err(|error| format!("Could not serialize the tag: {error}"))?;
+            let copy = TagFile::read_from_bytes(&bytes)
+                .map_err(|error| format!("Could not re-read the copied tag: {error}"))?;
+            self.add_new_container_tag(new_rel, group_tag, &group_name, &extension, copy)?;
+            return Ok(format!("Copied to {new_rel}.{extension} (unsaved)"));
+        }
+
+        let package = new_container_package(new_rel, &group_name);
+        let new_key = new_container_key(&package);
+        if new_key == key {
+            return Ok(format!("{} is already at that path", entry.display_path));
+        }
+        if self.kits[self.active].parsed_tags.contains_key(&new_key)
+            || self.source().is_some_and(|source| {
+                source
+                    .entries
+                    .iter()
+                    .chain(source.all_entries.iter())
+                    .any(|existing| existing.key == new_key)
+            })
+        {
+            return Err(format!("A tag already exists at {new_rel}"));
+        }
+        let Some(document) = self.kits[self.active].parsed_tags.remove(key) else {
+            return Err("Load the tag before renaming it".to_owned());
+        };
+        // The project stashes overlays under the package path, so the old
+        // identity has to go — otherwise the checkpoint keeps a copy of the tag
+        // at its previous path and restores it as a second tag next session.
+        let kit = self.active;
+        self.forget_campaign_overlay(kit, key);
+        self.forget_new_container_entry(kit, key);
+        let old_display = entry.display_path.clone();
+        self.register_in_memory_tag(
+            TagEntry {
+                key: new_key,
+                display_path: format!("{new_rel}.{extension}"),
+                group_tag: entry.group_tag,
+                group_name: Some(group_name),
+                location: TagEntryLocation::NewContainer {
+                    template_container,
+                    template_rel,
+                    package,
+                    group_tag,
+                },
+            },
+            document.tag,
+        );
+        Ok(format!(
+            "Renamed {old_display} → {new_rel}.{extension} (unsaved)"
+        ))
     }
 
     /// Open the "Import tag" dialog: pick a self-describing MCC/Reach tag file,
@@ -1219,6 +1337,21 @@ impl Baboon {
             source.group_tree = group_tree;
         }
         self.kits[self.active].generation = self.kits[self.active].generation.wrapping_add(1);
+        // Index what the new tag points at. Nothing else can: the reverse-
+        // dependency builder reads tags from their source, and this one has no
+        // source — so without this the tag is invisible to reference queries in
+        // both directions, and to the tag tree's children view.
+        let dependencies = {
+            let mut refs = Vec::new();
+            collect_tag_dependency_refs(tag.root(), &mut refs);
+            refs
+        };
+        if let Some(index) = self
+            .source_mut()
+            .and_then(|source| source.reverse_dependencies.as_mut())
+        {
+            index.set_tag_dependencies(key.clone(), dependencies);
+        }
         self.kits[self.active].parsed_tags
             .insert(key.clone(), TagDocument::modified(tag));
         self.kits[self.active].open_tag_pane(&key);
@@ -2009,12 +2142,59 @@ impl Baboon {
                 return;
             }
         }
+        // A brand-new tag has no source to reload from — the document that was
+        // just dropped WAS the tag. Take its browser entry with it instead of
+        // leaving a row that errors on every reopen.
+        if self.forget_new_container_entry(kit, key) {
+            self.status = format!("Discarded the unsaved new tag {label}");
+            return;
+        }
         // Still open: reload it as the source has it, rather than leaving an
         // empty pane behind.
         if self.kits[kit].open_tabs.iter().any(|open| open == key) {
             self.select_entry(key.to_owned(), ctx.clone());
         }
         self.status = format!("Discarded unsaved changes to {label}");
+    }
+
+    /// Drop a brand-new (never-saved) container tag's browser entry, closing its
+    /// pane and dropping everything derived from it. No-op — returning `false` —
+    /// for any other kind of entry.
+    ///
+    /// Load-bearing for every path that discards a new tag's document: the
+    /// document is the tag's ONLY copy (there is no `.ubulk` behind it), so an
+    /// entry that outlives it is a row whose every reopen fails in `read_entry`
+    /// with "unsaved new tag is no longer loaded".
+    pub(super) fn forget_new_container_entry(&mut self, kit: usize, key: &str) -> bool {
+        if !matches!(
+            self.entry_for_key_in(kit, key).map(|entry| &entry.location),
+            Some(TagEntryLocation::NewContainer { .. })
+        ) {
+            return false;
+        }
+        self.kits[kit].close_tag_pane(key);
+        let kit_state = &mut self.kits[kit];
+        kit_state.parsed_tags.remove(key);
+        kit_state.loading_tags.remove(key);
+        kit_state.bitmap_previews.remove(key);
+        kit_state.model_previews.remove(key);
+        kit_state.field_search.remove(key);
+        kit_state.field_search_applied.remove(key);
+        kit_state.edit_buffers.forget_tag(key);
+        if kit_state.selected_key.as_deref() == Some(key) {
+            kit_state.selected_key = None;
+        }
+        if let Some(source) = kit_state.source.as_mut() {
+            source.entries.retain(|entry| entry.key != key);
+            source.all_entries.retain(|entry| entry.key != key);
+            source.tree = crate::source::build_tree(&source.entries);
+            source.group_tree = crate::source::build_group_tree(&source.entries);
+            if let Some(index) = source.reverse_dependencies.as_mut() {
+                index.clear_tag(key);
+            }
+        }
+        kit_state.generation = kit_state.generation.wrapping_add(1);
+        true
     }
 
     /// Whether `key` has anything to discard — unsaved edits, or bytes stashed
@@ -2070,6 +2250,16 @@ impl Baboon {
         else {
             return;
         };
+        // A new tag reaching here has lost its document and its project overlay
+        // (`select_entry` tries the overlay first), so there is nothing left to
+        // read — `read_entry` would only fail on the worker thread. Retire the
+        // entry here instead of leaving a row that fails forever.
+        if matches!(entry.location, TagEntryLocation::NewContainer { .. }) {
+            let kit = self.active;
+            self.forget_new_container_entry(kit, &key);
+            self.status = format!("The unsaved new tag {} was discarded", entry.display_path);
+            return;
+        }
         let source_kind = source.source.clone();
         let tx = self.tx.clone();
         let kit = self.active_kit_id();
@@ -3912,7 +4102,9 @@ impl Baboon {
     }
 
     /// Open the rename dialog in "duplicate" mode (Save As for a container tag —
-    /// writes a new tag with no redirect).
+    /// writes a new tag with no redirect). For a tag that has never been saved
+    /// there is nothing to write yet, so the copy is made in memory and both
+    /// tags stay unsaved until Save/Export Mod.
     pub(super) fn open_container_duplicate(&mut self, key: &str) {
         self.open_rename_or_duplicate(key, false);
     }
@@ -3921,7 +4113,9 @@ impl Baboon {
         let Some(entry) = self.entry_for_key(key).cloned() else {
             return;
         };
-        let is_container = matches!(entry.location, TagEntryLocation::Container { .. });
+        let is_new_container = matches!(entry.location, TagEntryLocation::NewContainer { .. });
+        let is_container =
+            is_new_container || matches!(entry.location, TagEntryLocation::Container { .. });
         if !is_container && !matches!(entry.location, TagEntryLocation::LooseFile(_)) {
             self.status = "Only loose-folder or container tags can be renamed".to_owned();
             return;
@@ -3931,7 +4125,13 @@ impl Baboon {
             Some((stem, ext)) => (stem.to_owned(), ext.to_owned()),
             None => (display.clone(), String::new()),
         };
-        let name = stem.rsplit(['/', '\\']).next().unwrap_or(&stem).to_owned();
+        // A new tag edits its whole path (rename and move are the same in-memory
+        // operation for it); everything else edits the leaf name only.
+        let name = if is_new_container {
+            stem.clone()
+        } else {
+            stem.rsplit(['/', '\\']).next().unwrap_or(&stem).to_owned()
+        };
         let (referrers, referrers_unavailable) = match self.references_to_entry(&entry) {
             Some(list) => (
                 list.iter()
@@ -3951,6 +4151,7 @@ impl Baboon {
             referrers_unavailable,
             is_container,
             redirect,
+            is_new_container,
         });
     }
 
@@ -3969,7 +4170,7 @@ impl Baboon {
             self.status = "The workspace this rename came from is closed".to_owned();
             return;
         }
-        let Some((key, old_display, new_name_raw, is_container, redirect)) =
+        let Some((key, old_display, new_name_raw, is_container, redirect, is_new_container)) =
             self.rename_tag.as_ref().map(|s| {
                 (
                     s.key.clone(),
@@ -3977,6 +4178,7 @@ impl Baboon {
                     s.new_path_input.clone(),
                     s.is_container,
                     s.redirect,
+                    s.is_new_container,
                 )
             })
         else {
@@ -3987,7 +4189,9 @@ impl Baboon {
             self.status = "Enter a new tag name".to_owned();
             return;
         }
-        if new_name.contains(['/', '\\']) {
+        // A new tag's whole path is editable, so a separator is the move half of
+        // the operation rather than a mistake.
+        if !is_new_container && new_name.contains(['/', '\\']) {
             self.status = "Enter a name only; use Move to choose a folder".to_owned();
             return;
         }
@@ -3995,15 +4199,30 @@ impl Baboon {
             self.status = "Enter a name without an extension".to_owned();
             return;
         }
-        let parent = old_display
-            .rsplit_once('/')
-            .map(|(parent, _)| parent)
-            .unwrap_or("");
-        let new_rel = if parent.is_empty() {
-            new_name
+        let new_rel = if is_new_container {
+            normalize_container_tag_rel(&new_name)
         } else {
-            format!("{parent}/{new_name}")
+            let parent = old_display
+                .rsplit_once('/')
+                .map(|(parent, _)| parent)
+                .unwrap_or("");
+            if parent.is_empty() {
+                new_name
+            } else {
+                format!("{parent}/{new_name}")
+            }
         };
+
+        // A brand-new tag has no container to override — it exists only as the
+        // open document, so both rename and duplicate are in-memory edits.
+        if is_new_container {
+            self.rename_tag = None;
+            match self.apply_new_container_rename(&key, &new_rel, !redirect) {
+                Ok(message) => self.status = message,
+                Err(error) => self.status = error,
+            }
+            return;
+        }
 
         // Container tags: write an override container (rename adds a redirect,
         // duplicate does not) instead of moving a loose file.
@@ -4048,6 +4267,16 @@ impl Baboon {
     /// Starts a filesystem refactoring transaction from a captured source snapshot.
     /// Progress and the final replacement tree are applied only through worker messages.
     pub(super) fn begin_move_tag(&mut self, key: &str) {
+        // A new tag has no file to move and no folder to browse to: its whole
+        // container-relative path is editable in the rename dialog, so Move and
+        // Rename are the same in-memory operation for it.
+        if matches!(
+            self.entry_for_key(key).map(|entry| &entry.location),
+            Some(TagEntryLocation::NewContainer { .. })
+        ) {
+            self.open_rename_tag(key);
+            return;
+        }
         if self.folder_refactor.is_some() {
             self.status = "A move/rename is already running".to_owned();
             return;
@@ -6014,6 +6243,10 @@ impl Baboon {
                     // bytes stayed behind and came back on reopen.
                     self.forget_campaign_overlay(kit, tag_id);
                     self.kits[kit].edit_buffers.forget_tag(tag_id);
+                    // Declining to save a brand-new tag discards the tag, not
+                    // just its edits: nothing backs it but the document the
+                    // close is about to drop. Its browser entry goes with it.
+                    self.forget_new_container_entry(kit, tag_id);
                 }
                 let now = ctx.input(|input| input.time);
                 if let Err(error) = self.checkpoint_campaign_project(kit, now) {
@@ -8478,6 +8711,97 @@ mod dependency_tests {
             )
             .is_none()
         );
+    }
+
+    /// A tag created this session is a reference target like any other: it is
+    /// addressed by the same logical path, and "Open referenced tag" resolves
+    /// through this lookup. Excluding it reported the tag as missing.
+    #[test]
+    fn container_reference_resolution_finds_an_unsaved_new_tag() {
+        let names = TagNameIndex::default();
+        let camera_track = parse_group_tag("trak").unwrap();
+        let entries = vec![new_container_entry(
+            "test/example.camera_track",
+            camera_track,
+            "camera_track",
+        )];
+
+        let found = container_entry_for_reference(
+            &entries,
+            camera_track,
+            r"test\example.camera_track",
+            &names,
+        )
+        .expect("a new tag should resolve as a reference target");
+        assert_eq!(found.key, "newtag:/Game/Tags/test/example-camera_track");
+    }
+
+    /// The capability matrix for a brand-new container tag, in one place: what
+    /// it can do, and the two things it deliberately cannot. Every one of these
+    /// gates gets its answer from a `match` on `TagEntryLocation`, and each one
+    /// that forgot the `NewContainer` arm broke the tag in a different way —
+    /// the editability gate made every field and block button inert.
+    #[test]
+    fn a_new_container_tag_has_the_expected_capabilities() {
+        let camera_track = parse_group_tag("trak").unwrap();
+        let entry = new_container_entry("test/example.camera_track", camera_track, "camera_track");
+        let tag = TagFile::new("definitions/haloce_evolved/camera_track.json").unwrap();
+
+        assert!(
+            crate::app::is_editable_tag(&entry, &tag),
+            "fields and block controls must be live for a new tag"
+        );
+        assert!(
+            crate::app::supports_rename_menu(&entry),
+            "rename/move is the only way to correct a mistyped new-tag path"
+        );
+        // No `.ubulk` behind it, so there is nothing to pull out.
+        assert!(
+            !crate::app::is_embedded_tag_entry(&entry),
+            "a new tag has no embedded payload to extract"
+        );
+    }
+
+    fn new_container_entry(display_path: &str, group_tag: u32, group_name: &str) -> TagEntry {
+        let logical = display_path
+            .rsplit_once('.')
+            .map(|(stem, _)| stem)
+            .unwrap_or(display_path);
+        let package = new_container_package(logical, group_name);
+        TagEntry {
+            key: new_container_key(&package),
+            display_path: display_path.to_owned(),
+            group_tag,
+            group_name: Some(group_name.to_owned()),
+            location: TagEntryLocation::NewContainer {
+                template_container: 0,
+                template_rel: "Tags/other-camera_track.uasset".to_owned(),
+                package,
+                group_tag,
+            },
+        }
+    }
+
+    /// Renaming a new tag must land on exactly the key and package that
+    /// creating it at that path would have produced — the save and project-
+    /// overlay paths identify the tag by them, so a second derivation that
+    /// drifted would strand the renamed tag.
+    #[test]
+    fn renaming_a_new_tag_derives_the_same_identity_as_creating_it_there() {
+        let created = new_container_package("objects/foo/bar", "camera_track");
+        assert_eq!(created, "/Game/Tags/objects/foo/bar-camera_track");
+        assert_eq!(
+            new_container_key(&created),
+            "newtag:/Game/Tags/objects/foo/bar-camera_track"
+        );
+
+        // The rename path normalizes its input first — backslashes, case, and
+        // stray separators must not fork the identity.
+        let renamed = new_container_package(
+            &normalize_container_tag_rel("/Objects\\Foo//Bar/"),
+            "camera_track",
+        );
+        assert_eq!(renamed, created);
     }
 
     #[test]

--- a/src/app/controller/references.rs
+++ b/src/app/controller/references.rs
@@ -240,8 +240,13 @@ pub(super) fn container_entry_for_reference<'a>(
 ) -> Option<&'a TagEntry> {
     let target = normalized_reference_lookup_path(rel_path, group_tag, names);
     entries.iter().find(|entry| {
-        matches!(&entry.location, TagEntryLocation::Container { .. })
-            && entry.group_tag == group_tag
+        // A tag created this session is a legitimate reference target — it is
+        // addressed by the same logical path a saved one is, and "Open
+        // referenced tag" reported it missing while it was excluded here.
+        matches!(
+            &entry.location,
+            TagEntryLocation::Container { .. } | TagEntryLocation::NewContainer { .. }
+        ) && entry.group_tag == group_tag
             && normalized_reference_lookup_path(&entry.display_path, entry.group_tag, names)
                 == target
     })

--- a/src/app/editor/tests.rs
+++ b/src/app/editor/tests.rs
@@ -1691,4 +1691,43 @@ mod tag_diff_tests {
             "an added element has no previous value: {diffs:?}"
         );
     }
+
+    /// A brand-new Campaign Evolved tag must be editable the moment it is
+    /// created. `is_editable_tag` drives `FieldEditContext::editable`, which
+    /// gates every value widget and every block grow/shrink button, so a
+    /// `NewContainer` entry missing from the match rendered the whole tag
+    /// read-only until it was exported as a mod and remounted.
+    #[test]
+    fn a_new_container_tag_is_editable() {
+        let tag = TagFile::new("definitions/haloce_evolved/camera_track.json").unwrap();
+        let entry = TagEntry {
+            key: "newtag:/Game/Tags/test/example-camera_track".into(),
+            display_path: "test/example.camera_track".into(),
+            group_tag: tag.header.group_tag,
+            group_name: Some("camera_track".into()),
+            location: TagEntryLocation::NewContainer {
+                template_container: 0,
+                template_rel: "Tags/other-camera_track.uasset".into(),
+                package: "/Game/Tags/test/example-camera_track".into(),
+                group_tag: tag.header.group_tag,
+            },
+        };
+
+        assert!(
+            is_editable_tag(&entry, &tag),
+            "a newly created container tag must be editable"
+        );
+
+        // And the block op the UI defers actually appends to the fresh tag.
+        let mut tag = tag;
+        let index = add_block_element(&mut tag, "control points").unwrap();
+        assert_eq!(index, 0);
+        assert_eq!(
+            tag.root()
+                .field_path("control points")
+                .and_then(|field| field.as_block())
+                .map(|block| block.len()),
+            Some(1)
+        );
+    }
 }

--- a/src/app/editor/value_parser.rs
+++ b/src/app/editor/value_parser.rs
@@ -6,9 +6,17 @@ use super::*;
 pub(in crate::app) fn is_editable_tag(entry: &TagEntry, tag: &TagFile) -> bool {
     // Loose tags are edited in place; container (Campaign Evolved) tags are
     // edited in memory and written out as an override on Save/Save As/Rename.
+    // A brand-new container tag (New Tag / Import of a new path) has no backing
+    // `.ubulk` at all — the in-memory document IS the tag — so it is the most
+    // editable of the three, not the least. Leaving it out made every new CE
+    // tag render read-only: no field could be typed into and no block element
+    // added, until the user exported it as a mod and remounted it as a real
+    // `Container` entry.
     matches!(
         entry.location,
-        TagEntryLocation::LooseFile(_) | TagEntryLocation::Container { .. }
+        TagEntryLocation::LooseFile(_)
+            | TagEntryLocation::Container { .. }
+            | TagEntryLocation::NewContainer { .. }
     ) && (tag.classic_engine().is_some() || tag.endian == Endian::Le)
 }
 

--- a/src/app/state/browser.rs
+++ b/src/app/state/browser.rs
@@ -61,6 +61,11 @@ pub(in crate::app) struct RenameTagState {
     /// Container-only: rename (redirect old references to the new tag) vs.
     /// duplicate (Save As — no redirect). Ignored for loose sources.
     pub(in crate::app) redirect: bool,
+    /// Source is a brand-new (never-saved) Campaign Evolved tag: apply rewrites
+    /// the in-memory entry rather than writing any container, so the whole
+    /// destination path is editable — this is how a new tag is moved as well as
+    /// renamed. Implies `is_container`.
+    pub(in crate::app) is_new_container: bool,
 }
 
 /// Results of a tag query (find-references / unreferenced), shown in a floating

--- a/src/app/ui/dialogs.rs
+++ b/src/app/ui/dialogs.rs
@@ -1696,10 +1696,11 @@ impl Baboon {
         let mut cancel = false;
         {
             let state = self.rename_tag.as_mut().expect("checked above");
-            let title = if state.is_container && !state.redirect {
-                "Save Tag As (New Copy)"
-            } else {
-                "Rename Tag"
+            let title = match (state.is_new_container, state.redirect) {
+                (true, true) => "Rename / Move New Tag",
+                (true, false) => "Copy New Tag",
+                (false, false) if state.is_container => "Save Tag As (New Copy)",
+                _ => "Rename Tag",
             };
             egui::Window::new(title)
                 .id(egui::Id::new("rename_tag"))
@@ -1714,9 +1715,13 @@ impl Baboon {
                     );
                     ui.add_space(6.0);
                     ui.label(
-                        RichText::new("New name (extension is fixed)")
-                            .color(subtle_dark())
-                            .small(),
+                        RichText::new(if state.is_new_container {
+                            "New path (folders allowed; extension is fixed)"
+                        } else {
+                            "New name (extension is fixed)"
+                        })
+                        .color(subtle_dark())
+                        .small(),
                     );
                     ui.horizontal(|ui| {
                         ui.add(
@@ -1728,11 +1733,17 @@ impl Baboon {
                             RichText::new(format!(".{}", state.extension)).color(subtle_dark()),
                         );
                     });
-                    let preview_parent = state
-                        .old_display
-                        .rsplit_once('/')
-                        .map(|(parent, _)| parent)
-                        .unwrap_or("");
+                    // A new tag edits its whole path, so it keeps no parent from
+                    // the old one — what is typed IS the destination.
+                    let preview_parent = if state.is_new_container {
+                        ""
+                    } else {
+                        state
+                            .old_display
+                            .rsplit_once('/')
+                            .map(|(parent, _)| parent)
+                            .unwrap_or("")
+                    };
                     let preview_name = state.new_path_input.trim();
                     let preview = if preview_name.is_empty() {
                         "(enter a new name)".to_owned()
@@ -1750,7 +1761,26 @@ impl Baboon {
                             .small(),
                     );
                     ui.add_space(8.0);
-                    if state.is_container {
+                    if state.is_new_container {
+                        ui.label(
+                            RichText::new(if state.redirect {
+                                "This tag has not been saved yet, so it simply moves to the new \
+                                 path — nothing is written."
+                            } else {
+                                "Creates a second unsaved tag with a copy of this one's contents."
+                            })
+                            .color(text_dark()),
+                        );
+                        ui.label(
+                            RichText::new(if state.redirect {
+                                "It is written when you Save it or Export Mod."
+                            } else {
+                                "Both tags are written only when you Save them or Export Mod."
+                            })
+                            .color(subtle_dark())
+                            .small(),
+                        );
+                    } else if state.is_container {
                         if state.redirect {
                             ui.label(
                                 RichText::new(
@@ -1812,7 +1842,11 @@ impl Baboon {
                                 !state.new_path_input.trim().is_empty(),
                                 egui::Button::new("Apply"),
                             )
-                            .on_hover_text(if state.is_container {
+                            .on_hover_text(if state.is_new_container && state.redirect {
+                                "Move this unsaved tag to the new path (nothing is written yet)"
+                            } else if state.is_new_container {
+                                "Copy this unsaved tag to the new path (nothing is written yet)"
+                            } else if state.is_container {
                                 "Write a higher-priority overlay container (base game unchanged)"
                             } else {
                                 "Move the file on disk and rewrite all references"


### PR DESCRIPTION
A newly created Campaign Evolved tag could not be modified at all — reported against a fresh `camera_track`, whose top-level "control points" block would not take an element, but it applied to every field of every new tag.

## The cause

`is_editable_tag` matched only `LooseFile` and `Container` locations, so a `NewContainer` entry fell through to `false`. That single bool becomes `FieldEditContext::editable`, which gates every value widget and, through `prepare_block_control_availability`, every block grow/shrink button. The Add button rendered but was disabled, so clicking it did nothing. The tag only became editable after Export Mod + remount, which brings it back as a real `Container` entry.

## The same missing arm, three more places

**Discarding a new tag left a broken row.** Revert, and "Don't Save" on close, dropped the document — the tag's only copy, since there is no `.ubulk` behind it — but left the browser entry. Every reopen of that row then failed with *"unsaved new tag is no longer loaded"*. `forget_new_container_entry` now retires the entry with the document, and `ensure_tag_loading` retires one that has lost both its document and its project overlay rather than dispatching a read that can only fail.

**Rename and Move were disabled**, so a path mistyped in the New Tag dialog could not be corrected. Both are now in-memory for a never-saved tag: rename re-homes the document under the new key, copy round-trips the tag through its own bytes (`TagFile` is not `Clone`). The old project overlay is forgotten first, so a checkpoint cannot restore the tag at its previous path. There is no folder to browse to, so Move opens the rename dialog with the whole container-relative path editable; the dialog retitles and states that nothing is written until Save/Export Mod.

**References to a new tag did not resolve.** `container_entry_for_reference` skipped new entries, so "Open referenced tag" reported a just-created target as missing. `register_in_memory_tag` also indexes the new tag's outgoing references — nothing else can, because the reverse-dependency builder reads tags from a source and this one has none until it is saved.

## Notes

Creation and rename derive the entry key and package path through the same two helpers. Save and the project overlay identify a tag by those strings, so two derivations that drifted would strand a renamed tag; a test asserts rename lands on exactly the identity creation would have produced.

"Discard changes" on a new tag deletes the tag rather than reverting it — there is no baseline to revert to — and says so in the status line.

A saved new tag stays a `NewContainer` entry for the rest of the session (Save writes the external `_P` triplet but never re-homes the entry), so it keeps flowing through these paths until the source is reloaded with the mod mounted. Unchanged here.

## Validation

- `cargo test --all-targets`: 396 passed, 18 intentionally ignored
- `cargo build --release`: passed
- `git diff --check`: passed

Four new tests, including a capability matrix for a `NewContainer` entry — every one of these gates answers from a `match` on `TagEntryLocation`, so the matrix is what catches the next arm that gets forgotten.
