### PR TITLE
Save a tag back into a mod you already exported

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,10 @@ jobs:
         run: |
           sudo apt-get update
           # libasound2-dev: ALSA headers for rodio's Linux backend (cpal/alsa-sys).
+          # libxcb1-dev: links the `xcb` crate, which window_state uses to read
+          # X11 work areas. The runners ship libxcb1 but not its .so symlink.
           # libopus is NOT needed — it's vendored + statically compiled.
-          sudo apt-get install -y libxkbcommon-dev libasound2-dev
+          sudo apt-get install -y libxkbcommon-dev libasound2-dev libxcb1-dev
 
       - name: Install Windows CMake generator
         if: runner.os == 'Windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,8 +53,10 @@ jobs:
         run: |
           sudo apt-get update
           # libasound2-dev: ALSA headers for rodio's Linux backend (cpal/alsa-sys).
+          # libxcb1-dev: links the `xcb` crate, which window_state uses to read
+          # X11 work areas. The runners ship libxcb1 but not its .so symlink.
           # libopus is NOT needed — it's vendored + statically compiled.
-          sudo apt-get install -y libxkbcommon-dev libasound2-dev
+          sudo apt-get install -y libxkbcommon-dev libasound2-dev libxcb1-dev
 
       - name: Build release
         run: cargo build --release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,7 +502,7 @@ dependencies = [
 [[package]]
 name = "blam-tags"
 version = "0.1.0"
-source = "git+https://github.com/camden-smallwood/blam-tags?rev=cb0e6a1#cb0e6a14cdb35ac6d8292cc03215ed005895f540"
+source = "git+https://github.com/camden-smallwood/blam-tags?rev=1c3ad0c#1c3ad0c75f4d2ad1fcc623d08fb86a5f652d4442"
 dependencies = [
  "anyhow",
  "bcdec_rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1"
 atomic-write-file = "0.3"
-blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "cb0e6a1", features = ["audio", "iostore"] }
+blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "1c3ad0c", features = ["audio", "iostore"] }
 directories = "6"
 display-info = "0.5"
 eframe = { version = "0.29", default-features = false, features = ["default_fonts", "glow"] }

--- a/docs/campaign-evolved-tag-authoring-plan.md
+++ b/docs/campaign-evolved-tag-authoring-plan.md
@@ -1,0 +1,810 @@
+# Campaign Evolved custom-tag authoring — implementation plan
+
+Companion to [`campaign-evolved-tag-packages.md`](campaign-evolved-tag-packages.md),
+which is the measured specification. This document is the plan: what to build,
+in what order, with what acceptance gates, and what each step de-risks.
+
+**The defect being fixed.** A CE tag is a UE package whose `.uasset` wrapper
+carries the tag's identity, its hard-reference preload list, and (for 22 of 101
+groups) a binding to an Unreal asset. Today Baboon never builds that wrapper —
+it copies one. `add_override_to_writer` re-emits the base game's `.uasset`
+verbatim, patching only `serial_size` and only on a size change;
+`add_new_package_to_writer` clones a same-group template including its import
+map and export body. So a new tag inherits the template's `AssetReference` and
+dependencies, and a reference repointed at a new tag never gains the import that
+would preload it.
+
+---
+
+## Phase 0 — The spike (do this first)
+
+**Purpose.** Three unknowns remain, all about the *load model*, and one branch
+of them is project-ending: if the tag registry is populated from a fixed list a
+mod cannot write, custom tags are impossible rather than merely harder.
+Discovering that after two weeks of building would be a bad trade. This spike
+answers all three for about a day, **using only code that exists today**.
+
+**The unknowns**
+
+1. Is the runtime tag registry populated by enumerating packages, or from a
+   fixed list?
+2. Does resolution *load* on demand (`TryLoad`) or only find an already-loaded
+   object (`ResolveObject`)?
+3. Does the engine honour a mod-supplied `ContainerHeader` package-store entry
+   for a brand-new package?
+
+**The experiment**
+
+1. Take `marine-biped` — the one override already confirmed loading in-game.
+2. Edit its blob so a single tag reference points at a **new** path, e.g.
+   `objects/characters/marine/my_test` in group `collision_model`.
+3. Ship a new `my_test-collision_model` package cloned from an existing
+   `collision_model`. Cloning is genuinely correct here: `collision_model` is one
+   of the 47 bare groups, so the template wrapper carries nothing
+   group-specific.
+4. **Leave `marine-biped`'s `.uasset` import map untouched.** Nothing in the
+   game will import the new package.
+5. Build with `write_mod_container_ex` (one override + one new package) and run.
+
+**Reading the result**
+
+| Outcome | Conclusion |
+|---|---|
+| Marine still has collision | The new tag resolved **by name** with nothing importing it → registry is dynamic, load-on-demand works, mod `ContainerHeader` is honoured. All three unknowns answered positively; the plan below stands unchanged. |
+| Collision missing / `Default/default-collision_model` behaviour | Name resolution alone is insufficient. Re-run with the import added to `marine-biped`'s wrapper (requires Phase 1+2) to separate "needs the hard reference" from "new packages don't register at all". |
+| Game fails to mount the container | The `ContainerHeader` path is wrong — isolate before anything else. |
+
+**Also worth capturing in the same session**, since the build is already made:
+try the debug-menu config override (see §"Debug surface" below). Low expected
+value, five minutes.
+
+---
+
+## Phase 1 — blam-tags: the encoder and the builder
+
+Everything downstream depends on these two, and both are policed by corpus
+gates. Build the gates first: this investigation was wrong twice under corpus
+pressure (the `imported_public_export_hashes` dedup rule, worth 8 bytes; and the
+`FUnversionedHeader` fragment bit layout), and both were caught only by checking
+against all 12,291 packages.
+
+### 1.1 `iostore::unversioned::write_export_struct`
+
+The mirror of the existing reader. The complete surface it must cover, measured
+across every tag export:
+
+| Kind | Encoding |
+|---|---|
+| `Object` | `i32` `FPackageIndex` |
+| `Name` | `i32` name-map index + `i32` number |
+| `Array` | `i32` count, then elements |
+| `Map` | `i32` NumToRemove (always 0), `i32` Num, then key/value pairs |
+| `Struct` | nested unversioned block (`FBlamVariant`, `FBlamCustomizationGlobalsTagDataIndices` only) |
+| `Bool` | one byte |
+| `Int`/`UInt32` | 4 bytes |
+| `SoftObjectPath` | three `FName`s (package, asset, sub-path) |
+
+Header rules:
+
+- fragment layout: `skip` = bits 0–6, `has_zeroes` = bit 7, `is_last` = bit 8,
+  `value_num` = bits 9+
+- **no zero mask** — not one tag export uses a has-zeroes fragment. Assert
+  rather than implement, so a future case surfaces loudly.
+- body frame: `[00 00 00 00] [fragments] [values] [00 00 00 00]` — both
+  4-byte pads are inside `cooked_serial_size`
+- max 5 fragments per export, 3.12 average
+- `DefaultAssetReference`, `BinaryBlobSize`, `NativeClass`,
+  `Permutations_EMPTY`, `ObjectTagDataAsset`, and model's `Variants`/
+  `RegionTable` are never emitted — the encoder reaches them only as skip counts
+
+Supporting work: `FNameMap::store` must fold a trailing `_<n>` back into
+`(base, number+1)` when the base is already interned (ordinary UE `FName`
+semantics; three model tags depend on it).
+
+**Gate 1.1** — re-encode all 12,291 shipped export bodies byte-for-byte.
+
+### 1.2 `iostore::tag_package::TagPackageBuilder`
+
+Synthesize a complete `.uasset` from `(package path, group, referenced packages,
+AssetReference, group-specific extras)`. Rules, all at 100% over the corpus:
+
+- `FPackageId` = `cityhash64` of the lowercased UTF-16LE package name
+- `public_export_hash` = same hash of the *object* (leaf) name
+- class / template = ScriptImport hashes of
+  `/Script/BlamSynchronization.Blam<Pascal(group)>TagDataAsset` and its
+  `Default__` form
+- exactly 3 script imports: class, CDO, and the module package
+  `/Script/BlamSynchronization`
+- one Null import slot per imported package
+- `imported_packages` sorted ascending by `FPackageId`, names parallel
+- `imported_public_export_hashes`: one entry per unique
+  `(imported_package_index, hash)` pair, in import-map first-use order
+- dependency bundle = exactly the property-referenced imports, ordered by
+  **reversed** usmap property order (base-class properties first)
+- name map = case-insensitively sorted unique property `FName` bases, then
+  object name, then package name
+- one export; one bulk entry with `flags = 66817`, `serial_size = len(.ubulk)`
+- flags: `0xb`/`0x80002200` for every group **except** `scenario`,
+  `scenario_structure_bsp`, `scenario_structure_lighting_info`,
+  `structure_design`, `structure_seams`, which use `0x1`/`0x88002200`
+  (`PKG_CookGenerated`)
+- package trailer `c1 83 2a 9e` after the export body
+
+**Gate 1.2a (byte-identity)** — parse each shipped package, rebuild it through
+the builder *reusing the parsed import order*, re-serialize: byte-identical for
+all 12,291. This proves the serializer and every derivation.
+
+**Gate 1.2b (semantic)** — build from the builder's own canonical import order,
+parse back, and assert identical resolved property targets, dependency set,
+identity hashes, flags and name map. Necessary because the cooker's import-map
+slot order is linker-derived and not reproducible; it does not need to be, since
+the array is only indexed from inside the package.
+
+---
+
+## Phase 2 — blam-tags: derivations and writer rewiring
+
+### 2.1 Group tables
+
+Derived from the corpus, **not** the usmap —
+`BlamFrameEventListTagDataAsset` ships 130 tags but is absent from both the usmap
+and the UHT dump, and must fall back to `BlamTagDataAssetBase`.
+
+- group → class name (mechanical `Blam<Pascal>TagDataAsset`)
+- group → wrapper base, which decides whether `AssetReference` applies and which
+  hash rule it uses
+- group → flag pair
+
+### 2.2 `CookedAssetsReferencedByTag`
+
+Walk the `TagFile`'s `tag_reference` fields (reuse the existing walker) and emit
+every ref that resolves to a package we ship or that exists in the base game.
+This is a superset of shipped behaviour and demonstrably safe — the cooker itself
+emits supersets on 34 tags and omits the array entirely on 124 others.
+
+Dangling references must **warn, not error**: 1,381 shipped reference instances
+already point at packages that do not exist.
+
+### 2.3 `AssetReference`
+
+Computable from the target package path alone — 6404/6404, no donor tag and no
+Blueprint parsing:
+
+- `TSubclassOf` groups (the 14 object groups plus `effect`):
+  `cityhash64("<PackageLeaf>_C")`
+- plain `UObject*` groups (`sound`, `sound_looping`, `sound_combiner`,
+  `cinematic`, `damage_response_definition`): `cityhash64("<PackageLeaf>")`
+
+### 2.4 `RuntimeVariants` (model)
+
+`{VariantName: variants[i].name, Permutations: {region.name →
+region.permutations[0] or "None"}}` — 407/408 exact. Only `RuntimeVariants`
+ships; `Variants` and `RegionTable` are never serialized. Without this, a variant
+edit in Baboon is invisible in-game.
+
+### 2.5 `BlamModelRegionStringTable` synthesis
+
+A second, much simpler package builder reusing 1.1/1.2 — the asset is 370 bytes,
+no bulk data, 3 script imports. Content: `Regions` from the model tag's variant
+regions (matches 278/364), `Permutations` from the **mesh-side** vocabulary that
+blam-tags already reads from the mesh-sync data (the tag's designated subset is
+*not* sufficient — `DA_Marine_Regions` carries 88 permutations shared across
+several models).
+
+### 2.6 Rewire the writer
+
+- `add_override_to_writer`: **rebuild** the wrapper from the edited blob rather
+  than copy-and-patch `serial_size`. Always reissue the `.uasset`, not only on a
+  size change — a reference edit changes the wrapper even when the blob length
+  does not.
+- `add_new_package_to_writer`: **build** rather than clone a template.
+- Preserve the existing `_P` suffix / `.pak` stub / priority behaviour, which is
+  already proven in-game.
+
+### 2.7 Robustness
+
+`FOL_MC_GearMove_Land-sound` ships with no `.ubulk` chunk at all despite
+declaring `serial_size = 4700`. Degrade gracefully on a missing bulk chunk rather
+than erroring.
+
+---
+
+## Phase 3 — In-game validation matrix
+
+Phase 0 covers the first new-package case. This is the full matrix; each row is
+one mod build.
+
+| # | Case | Currently |
+|---|---|---|
+| 1 | Same-size blob edit | **proven** (`marine-biped`) |
+| 2 | Size-changing blob edit (reissues the `.uasset`) | unproven |
+| 3 | New bare-group tag, referenced by an edited tag | Phase 0 |
+| 4 | New wrapper-bearing tag — object group with `AssetReference` = `BP_EmptyActor` | unproven |
+| 5 | New `model` tag with `RuntimeVariants` + a generated region table | unproven |
+| 6 | Override of a tag in a **non-pakchunk0** (per-level) pak | unproven |
+| 7 | A `_Generated_` group tag (`0x1`/`0x88002200` flags) | unproven |
+| 8 | Rename via package redirect | unproven |
+
+Row 6 matters because the only proven override lives in `pakchunk0`; chunk ids
+are global so it should be identical, but level tags are exactly where scenario
+editing will land.
+
+---
+
+## Phase 4 — Baboon
+
+### 4.1 Persistence for the Unreal-only values
+
+The single highest-risk piece, and textbook
+[unconsulted-state](../../.claude/projects) territory — a value written and never
+read. The layering:
+
+1. **Seed** from the tag's existing `.uasset` when it has one, so untouched tags
+   round-trip identically.
+2. **Override** in the workspace project file, keyed by tag path, for new tags
+   and user edits.
+3. **Fall back** to the group default.
+
+Every one of those three paths needs a test that asserts on the value the export
+actually emits, not on the value that was stored.
+
+### 4.2 Unreal binding panel
+
+Shown for CE container tags:
+
+- derived `CookedAssetsReferencedByTag` — read-only, with a count and which
+  entries are unresolved
+- `AssetReference` path field plus picker, for the 22 groups that have one. The
+  picker offers targets already used by tags of the same group (22 for `biped`,
+  29 for `projectile`, 257 for `crate`, …) plus free search over the package
+  index, pre-filled with `BP_EmptyActor` for object groups.
+- `effect`: `bSpawnPerInstance` checkbox
+- `model`: `ModelRegionStringTable` picker defaulting to
+  `/Game/Tags/objects/shared/RT_default_object_regions` (214 of 364 shipped model
+  tags use it), a "Generate region table…" action, and a read-only preview of the
+  derived `RuntimeVariants`
+- `player_model_customization_globals`: a small map editor. One tag in the game;
+  lowest priority.
+
+### 4.3 New Tag
+
+Drop the "needs a same-group template" restriction — all 139 defined groups
+become authorable, with the binding fields inline for the 22.
+
+### 4.4 Pre-export lint
+
+- new tags that nothing references (the silent-death case)
+- dangling references — **warn**
+- object-group tags with no `AssetReference`
+- model tags whose variants name regions absent from the chosen string table
+- new tags in the `_Generated_` groups (flag them; creating scenarios is
+  deferred)
+
+### 4.5 Export preview
+
+Extend the existing diff view to show wrapper changes, not just blob changes —
+otherwise the most consequential part of an export is invisible in review.
+
+---
+
+## Phase 5 — Loose ends
+
+None block; each touches at most 11 tags. Worth a pass once the trunk is
+working.
+
+1. The second extra script import on `player_model_customization_globals`
+   (`3870AE7534B9FC0D`) is unidentified. The first is
+   `/Script/GameplayTags.GameplayTag`.
+2. Why struct-typed properties sometimes need a `UScriptStruct` script import and
+   sometimes not — `FBlamVariant` gets none across 408 model tags,
+   `FGameplayTag` gets one. Matters only if a new group uses a struct property.
+3. The 122-vs-220 `squad_template` split (array absent vs present with identical
+   shape) — presumed cook non-determinism, unproven.
+4. Eleven `model_animation_graph` tags whose cooked array names a
+   *differently titled* `frame_event_list` (`plasma_rifle_red` →
+   `plasma_rifle`).
+5. The single `RuntimeVariants` outlier (`rocket_launcher_ammo` dropping `hits`).
+6. Why `FOL_MC_GearMove_Land-sound` ships with no `.ubulk`.
+
+---
+
+## Debug surface (opportunistic)
+
+The retail simulation DLL retains the Blam debug command set —
+`tag_is_active`, `dump_loaded_tags`, `tag_load_force`, `tag_unload_force`,
+`tag_reload_force`, and the `scenario_load_all_tags` global. Those would settle
+the load model directly, but everything reaches them through the single
+`CreateBlamEngineShell` vtable and the dispatch path is not established.
+
+The retail exe also ships ImGui and a Blam debug menu gated by
+`UDebugMenuSettings` (`Config=Game`, `DefaultConfig`), whose three `*Shipping`
+flags default false. A user-layer `Game.ini` override is worth trying:
+
+```ini
+[/Script/Meteorite.DebugMenuSettings]
+bEnableDebugMenuDefaultShipping=True
+bEnableDebugMenuReleaseShipping=True
+bEnableDebugMenuBetaShipping=True
+```
+
+placed beside the `HaloGlobalGameUserSettings.ini` the game already writes.
+Caveat: `UBlamDebugMenuWidget` looks like an object/tag-name inspector
+(`SetShowTagDebugNames`), not a command console, and `HaloImGuiUtils` is only a
+Blueprint wrapper around ImGui drawing primitives. Low expected value; not on
+the critical path.
+
+---
+
+## The Unreal side of an object — what is actually authorable
+
+The tag→Unreal binding is **bidirectional**, and only one direction was mapped
+in the sections above:
+
+- **tag → Unreal**: the object tag's `AssetReference` → a BP actor class
+  *(mapped, 6404/6404)*
+- **Unreal → tag**: the BP's `BlamMeshSynchronizationComponent` →
+  `BlamMeshSynchronizationDataAsset` → `ModelTag`, a hard reference **back** at a
+  model tag. 120/120 data assets carry one, hitting 116 distinct model tags.
+
+`BP_EmptyActor` — the recommended default for a new object tag — has **5
+exports, zero imported packages and nothing but a `DefaultSceneRoot`**. So a new
+object tag pointed at it is fully understood by the simulation and renders as
+nothing. Pointing at a real BP instead inherits that BP's geometry *and* its
+bound model tag.
+
+### Where the geometry actually lives
+
+`RuntimeRegions` is on the **component template inside the Blueprint**, not on
+the data asset. For `BP_BruteBipedActor` (51 exports, 71,776 bytes) it is
+export[0], `BlamMeshSynchronization_GEN_VARIABLE`, 2,704 bytes:
+
+```
+AnimationClass               = HARD import
+MeshSynchronizationDataAsset = HARD import
+RuntimeRegions = Map[region] -> { Permutations: Map[perm] -> {
+    SkeletalMeshes: [ { Asset: SOFT('/Game/Characters/Brute/Default/Mesh/SK_Brute'),
+                        Class: SOFT('/Game/Blueprints/CVW/BPC_SkeletalMesh'),
+                        MaterialOverrides: [], ComponentTags: [] } ],
+    StaticMeshes:   [ { Asset: SOFT('…/SM_Brute_Head_M_Default'), ParentBoneName, Transform, … } ] } }
+```
+
+**The mesh and component-class references are `FSoftObjectPath` — plain
+strings.** Only `AnimationClass` and `MeshSynchronizationDataAsset` are
+import-map entries.
+
+That means swapping an object's geometry is *rewriting strings in one export's
+property blob* — no import-map surgery, no Kismet, no new package. And the tool
+for it is the **same `write_export_struct` from Phase 1.1**; the tag work and
+the Unreal work share one encoder.
+
+### The capability ladder
+
+| Level | What it takes | Feasibility |
+|---|---|---|
+| Retexture / re-material | `MaterialOverrides` in `RuntimeRegions` (soft), or MIC parameter overrides | high — encoder only |
+| **Mesh swap on an existing object** | rewrite soft paths in the BP's component template | high — encoder only |
+| New object reusing existing behaviour | clone a BP package, repoint `MeshSynchronizationDataAsset` (hard import), rewrite `RuntimeRegions`, new mesh-sync DA, new model tag | medium — needs import-map editing on a cloned BP |
+| Genuinely new behaviour | Kismet bytecode (`BndEvt__…` UFunctions, delegate bindings) | out of reach |
+
+### Swept over all 335 mesh-sync packages
+
+- **336 components, 333 decoded** (3 failures, uninvestigated)
+- **Hard import refs: exactly 270, and only ever `AnimationClass` (139) and
+  `MeshSynchronizationDataAsset` (131). Nothing else.**
+- **Soft path refs: 10,078** — every mesh and component class, without exception
+- 146 components serialize `RuntimeRegions`; 187 leave it default (the FP and
+  cinematic variants, populated at runtime)
+- region counts run 1–64, median 1
+- exports per package: min 7, median 13, max 250
+
+### 188 of 335 have no Kismet at all
+
+Those are pure-data Blueprints. Their entire export composition is:
+
+```
+BlueprintGeneratedClass, SimpleConstructionScript, SCS_Node ×N,
+InheritableComponentHandler, the CDO, and component templates
+(SceneComponent, StaticMeshComponent, SkeletalMeshComponent,
+BlamMeshSynchronizationComponent, Niagara*, Blam*Component…)
+```
+
+The smallest is **7 exports / 2,637 bytes**
+(`BP_DeviceMover_DeviceMachineActor`); the Sentinel garbage actors are 8 exports
+/ ~3.5 KB.
+
+**A minimally viable actor Blueprint is therefore ~7 exports of pure property
+data and no bytecode — synthesizable with the same encoder and package builder
+as everything else.** That raises the ceiling from "new tags reusing an existing
+actor" to **new objects with new geometry, authored end to end**:
+
+1. new model tag (+ collision / physics / skeleton / animation tags)
+2. new `BlamMeshSynchronizationDataAsset` — one property, `ModelTag`
+3. new Kismet-free BP — 7–13 data exports, `RuntimeRegions` pointing at meshes
+   by soft path
+4. the object tag's `AssetReference` → the new BP class
+
+Only actors needing *new behaviour* (the 147 packages that do carry
+`BndEvt__…` UFunctions) remain out of reach.
+
+---
+
+## Blocking bug found in `Usmap::flattened_properties`
+
+`flattened_properties` walks derived→base and concatenates each struct's own
+properties sorted by `schema_index`. It **ignores `array_dim`**. A static-array
+property occupies `array_dim` *consecutive schema slots*, so any class
+containing one has every subsequent property mis-indexed, and the
+unversioned reader desyncs.
+
+`MaterialInstance::PhysicalMaterialMap` has `array_dim = 8`, which is exactly
+why `Parent` sits at `schema_index 9` and why every
+`MaterialInstanceConstant` fails to decode with
+`MaterialParameterInfo: present schema index N beyond 3 props`.
+
+**Verified rule** — expanding each property `array_dim` times, rebasing per
+struct in the chain, makes position == `schema_index` for **10,647 of 10,647
+classes in the usmap, zero exceptions.**
+
+Why the tag work never hit it: every property on every `Blam*TagDataAsset` has
+`array_dim = 1`, so the flattening is accidentally correct there — which is why
+all 12,291 tags decode. The bug is invisible until a class uses a static array.
+
+**Impact:** `MaterialInstanceConstant` (5,764 packages) and `Material` (1,397)
+currently cannot be decoded at all. Fix this before any material work.
+
+**Fixed.** Both classes now decode completely — see the coverage report below.
+
+## Asset anatomy — measured so far
+
+### `Texture2D` — 5,524 packages, 5,524 decoded, 0 failed
+
+15 properties total, all simple: `ImportedSize` and `LightingGuid` (native),
+`CompressionSettings`, `LODGroup`, `Filter`, `LODBias`, `AddressX`/`AddressY`,
+`Availability`, `MipLoadOptions` (ints), `SRGB`, `VirtualTextureStreaming`,
+`NeverStream` (bools), `AssetUserData`, `Downscale`.
+
+**Only 13 hard refs in the entire set (all `AssetUserData`), and zero soft
+refs.** Bulk entries run 1–3 for a normal texture (mip streaming levels).
+
+The property block is tiny — median 874 bytes — but export sizes reach 16 MB,
+because `UTexture2D::Serialize` writes `FTexturePlatformData` (pixel format, mip
+descriptors, inline mips) *after* the property block as native serialization the
+usmap does not describe. **That structure is the remaining work for texture
+authoring**; the reflected properties are trivial.
+
+## Coverage report — measured 2026-07-28
+
+Produced by `ce_coverage_matrix 1`, which decodes **every export of every
+package** in the shipped paks and tallies per class. Run it at threshold `1`;
+a higher min-exports argument hides the small failing classes and makes the
+remainder look far shorter than it is.
+
+Corpus: **103,867 packages**, 54,825 script objects resolved, 322,300
+identifiers read out of the shipped executable.
+
+Note the unit change from earlier tables in this document: these are **export
+occurrences**, not packages containing one.
+
+| | share | count |
+|---|---|---|
+| runtime native-class exports | — | **1,153,834** |
+| property block decodes | **99.9944 %** | 1,153,769 (65 fail) |
+| every byte accounted for | **99.96 %** | 1,153,425 |
+| never attempted | — | 0 |
+
+That byte figure was 99.43 % at the start of this session; the layout fixes
+listed below account for the 6,189-export difference. Measured in *bytes* rather
+than exports the change is far larger — the unread total fell from roughly
+1.02 GB to **156 MB** — of which 151 MB is a single class.
+
+Plus **89,762** Blueprint-class exports, which have no native schema and decode
+via their class package, and **153** editor-only exports the shipped runtime
+cannot construct (`BlamFrameEventListTagDataAsset` 130, `PerfToolTextBox` 17,
+two `HLODBuilder*` settings, two more `PerformanceOverlayTool` shims). These are
+correctly excluded from the runtime denominator — they are cooker leftovers,
+written by an editor that had those plugins loaded, and their names appear in no
+shipped binary in either encoding.
+
+### Classes this document previously called blocked
+
+| Class | Exports | Decoded | Bytes complete |
+|---|---|---|---|
+| `Material` | 1,397 | 1,397 | **all** |
+| `MaterialInstanceConstant` | 7,852 | 7,852 | **all** |
+| `Texture2D` | 14,237 | 14,237 | **all** |
+| `AnimSequence` | 14,130 | 14,130 | **all** |
+| `StaticMesh` | 15,231 | 15,231 | **all** |
+| `BodySetup` | 17,754 | 17,754 | **all** |
+| `World` / `Level` | 14,240 each | all | **all** |
+| `PhysicsAsset` | 96 | 96 | **all** |
+| `SkeletalMesh` | 415 | 415 | **all** |
+| `Skeleton` | 128 | 128 | **all** |
+
+The `array_dim` bug and the native-struct sizing that blocked `StaticMesh`
+(`MeshUVChannelInfo: present schema index 3 beyond 3 props`) and `SkeletalMesh`
+(`implausible array count 1017370378`) are both resolved. `StaticMesh` is
+complete through `FStaticMeshRenderData` including Nanite, and `SkeletalMesh`
+is now complete through `FSkeletalMeshRenderData` — every byte of all 415.
+
+**`MaterialInstanceConstant` authoring surface** (unchanged, still the point):
+`Parent`, `ScalarParameterValues`, `TextureParameterValues`,
+`VectorParameterValues`, `BasePropertyOverrides`, `StaticParametersRuntime`.
+The refs are **all hard imports and zero soft**, so **retexturing a material
+requires import-map surgery** — unlike a mesh swap on a mesh-sync component,
+which is soft paths only. Two different authoring mechanisms.
+
+### Closed this session — the `UStruct` chain and six native tails
+
+All verified against UE `5.5.4-release` source, then corpus-gated: every class
+below went to **zero** remaining tails with **zero** new decode failures.
+
+| Class | Tails closed | What it actually was |
+|---|---|---|
+| `Function` | 897 | see below |
+| `NiagaraSpriteRendererProperties` | 918 | `FSubUVDerivedData` = one `TArray<FVector2f>` of cutout geometry |
+| `SkeletalMesh` | 415 | the whole `FSkeletalMeshRenderData` — see below |
+| `TextureCube` / `VolumeTexture` / `Texture2DArray` | 58 | share `SerializeCookedPlatformData`; **only `UTexture2D` writes the `bSerializeMipData` flag**, so the existing `SkipOffset` skip transferred once parameterised — 179 MB |
+| `StaticMesh` | 1 | not a layout bug: `FRawStaticIndexBuffer` stores indices as **single-byte** elements, so a 1024×1024 plane's count of 25,165,824 tripped a flat 10 M plausibility ceiling. Bounding array counts by the bytes actually remaining is both correct here and tighter everywhere else — 75 MB |
+| `PhysicsAsset` | 49 | `CollisionDisableTable`, a `TMap<FRigidBodyIndexPair, bool>` at 12 bytes per entry |
+| `StringTable` | 29 | `FStringTable::Serialize` — namespace, key/source `FString` pairs, then a per-key meta-data map |
+| `SkyAtmosphereComponent` | 17 | `bStaticLightingBuiltGUID`, 16 bytes |
+| `AkStateValue` / `AkSwitchValue` / `AkRtpc` / `AkAuxBus` / `AkInitBank` | 178 | each appends its Wwise cooked-data struct as a property block — **no plugin source needed, the usmap describes them all** |
+| `RecastNavMesh` | 13 | a version and a byte count the loader seeks past |
+| `ModelComponent` | 17 | `Model`, the elements, then `ComponentIndex` + node list |
+| `PCGMetadata` | 63 of 123 | typed attribute table; see below |
+| `DNAAsset` | 21 | two embedded RigLogic DNA streams — **91 MB**, see below |
+| `NiagaraScript` | 17,674 | the cooked GPU shader maps — see below |
+| `InstancedFoliageActor` | 238 | `FoliageInfos` map: key ref, `uint8 EFoliageImplType`, and for `StaticMesh` one component ref |
+| `Skeleton` | 128 | `FReferenceSkeleton` + retarget sources + `Guid` + empty smart-name map + `FStripDataFlags` |
+| `WorldPartition` | 72 | cooked flag, then the streaming-policy ref |
+| `UserDefinedEnum` | 64 | `UEnum`'s `Names` (`FName` + `int64` each) then a `uint8 CppForm` |
+| `FontFace` | 37 | cooked flag + inline-data flag (CE ships every face out of line) |
+| `BlueprintGeneratedClass` etc. | 67 | rode along on the `UStruct` fix |
+
+**`Function` was three separate `FProperty` layout bugs, not a padding
+problem.** The `Struct` arm used to *probe* several word offsets for the field
+count, which silently accepted a wrong parse whenever the real one failed — so
+the reader reported a bogus decoded prefix instead of a tail, and hid all three:
+
+- `FEnumProperty::Serialize` writes `Enum` **before** the underlying property.
+  We read them the other way round, so the nested field's type-name `FName`
+  landed on a negative package index.
+- `FClassProperty` adds a `MetaClass` after `FObjectPropertyBase`'s
+  `PropertyClass` — two references, not one. Same for `FClassPtrProperty`.
+- `FSoftClassProperty` likewise adds `MetaClass` on top of `FSoftObjectProperty`.
+
+With those fixed, `UStruct::Serialize` reads straight through with no padding
+anywhere: `SuperStruct`, `TArray<UField*> ChildArray`, `SerializeProperties`
+(an `int32` count then that many `FField`s), then the Kismet script.
+
+The probing is now gone, so a layout error surfaces as a tail instead of a
+plausible-looking wrong answer. **Do not reintroduce offset probing here** — it
+cost roughly a thousand exports of silent mis-parse.
+
+### `SkeletalMesh` — the deepest walk in the reader
+
+`USkeletalMesh::Serialize` is strip flags, a 56-byte `FBoxSphereBounds`, the
+`FSkeletalMaterial` list, the `FReferenceSkeleton`, a cooked flag, and then the
+entire `FSkeletalMeshRenderData`: every LOD's sections, then either the inlined
+buffer set (`SerializeStreamedData`) or a `.ubulk` header plus
+`SerializeAvailabilityInfo`, then `FNaniteResources`, then two `uint8` counts.
+Four details cost real time and are worth keeping:
+
+- **`FStripDataFlags` bit 0 is `EditorOnly`, bit 1 is `AudioVisual`.** Every
+  client cook sets bit 0, so testing it as "audio-visual stripped" silently
+  skips all render data. The observed value is `5`.
+- **Two array conventions sit side by side.** Vertex payloads reached through
+  `TStaticMeshVertexData::Serialize` use `BulkSerialize` — an element size *and*
+  a count. Members reached through a plain `Ar <<` (`SourceRayTracingGeometry
+  .RawData`, `MorphData`, both half-edge buffers, the skin-weight profile
+  arrays) are a bare count. Reading one as the other drifts by four bytes per
+  array and shows up hundreds of bytes later.
+- **`NumInlinedLODs`/`NumNonOptionalLODs` are `uint8`,** not `int32`.
+- **`bHasVertexColors` and `bEnablePerPolyCollision` are reflected properties
+  that gate native layout** — the tail reader takes them from the decoded
+  property block rather than probing.
+
+### `NiagaraScript` — the "deep one" was walkable after all
+
+This was recorded across two earlier sessions as the one part of the corpus with
+no tractable path: `FNiagaraShaderScript::SerializeShaderMap` →
+`FShaderMapBase::Serialize` → `FMemoryImageResult::LoadFromArchive`, ending in a
+**frozen memory image** — a raw dump of C++ objects whose layout depends on
+target-platform pointer size and alignment. The earlier note also established
+that Niagara does *not* use `FMaterialResourceProxyReader`, so the `NumBytes`
+skip that works for materials does not transfer.
+
+All true, and all beside the point. **Nothing in it needs interpreting.** The
+frozen image is length-prefixed (`FrozenSize`), the shader bytecode is two
+length-prefixed `FSharedBuffer`s, and every table between them is a plain count.
+The full walk:
+
+```
+int32 ResourceCount, then per resource:
+  bCooked, NumPermutations, BaseCompileHash (count + bytes)
+  bValid                                    -- a cooked resource may have none
+  FPlatformTypeLayoutParameters             -- 8 bytes
+  FrozenSize + that many opaque bytes
+  pointer table: type dependencies (32 B each: FName + size + FSHAHash),
+                 shader + vertex-factory type names (FHashedName, 8 B each),
+                 then Niagara's own data-interface class names (FStrings)
+  NumVTables / NumScriptNames / NumMemoryImageNames, counted up front,
+                 then their three patch tables
+  bShareCode, ShaderPlatformName
+  bShareCode ? FSHAHash : FShaderMapResourceCode
+                 (ResourceHash, shader hashes, then per shader two
+                  uint64-prefixed buffers: header and code)
+```
+
+One thing is genuinely Niagara-specific and easy to miss: it subclasses the
+pointer table as `FNiagaraShaderMapPointerTable`, which appends its
+**data-interface class names as `FString`s** after the base class's hashed type
+names. Without that the walk desyncs a few hundred bytes later, deep inside the
+patch tables, where the failure looks nothing like its cause.
+
+All 17,674 exports now account for every byte. The lesson is worth keeping: *"the
+payload is opaque" and "the structure is opaque" are different claims*, and only
+the second one blocks a byte-accounting reader.
+
+### `DNAAsset` — a foreign, big-endian container with no length
+
+`UDNAAsset::Serialize` embeds **two** RigLogic DNA streams back to back
+(behavior, then geometry). The DNA container is not UE serialization at all:
+a three-byte `DNA` signature, a generation/version pair, a section table, then
+the sections — and **every scalar in it is big-endian**. Nothing records a
+stream's total length.
+
+Two header shapes ship in CE, and the mix is what makes this work:
+
+- **generation 2 version 5** — a `uint32` section count then 16-byte entries
+  (`desc`, `defn`, `bhvr`, `geom`, `mlbh`, `rbfb`, `rbfe`, `jbmd`, `twsw`), each
+  with an offset *and a size*. The stream's end is the furthest section end.
+  Verified: the index ends at exactly the first section's offset.
+- **generation 2 version 1** — eight bare `uint32` offsets, **no sizes**. Its own
+  bytes cannot give its length.
+
+The version-1 boundary is still derivable rather than guessed. `UDNAAsset` is the
+last class in its chain, so the *second* stream must end exactly at the end of
+the export — and in every version-1 asset that second stream is a version-5
+geometry stub. So the split point is the unique later `DNA` signature whose own
+sized index lands precisely on the export end. Searching for a magic byte pattern
+would be a heuristic; requiring it to close the export exactly is a constraint.
+
+All 21 assets resolve. These are the MetaHuman head rigs, so this reader is worth
+more than its coverage share — it is the entry point to the DNA data behind the
+existing CE head extraction, not just a way to skip 91 MB.
+
+**`SK_Manny` — a missing trailing field, 400 KB downstream.** The last mesh to
+resolve failed *before* any of the above ran: its 768 KB `SamplingInfo` property
+block ended in the wrong place, so the `UObject` `hasGuid` trailer read `10` and
+the class chain stopped before `USkeletalMesh::Serialize`. The cause was one
+omitted array. `FSkeletalMeshSamplingRegionBuiltData` sets `WithSerializer` and
+its hand-written serializer writes:
+
+```
+Ar << TriangleIndices;  Ar << BoneIndices;  AreaWeightedSampler.Serialize(Ar);
+if (CustomVer(FNiagaraObjectVersion) >= SkeletalMeshVertexSampling) Ar << Vertices;
+```
+
+`Vertices` comes **last**, after the sampler — not in declaration order, where it
+sits between the triangle and bone arrays — and it is version-gated, so it reads
+as optional. The reader stopped at the sampler, leaving every region element
+short by `4 + 4 * NumVertices`. All 415 skeletal meshes now account for every
+byte.
+
+`BLAM_TAIL_WHY=1` narrates this walk stage by stage and hexdumps around any
+bail — the tail is far too deep to diagnose by reasoning about the schema.
+
+### What is left — 409 exports (0.035 %), 156 MB
+
+**344 unmodeled native tails:**
+
+| Class | Tails | Bytes | Note |
+|---|---|---|---|
+| `UserDefinedStruct` | 117 | 4.7 KB | its default instance via `SerializeItem` — needs the struct's own field chain as a schema |
+| `DataTable` | 77 | 82 KB | each row is a property block in the table's row struct |
+| `PCGMetadata` | 60 | 2.1 MB | 63 of 123 now decode; the rest leave a trailing run of `-1` entry keys not yet accounted for |
+| `SoundWave` | 27 | 4 KB | |
+| `GeometryCollection` | 14 | **151 MB** | the Chaos port — see above |
+| `MorphTarget` / `CompositeDataTable` | 11 each | small | |
+| ~20 more classes | 1–6 each | | `VectorFieldStatic`, `Model`, `OptimusComputeGraph`, `DynamicMesh`, `RigVMMemoryStorageGeneratorClass`, sound nodes … |
+
+**`GeometryCollection` is 97 % of the remaining bytes and everything else
+together is under 5 MB.** By exports the work is now dominated by three
+schema-driven cases — `UserDefinedStruct`, `DataTable` and `CompositeDataTable`
+(205 exports) all need the *same* missing capability: walking a property block
+against a struct schema that comes from the package rather than the usmap. That
+is one piece of machinery, not three.
+
+**65 decode failures,** the complete list:
+
+| Class | Failed / seen |
+|---|---|
+| `PCGGraphInstance` | 28 / 43 |
+| `LandscapeGrassType` | 10 / 15 |
+| `PCGGraph` | 7 / 19 |
+| `Font` | 6 / 6 |
+| `OptimusKernelSource` | 3 / 3 |
+| `StaticMeshComponent` | 3 / 126,158 |
+| `BlamMeshSynchronizationComponent` | 3 / 358 |
+| `NiagaraComponent` | 2 / 16,403 |
+| `RigVM` | 1 / 1 |
+| `MovieSceneSkeletalAnimationSection` | 1 / 5 |
+| `HaloUINumericTextBlock` | 1 / 43 |
+
+`PCGGraphInstance`/`PCGGraph` are one cause (`InstancedPropertyBag`), `Font` is
+`FontData`, and the three `StaticMeshComponent` failures are a `FColorVertexBuffer`
+in a component LOD. The `BlamMeshSynchronizationComponent` and `NiagaraComponent`
+outliers are long-standing and verified *not* truncated.
+
+A further 19 failures exist in `PerformanceOverlayTool` classes and are **not**
+counted in the 65 — those classes are editor-only, no schema for them exists in
+the usmap or in any public source, and the shipped game cannot construct them.
+They are permanently unreachable and that is correct.
+
+---
+
+## Explicitly out of scope
+
+Named so they are decisions rather than oversights. None block tag authoring.
+
+- **New Unreal assets** — Blueprints, skeletal meshes, materials, textures.
+  Textures and material-instance parameters are tractable with the same
+  machinery and are the obvious follow-on; Blueprints and meshes realistically
+  need the UE 5.5.4 editor plus `retoc to-zen`.
+- **Creating new scenarios** — different flags, level-pak resident, and every
+  scenario is imported by nothing. Editing existing ones is in scope.
+- **New audio** — the Wwise path, separately established as feasible, unbuilt.
+- **Whether CE's engine-class layouts diverge from stock UE 5.5.4** — only
+  matters for the excluded editor-cooking path. Checkable by diffing against a
+  stock 5.5.4 usmap.
+
+---
+
+## Dependency order
+
+```
+Phase 0  spike                        (no dependencies, no new code)
+   │
+Phase 1  1.1 encoder ──► 1.2 builder  (gates 1.1, 1.2a, 1.2b)
+   │
+Phase 2  2.1 tables
+         2.2 CookedAssets  ──┐
+         2.3 AssetReference ─┼──► 2.6 writer rewiring
+         2.4 RuntimeVariants ┤
+         2.5 region tables ──┘
+         2.7 robustness
+   │
+Phase 3  in-game matrix rows 2, 4–8
+   │
+Phase 4  4.1 persistence ──► 4.2 panel ──► 4.3 New Tag ──► 4.4 lint ──► 4.5 preview
+   │
+Phase 5  loose ends
+```
+
+Phase 0 gates everything: a negative result there changes Phase 2.6 and adds a
+registration step, but leaves Phases 1, 2.1–2.5 and 4 untouched.
+
+### Remaining class sweep (measured)
+
+| Class | Sampled | Decoded | Finding |
+|---|---|---|---|
+| `AkAudioEvent` | 3,000 | 3,000 | **zero reflected properties** — pure native serialization; already handled by `iostore/wwise_event.rs` |
+| `World` (`.umap`) | 400 | 400 | the `UWorld` export is 18–22 bytes, 1 property. The level's content is the *other* exports (median 30, max 2,232 per package) — actors and components. Covering levels means covering that class long tail, not `UWorld`. |
+| `LevelSequence` | 121 | 52 | hard refs `MovieScene`, `CompiledData`, `Signature`; 69 fail |
+| `NiagaraSystem` | 400 | 0 | native serialization throughout |
+
+### Classes requiring native-format work (not reflected properties)
+
+Each is a separate reverse-engineering effort, listed so the scope is explicit:
+
+- `FTexturePlatformData` — pixel format, mip descriptors, inline/bulk mips
+- `FStaticMeshRenderData` / `FSkeletalMeshRenderData` — vertex/index buffers
+  (partially covered by `iostore/static_mesh.rs`, `skeletal_mesh.rs`,
+  `nanite.rs`)
+- Niagara system/emitter/script serialization
+- `MovieScene` evaluation data
+- Wwise `.bnk`/`.wem` (already covered by the audio module)
+
+Plus the reflected-property blockers: the `native_struct_size` additions needed
+for `StaticMesh` (`MeshUVChannelInfo`) and `SkeletalMesh`.

--- a/docs/campaign-evolved-tag-packages.md
+++ b/docs/campaign-evolved-tag-packages.md
@@ -1,0 +1,553 @@
+# Campaign Evolved tag packages — complete specification
+
+Every rule here was measured against all **12,291** shipped tag packages in
+`Meteorite/Content/Paks` (build `2026.06.26.1097863-Release`, UE 5.5.4), the
+UHT header dump, and the shipped `.usmap`. Percentages are exact counts, not
+estimates. Where a rule is not 100%, the exceptions are enumerated and
+explained.
+
+Ground-truth extractor: `blam-tags/examples/ce_tag_ground_truth.rs` (one JSON
+record per tag). All other `ce_*` probes referenced below live alongside it.
+
+---
+
+## 1. What a tag is
+
+A CE tag is **two chunks of one UE IoStore package**:
+
+| Chunk | Contents |
+|---|---|
+| `.uasset` (`ExportBundleData`, index 0) | a Zen package header + one export: a `UBlam<Group>TagDataAsset` |
+| `.ubulk` (`BulkData`, index 0) | the byte-complete Reach-format tag blob |
+
+The simulation runs off the blob. The `.uasset` exists to give the blob a UE
+identity, to hold hard references so its dependencies are preloaded, and (for
+22 groups) to bind the tag to an Unreal asset.
+
+---
+
+## 2. Derivation rules — all 100% over 12,291 tags
+
+Given a Halo tag path `objects\characters\spartans\spartans` and group `biped`:
+
+| Field | Rule | Verified |
+|---|---|---|
+| package name | `/Game/Tags/objects/characters/spartans/spartans-biped` | — |
+| `FPackageId` | `cityhash64(lowercase UTF-16LE package name)` | 12291/12291 |
+| export object name | `spartans-biped` (the leaf) | 12291/12291 |
+| `public_export_hash` | `cityhash64(lowercase UTF-16LE object name)` | 12291/12291 |
+| `class_index` | ScriptImport hash of `/Script/BlamSynchronization.Blam<PascalCase(group)>TagDataAsset` | 12291/12291 |
+| `template_index` | same, `Default__` prefixed | 12291/12291 |
+| `.uasset` chunk id | `(package_id, 0, ExportBundleData=1)` | — |
+| `.ubulk` chunk id | `(package_id, 0, BulkData=2)` | — |
+
+`PascalCase` splits on `_` and upper-cases each initial: `frame_event_list` →
+`BlamFrameEventListTagDataAsset`. This holds for all 101 shipped groups.
+
+> `BlamFrameEventListTagDataAsset` exists in the game but is **absent from both
+> the UHT dump and the `.usmap`**. Decode/encode it as `BlamTagDataAssetBase`.
+> Do not derive the group→class table from the usmap.
+
+### Structural constants (no exceptions in 12,291)
+
+- exactly **1 export**; `outer_index`, `super_index` both Null
+- exactly **1 bulk-data map entry**, `flags = 66817` (`0x10501`),
+  `serial_offset = 0`, `duplicate_serial_offset = -1`,
+  `serial_size = len(.ubulk)`
+- `is_unversioned = true`
+- export bundle entries: `[Create(0), Serialize(0)]`
+- exactly **1** dependency-bundle header, always
+  `(0, 0, N, 0)` — every dependency is `create_before_serialize` — and
+  `N == len(dependency_bundle_entries)`
+- 4-byte trailer after the export body: `c1 83 2a 9e` (`PACKAGE_FILE_TAG`)
+- 0 shader map hashes, 0 cell imports/exports
+
+### Flags — three variants, not one
+
+| `object_flags` | `package_flags` | Count | Applies to |
+|---|---|---|---|
+| `0xb` | `0x80002200` | 9,416 | the default for every group |
+| `0x3` | `0x80002200` | 2,563 | 2,562 `sound` + 1 `ai_mission_dialogue` |
+| `0x1` | `0x88002200` | 312 | **all** `scenario`, `scenario_structure_bsp`, `scenario_structure_lighting_info`, `structure_design`, `structure_seams` |
+
+`0x80002200` = `PKG_FilterEditorOnly | PKG_UnversionedProperties | PKG_Cooked`.
+The extra `0x08000000` is `PKG_CookGenerated` — those 312 are the `_Generated_`
+level tags and they live in per-level paks, never `pakchunk0`.
+`0xb` = `RF_Public|RF_Standalone|RF_Transactional`; `0x3` drops
+`RF_Transactional`, which is inert in a cooked build. Only `sound` and
+`ai_mission_dialogue` are mixed — **use `0xb`/`0x80002200` for everything
+except the five `_Generated_` groups.**
+
+### Import map
+
+Every tag has exactly **3 script imports**: the class, its `Default__` CDO, and
+the module package `/Script/BlamSynchronization` (hash `24D5BCDF3D9D342`).
+Verified 12,290/12,291 — the sole exception is
+`player_model_customization_globals`, which has 5.
+
+Beyond that, per imported package the cooker emits **one `Null` slot** (the
+`UPackage` itself) plus one `PackageImport` slot per imported export.
+`sum(null slots) == sum(len(imported_package_names))` = **25,476/25,476**.
+
+Ordering rules, all **8733/8733** over tags that have imports:
+
+- `imported_packages` is sorted **ascending by `FPackageId`**, and
+  `imported_package_names[i]` is the name hashing to `imported_packages[i]`
+- `imported_public_export_hashes` has **one entry per unique
+  `(imported_package_index, hash)` pair**, in import-map first-use order.
+  Deduping by hash alone is wrong and costs 8 bytes per collision.
+
+The **import-map slot order itself is the cooker's and is not reproducible** —
+it interleaves script/package/null slots in linker order. It does not need to
+be: the array is only indexed from inside the package (export properties and
+dependency-bundle entries), so any self-consistent order loads identically.
+See §7 for what this means for the test gates.
+
+Of 92,006 total import slots, 25,266 are named by the export's properties,
+25,476 are the Null package slots, 36,875 are the 3 script imports, and **4,389
+are vestigial** — package imports that no property and no dependency entry
+references (BP sub-objects, all in the 12 object-ish groups). They are cook
+residue and are safe to drop.
+
+### Dependency bundle
+
+The entries are **exactly the imports the export's properties reference** —
+25,266 == 25,266 corpus-wide, and per-tag **12,291/12,291**.
+
+Their **order** is the *reversed* usmap property order — base-class properties
+first, then derived. So `CookedAssetsReferencedByTag` entries come first, then
+`AssetReference` / `ModelRegionStringTable`. Verified **1089/1089** on tags with
+two or more object-valued properties (on single-property tags both orders
+coincide).
+
+### Name map
+
+`names = sort_case_insensitive(unique FName base names used by the export's
+properties) + [object name, package name]` — **12,288/12,291**.
+
+The 3 exceptions are `FName` *numbers*: `default` and `default_0` are one
+name-map entry with `number` 0 and 1. A writer must fold a trailing `_<n>` back
+into `(base, number+1)` when `base` is already present, which is ordinary UE
+`FName` semantics. `FSoftObjectPath` package/asset/sub strings are FNames too
+and participate in the map (this is what makes
+`player_model_customization_globals` a 71-name outlier).
+
+---
+
+## 3. The wrapper's property surface — all of it
+
+Of the 178 declared `Blam*TagDataAsset` classes, **only 9 add any property at
+all**. Everything else is bare `BlamTagDataAssetBase`.
+
+| Class | Properties |
+|---|---|
+| `BlamTagDataAssetBase` (universal) | `CookedAssetsReferencedByTag: TArray<UBlamTagDataAssetBase*>`, `BinaryBlobSize: uint32` (Transient) |
+| `BlamObjectTagDataAsset` | `AssetReference: TSubclassOf<ABlamObjectActor>`, `DefaultAssetReference` (Transient) |
+| `BlamBaseEffectTagDataAsset` | `AssetReference`, `bSpawnPerInstance: bool`, `DefaultAssetReference` (Transient) |
+| `BlamBaseSoundDefinitionTagDataAsset` | `AssetReference: UObject*`, `DefaultAssetReference` (Transient) |
+| `BlamBaseLoopingSoundTagDataAsset` | same |
+| `BlamBaseSoundCombinerTagDataAsset` | same |
+| `BlamCinematicTagDataAsset` | same |
+| `BlamDamageResponseDefinitionTagDataAsset` | same |
+| `BlamModelTagDataAsset` | `ModelRegionStringTable: UBlamModelRegionStringTable*`, `RegionTable: TArray<FName>`, `Permutations_EMPTY` (Transient), `Variants: TArray<FBlamVariant>`, `RuntimeVariants: TArray<FBlamVariant>`, `ObjectTagDataAsset` (Transient) |
+| `BlamPlayerModelCustomizationGlobalsTagDataAsset` | `CustomizationDataTables: TMap<SoftObject,SoftObject>`, `CustomizationIndicesLookup: TMap<GameplayTag,FBlamCustomizationGlobalsTagDataIndices>` |
+
+**Never serialized** anywhere in the corpus — a builder must not emit them:
+`BinaryBlobSize`, `DefaultAssetReference`, `Permutations_EMPTY`,
+`ObjectTagDataAsset`, and on `model` both `Variants` (0/451) and `RegionTable`
+(0/451). Only `RuntimeVariants` ships.
+
+### Per-group breakdown
+
+**47 bare groups** (wrapper carries nothing at all):
+
+`achievements`, `ai_dialogue_globals`, `camera_fx_settings`, `camera_shake`,
+`camera_track`, `camo`, `chud_animation_definition`,
+`chud_widget_placement_data_template`, `chud_widget_render_data_template`,
+`chud_widget_state_data_template`, `cinematic_transition`, `collision_damage`,
+`collision_model`, `color_table`, `coop_spawning_globals_definition`,
+`encounter_remix`, `formation`, `game_engine_settings_definition`,
+`game_medal_globals`, `game_performance_throttle`, `grounded_friction`,
+`havok_collision_filter`, `incident_globals_definition`,
+`megalo_string_id_table`, `megalogamengine_sounds`,
+`multilingual_unicode_string_list`, `multiplayer_object_type_list`,
+`physics_model`, `rain_definition`, `rumble`,
+`scenario_structure_lighting_info`, `shader`, `shield_impact`,
+`simulated_input`, `simulation_interpolation`, `skeleton_model`,
+`sound_classes`, `sound_dialogue_constants`, `sound_global_propagation`,
+`sound_mix`, `sound_radio_settings`, `spring_acceleration`, `structure_design`,
+`structure_seams`, `style`, `text_value_pair_definition`,
+`water_physics_drag_properties`
+
+**54 wrapper-bearing groups.** 32 carry only `CookedAssetsReferencedByTag`.
+The 22 that carry more:
+
+| Group | Tags | Wrapper fields present |
+|---|---|---|
+| `biped` | 32 | AssetReference 27, CookedAssets 31 |
+| `crate` | 292 | AssetReference 267, CookedAssets 290 |
+| `creature` | 2 | AssetReference 2, CookedAssets 1 |
+| `device_control` | 20 | AssetReference 19, CookedAssets 19 |
+| `device_machine` | 63 | AssetReference 63, CookedAssets 61 |
+| `device_terminal` | 2 | AssetReference 2, CookedAssets 1 |
+| `effect_scenery` | 4 | AssetReference 1, CookedAssets 3 |
+| `equipment` | 20 | AssetReference 15, CookedAssets 19 |
+| `giant` | 1 | AssetReference 1 |
+| `projectile` | 61 | AssetReference 34, CookedAssets 60 |
+| `scenery` | 30 | AssetReference 27, CookedAssets 20 |
+| `sound_scenery` | 2 | AssetReference 2 |
+| `vehicle` | 25 | AssetReference 22, CookedAssets 24 |
+| `weapon` | 75 | AssetReference 49, CookedAssets 74 |
+| `effect` | 884 | AssetReference 100, CookedAssets 459, **bSpawnPerInstance 5** |
+| `sound` | 5895 | AssetReference 5595 |
+| `sound_looping` | 163 | AssetReference 123, CookedAssets 142 |
+| `sound_combiner` | 2 | AssetReference 1, CookedAssets 1 |
+| `cinematic` | 45 | AssetReference 45, CookedAssets 44 |
+| `damage_response_definition` | 155 | AssetReference 9, CookedAssets 153 |
+| `model` | 451 | CookedAssets 451, **RuntimeVariants 408, ModelRegionStringTable 364** |
+| `player_model_customization_globals` | 1 | CustomizationDataTables, CustomizationIndicesLookup |
+
+An absent property means "class default" (null / empty), which is legal
+everywhere — e.g. 784 of 884 `effect` tags and 300 of 5,895 `sound` tags have
+no `AssetReference` at all.
+
+---
+
+### The complete type surface a property writer must cover
+
+Every value in every tag export across the corpus, exhaustively:
+
+| Kind | Instances | Appears in |
+|---|---|---|
+| `Object` (`FPackageIndex` i32) | 25,266 | `AssetReference`, `CookedAssetsReferencedByTag`, `ModelRegionStringTable` |
+| `Name` (`FName`) | 4,445 | `RuntimeVariants`, `CustomizationIndicesLookup` |
+| `Array` | 3,457 | `CookedAssetsReferencedByTag`, `RuntimeVariants` |
+| `Struct` | 754 | `FBlamVariant`, `FBlamCustomizationGlobalsTagDataIndices` |
+| `Map` | 682 | `FName→FName`, `FGameplayTag→struct` |
+| `Int` | 74 | `CustomizationIndicesLookup` |
+| `SoftObjectPath` | 16 | `CustomizationDataTables` |
+| `Bool` | 5 | `bSpawnPerInstance` (all `true`) |
+
+That is the whole surface — seven kinds. No float, no string, no enum, no
+native struct.
+
+`FUnversionedHeader` facts, measured with the correct fragment layout
+(`skip` = bits 0–6, `has_zeroes` = bit 7, `is_last` = bit 8, `value_num` =
+bits 9+):
+
+- **no tag export uses a has-zeroes fragment** — the zero mask is never needed.
+  (Exactly one `.uasset` under `/Content/Tags/` does, and it is a Blueprint,
+  `BP_PulseConduit_C45`, not a tag.) The 5 `bSpawnPerInstance` bools serialize
+  as a real 1-byte value, not as a mask bit.
+- 3.12 fragments per export on average, **5 maximum**
+- **every tag export body begins with 4 zero bytes and ends with 4 zero bytes**,
+  both *inside* `cooked_serial_size` — 12,291/12,291 for the leading pair and
+  12,329/12,329 for the trailing. The trailing pair is distinct from the package
+  trailer `c1 83 2a 9e`, which follows `cooked_serial_size`.
+
+  The leading 4 bytes parse as two no-op fragments (`skip=0, value_num=0,
+  is_last=0`), so a reader consumes them harmlessly — but a *writer* that emits
+  only the minimal fragments produces a body 4 bytes short and fails
+  byte-identity. **Emit the 4-zero prefix.** The prefix is constant regardless of
+  how many properties the export carries, so it is a fixed frame, not a
+  position-dependent value.
+
+So the body layout is:
+`[00 00 00 00] [fragments…] [values…] [00 00 00 00]`
+
+Flattened schemas also contain `DefaultAssetReference`, `BinaryBlobSize` and
+`NativeClass` (inherited from `UDataAsset`); none is ever emitted, so the
+encoder reaches them only as skip counts.
+
+### Things that do not exist and need no handling
+
+- **no localized tag variants** — 2,316 `/Game/L10N` packages, none under
+  `/Tags/`, so the container header's localized-package machinery is unused
+- **no optional-segment chunks** — zero `.uptnl` and zero `.m.ubulk` anywhere in
+  the game; one bulk chunk per package, always index 0
+
+### One shipped tag is broken
+
+`/Game/Tags/sound/characters/masterchief/FOL_Move_ET/FOL_MC_GearMove_Land-sound`
+declares `serial_size = 4700` but **has no `.ubulk` chunk at all** — its five
+siblings in the same folder all do. Tooling must degrade gracefully on a missing
+bulk chunk rather than erroring.
+
+---
+
+## 4. `AssetReference` — computable from the target path alone
+
+**6404/6404, zero misses.** No donor tag and no Blueprint parsing needed:
+
+- target is a Blueprint class (`TSubclassOf`): hash =
+  `cityhash64(lowercase UTF-16 "<PackageLeaf>_C")` — 631 cases, exactly the 14
+  object groups plus `effect`
+- target is a plain asset (`UObject*`): hash =
+  `cityhash64(lowercase UTF-16 "<PackageLeaf>")` — 5,773 cases, exactly
+  `sound`, `sound_looping`, `sound_combiner`, `cinematic`,
+  `damage_response_definition`
+
+No target package is ever referenced with two different hashes (0 of 6,278).
+
+Which rule applies is decided by the declaring class, so it is known statically
+from the group.
+
+**Useful defaults**, from the target census:
+`/Game/_Prototypes/SynchronizationTestContent/TestActor/BP_EmptyActor` is the
+game's own generic actor, used by `biped`, `crate`, `creature`, `device_control`,
+`device_machine`, `effect_scenery`, `equipment`, `giant`, `projectile`.
+`damage_response_definition` has only ever pointed at two assets
+(`DA_Default-PlayerEffect`, `DA_AreaOfEffect-PlayerEffect`).
+
+---
+
+## 5. `CookedAssetsReferencedByTag` — derived from the blob
+
+Reconciled against every tag's own `tag_reference` set:
+
+| Case | Count |
+|---|---|
+| array absent, blob has 0 resolvable refs (correct) | 9,118 |
+| array present and **exactly equal** to the blob refs | 2,968 |
+| array present, a **strict subset** (cook-culled) | 47 |
+| array present, a **strict superset** | 34 |
+| array absent but the blob has refs | 124 |
+| differs in both directions | **0** |
+
+**98.7% is exact or an explained subset.** The exceptions:
+
+- **47 subsets** — deliberate cook-time culling on `character` (36), `biped`
+  (4), `model_animation_graph` (3), `frame_event_list` (2), `skull_globals`,
+  `multiplayer_globals`. These are tags that would otherwise hard-preload half
+  the game (an AI `character` naming every weapon and vehicle it can use).
+- **124 absent-with-refs** — 122 `squad_template` plus
+  `player_model_customization_globals` and `multiplayer_object_type_list`. The
+  other 220 squad_templates of identical shape *do* carry the array; no folder,
+  ref-count or content discriminator exists. This is cook non-determinism, and
+  it proves the array is a preload optimisation rather than a correctness
+  requirement *when something else already loads the target*.
+- **34 supersets** — fully explained: 13 `scenario` tags each add
+  `globals-globals`; 11 `model_animation_graph` add their sibling
+  `-frame_event_list`; 10 `frame_event_list` add refs that are covered by their
+  sibling `model_animation_graph`'s reference set (jmad and fel are cooked as a
+  unit and share a union).
+
+**Authoring rule:** emit every blob `tag_reference` that resolves to a package
+we ship or that exists in the base game. That is a superset of shipped
+behaviour, and supersets are demonstrably safe (they only preload more).
+
+### Dangling references are normal
+
+1,157 reference instances point at tag paths that are not shipped packages, plus
+224 whose group has no definition at all (`ligh` 124, `lens` 53, `gldf` 27,
+`ltvl` 18, `mode` 2 — groups whose rendering role moved to Unreal). Top dangling
+targets: `sound` 637, `scenario_structure_bsp` 122,
+`scenario_structure_lighting_info` 122, `sound_looping` 53, `effect` 48.
+A validator must **warn, not error**.
+
+---
+
+## 6. Inferable from tag data, or needs UI?
+
+### Fully inferable — never ask the user
+
+- everything in §2 (identity, hashes, flags, orderings, name map, dependency
+  bundle)
+- `CookedAssetsReferencedByTag` — §5
+- `RuntimeVariants` on `model`:
+  `{VariantName: variants[i].name, Permutations: {region.name →
+  region.permutations[0] or "None"}}` — **407/408 exact** (43 model tags have no
+  variants and correctly omit the property). The single outlier drops a region
+  the render_model does not have.
+- `AssetReference`'s *hash*, given the target path — §4
+
+### Genuinely Unreal-only — needs UI
+
+- **`AssetReference`'s target package.** Not inferable: `sound` leaf-names match
+  the tag leaf only 1119/5719, `cinematic` 1/45. This has always been the real
+  tag→Unreal bridge; the actor's meshes, components and firing sounds are
+  compiled into the Blueprint and unreachable from any tag.
+- **`ModelRegionStringTable`'s target.** 118 distinct packages, inconsistent
+  naming (`RT_*` / `DA_*` / `rst_*`) scattered across `/Game`, and 87 of 451
+  model tags have none. **214 of 364 share
+  `/Game/Tags/objects/shared/RT_default_object_regions`** — the obvious default.
+- **`bSpawnPerInstance`** — a checkbox; 5 tags, all `true`, absent = false.
+- **`CustomizationDataTables` / `CustomizationIndicesLookup`** — one tag in the
+  game; a map editor, lowest priority.
+
+### Half-inferable — offer a generate action, not an inference
+
+The *contents* of a `BlamModelRegionStringTable`: `Regions` matches the model
+tag's variant regions **278/364**, but `Permutations` is the **mesh-side**
+vocabulary (the union over the mesh-sync data), not the tag's designated subset
+— e.g. `DA_Marine_Regions` lists 88 permutations shared across marine/johnson.
+The asset itself is a 370-byte `UDataAsset` with **no bulk data** and 3 script
+imports, so it is trivially synthesizable: take `Regions` from the tag and
+`Permutations` from the mesh-sync data blam-tags already reads.
+
+---
+
+## 7. How a tag is found at runtime
+
+There is **no asset registry and no tag manifest** in the paks.
+
+From the shipped exe, the resolver builds a full object path with
+`FString::Printf` and resolves it as an `FSoftObjectPath`:
+
+```
+"%s/%s%s-%s.%s-%s"                  with "/Game/Tags"   ->  /Game/Tags/<dir>/<name>-<group>.<name>-<group>
+"%s/Default/default-%s.default-%s"  with "/Game/Tags"   ->  /Game/Tags/Default/default-<group>.default-<group>
+```
+
+The group string comes from a runtime-built table indexed by group index (it
+lives in the uninitialized tail of `.data`, so it cannot be dumped statically).
+
+So resolution is **by name, with a per-group `Default/default-<group>`
+fallback** — which is why an unresolvable reference degrades to the group
+default instead of crashing, and why the 22 `/Game/Tags/Default/default-*` tags
+are imported by nothing yet obviously load.
+
+Reachability across all 103,867 cooked packages:
+
+- 18,740 of 18,858 import edges into `/Game/Tags` come from **other tags**
+- only 118 come from non-tag packages (levels 40, characters 26, vehicles 26,
+  weapons 22, blueprints 20, …); only 20 tags are reachable *only* that way
+- **334 tags are imported by nothing** — 312 of them are exactly the
+  `_Generated_` level groups (every `scenario` among them), the rest are the
+  `Default/` fallbacks
+
+A single scenario's package-import closure reaches 37,475 packages and 74.8% of
+all tags.
+
+### There is a runtime tag registry
+
+The function that builds those paths (`0x140000000 + 0x075f7790`) is not a
+per-lookup resolver — it is a **registry builder**. It walks a per-group array
+at `+0x90` of a subsystem object, formats the object path, constructs an
+`FSoftObjectPath`, and inserts it into a `TMap` (visible as the standard UE
+bucket machinery: `-1` sentinels, `hash & (size-1)`, `[map+0x48]` bucket count).
+Its two callers are `0x76f030b` and `0x7712a40`; the latter references the
+string `'BlamEngine'`, so the registry is populated at BlamEngine subsystem
+init. The sibling at `0x075f8810` builds the `Default/default-<group>` fallback
+path and is called from `0x76fc1ad`.
+
+So tag identity → `FSoftObjectPath` → UE's soft-object-path machinery, which has
+both find-only (`ResolveObject`) and load-on-demand (`TryLoad`) modes.
+
+> **The one open question that gates the design.** Is that registry populated by
+> **enumerating packages**, or from a **fixed list**?
+>
+> - Enumerated → new tags are discovered automatically,
+>   `CookedAssetsReferencedByTag` is purely a preload optimisation, and the
+>   authoring plan is complete as written.
+> - Fixed list → a new tag must also be registered in that list, which is an
+>   entire additional requirement.
+>
+> `scenario_required_resource` is **not** that list (it holds 35 `character` +
+> 20 `weapon` refs for skulls). Static analysis has hit its limit here: symbols
+> are absent, dispatch is virtual (the call graph from the resolver reaches only
+> 57 functions statically), and the group-name table lives in the uninitialised
+> tail of `.data`, so it exists only at runtime. Settling this needs IDA's
+> decompiler on `0x075f7790` and its callers, or a live breakpoint — minutes
+> with either, hours without.
+
+---
+
+## 8. The two defects this exposes
+
+In `blam-tags/src/iostore/writer.rs`:
+
+1. **`add_override_to_writer`** re-emits the base game's `.uasset` verbatim,
+   patching only `serial_size`, and only when the size changed. Repointing a
+   reference at a **new** tag therefore never adds the import, so the new tag is
+   never preloaded. (Repointing at an *existing* tag often works by luck —
+   74.8% of tags are already in the closure — which is exactly the kind of
+   inconsistency that is hard to diagnose from symptoms.)
+2. **`add_new_package_to_writer`** clones a same-group template and copies its
+   export body and import map verbatim, so a new tag inherits the template's
+   `AssetReference` and dependency list.
+
+For the 47 bare groups, cloning happens to be correct. For the other 54 it is
+not.
+
+---
+
+## 9. What is actually proven in-game, and the debug surface
+
+**The container-header registration data is correct.** For 351 shipped tag
+packages, the `StoreEntry` our writer derives (via
+`FZenPackageHeader::serialize`) is **identical to the game's own** —
+`export_bundles_size`, `imported_packages` and `shader_map_hashes` all match.
+So what we would register for a new package is byte-correct; only whether the
+engine *honours* a mod-supplied header is untested.
+
+**The in-game-proven surface is narrower than it looks.** The mod that was
+confirmed loading (`mymod-WinGDK_P`) contains **one chunk**: a `BulkData`
+override of package `09bec3c47f33c65e` =
+`/Game/Tags/objects/characters/marine/marine-biped`, same size as the original
+(45,270 bytes). No `.uasset`, no `ContainerHeader`, no new package. So
+*same-size tag edits* are proven; **size-changing edits (which patch the
+`.uasset`), new packages, and container-header registration are all unproven**.
+
+**The retail simulation DLL retains the full Blam debug command set.**
+`HaloSimulation_tag_release.dll` exports only `CreateBlamEngineShell` (one
+vtable), but its string tables carry the Blam command and debug-global pools,
+including:
+
+| Name | Kind | Why it matters |
+|---|---|---|
+| `tag_load_force` | command | force-load a tag **by name** |
+| `tag_unload_force`, `tag_reload_force` | command | the other half of the cycle |
+| `tag_is_active` | command | **query whether a given tag is loaded** |
+| `dump_loaded_tags` | command | dump the whole loaded set |
+| `scenario_load_all_tags` | debug global | toggle loading every tag for a scenario |
+| `debug_tag_dependencies`, `debug_single_tag`, `debug_tags` | debug global | dependency tracing |
+| `enable_tag_edit_sync`, `enable_tag_resource_xsync` | debug global | the live-edit sync path |
+
+`tag_is_active` + `dump_loaded_tags` + `tag_load_force` are precisely the three
+primitives needed to settle the load model empirically, without a debugger.
+
+**The retail build also ships ImGui and a Blam debug menu.** `/Script/ImGui`,
+`/Script/HaloImGuiUtils`, `SBlamDebugMenuWidget` and `UBlamDebugMenuWidget` are
+all present in the shipping exe, gated by:
+
+```
+UCLASS(Blueprintable, DefaultConfig, Config=Game)
+class UDebugMenuSettings : public UDeveloperSettings {
+    bool bEnableDebugMenuBetaShipping    = false;
+    bool bEnableDebugMenuReleaseShipping = false;
+    bool bEnableDebugMenuDefaultShipping = false;
+    // …NonShipping variants all default true
+};
+```
+
+Because these are `Config=Game` properties, a `Game.ini` override is the
+obvious thing to try:
+
+```ini
+[/Script/Meteorite.DebugMenuSettings]
+bEnableDebugMenuDefaultShipping=True
+bEnableDebugMenuReleaseShipping=True
+bEnableDebugMenuBetaShipping=True
+```
+
+Untested. `Meteorite/Content/Config` ships only an `Achievements` folder, so the
+project config is baked in; whether the user-layer config is still consulted for
+a `DefaultConfig` class in this build is the open part.
+
+---
+
+## 10. Test gates
+
+Two distinct gates, because the import-map slot order is not reproducible (§2):
+
+- **Round-trip gate (byte-identity).** Parse a shipped package, rebuild it with
+  the builder using the parsed import order, re-serialize: must be
+  byte-identical for all 12,291. This proves the serializer, the property
+  encoder, and every derivation in §2–§6. Already demonstrated for 9 of 10
+  sampled groups by `ce_tag_pkg_synth.rs`; the tenth was off by exactly 8 bytes
+  from deduping `imported_public_export_hashes` by hash instead of by
+  `(package, hash)` pair.
+- **From-scratch gate (semantic).** Build from a canonical order, parse back,
+  and assert: identical resolved property targets, identical dependency set,
+  identical blob-ref set, identical identity hashes and flags.

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -3518,12 +3518,15 @@ impl Baboon {
                 return;
             }
         };
-        let utoc_path = {
+        let (root, utoc_path, archive) = {
             let Some(source) = self.source() else {
                 self.status = "No source loaded".to_owned();
                 return;
             };
-            let TagSource::IoStoreContainerSet { containers, .. } = &source.source else {
+            let TagSource::IoStoreContainerSet {
+                root, containers, ..
+            } = &source.source
+            else {
                 self.status = "Source is not a container".to_owned();
                 return;
             };
@@ -3531,30 +3534,56 @@ impl Baboon {
                 self.status = "Container provenance is stale".to_owned();
                 return;
             };
-            m.utoc_path.clone()
+            (root.clone(), m.utoc_path.clone(), m.archive.clone())
         };
-        if let Err(e) =
-            blam_tags::iostore::writer::overwrite_tag_in_place(&utoc_path, &rel_path, &bytes)
-        {
-            self.status = format!("Overwrite failed: {e}");
+        // Resolve against the MOUNTED archive, not a fresh handle: an override
+        // container (an exported mod the user then reloaded) ships no directory
+        // index, and only the mounted handle has the rebuilt file list that can
+        // name `rel_path`.
+        if let Err(e) = blam_tags::iostore::writer::overwrite_tag_in_place_with(
+            &archive, &utoc_path, &rel_path, &bytes,
+        ) {
+            // A mod exported by an older build carries the tag alone, so there
+            // is no `.uasset` chunk to rewrite the declared length into and
+            // nothing can be added to a container in place.
+            let hint = if e.to_string().contains("no paired .uasset") {
+                " — export this mod again instead of saving into it"
+            } else {
+                ""
+            };
+            self.status = format!("Overwrite failed: {e}{hint}");
             return;
         }
+        drop(archive);
         // Hot-swap the pak's archive so subsequent reads see the new bytes.
-        match blam_tags::iostore::IoStoreArchive::open(&utoc_path) {
-            Ok(a) => {
-                if let Some(source) = self.source_mut()
-                    && let TagSource::IoStoreContainerSet { containers, .. } = &mut source.source
-                    && let Some(m) = containers.get_mut(container_idx)
-                {
-                    m.archive = std::sync::Arc::new(a);
+        let containers = match self.source().map(|s| &s.source) {
+            Some(TagSource::IoStoreContainerSet { containers, .. }) => containers.clone(),
+            _ => Vec::new(),
+        };
+        let reload_error =
+            match crate::source::reopen_container_archive(&root, &containers, container_idx)
+            {
+                Ok(a) => {
+                    if let Some(source) = self.source_mut()
+                        && let TagSource::IoStoreContainerSet { containers, .. } = &mut source.source
+                        && let Some(m) = containers.get_mut(container_idx)
+                    {
+                        m.archive = std::sync::Arc::new(a);
+                    }
+                    None
                 }
-            }
-            Err(e) => self.status = format!("Saved, but reloading the pak failed: {e}"),
-        }
+                Err(e) => Some(e),
+            };
         if let Some(doc) = self.kits[self.active].parsed_tags.get_mut(key) {
             doc.dirty.clear();
         }
-        self.status = format!("Saved into {} (game files modified)", utoc_path.display());
+        self.status = match reload_error {
+            Some(e) => format!(
+                "Saved into {}, but reloading the pak failed: {e}",
+                utoc_path.display()
+            ),
+            None => format!("Saved into {} (game files modified)", utoc_path.display()),
+        };
     }
 
     /// Save a brand-new (in-memory) container tag as a new `_P` override

--- a/src/app/model_preview/loading.rs
+++ b/src/app/model_preview/loading.rs
@@ -752,9 +752,13 @@ fn ce_decode_metahuman_table(
     let mut usmap = Usmap::meteorite().ok()?;
     let sbytes = ce_find_uasset_by_basename(containers, struct_basename)?;
     let shdr = FZenPackageHeader::deserialize(&mut Cursor::new(&sbytes[..]), None, CE_CV, CE_HV, None).ok()?;
+    let sctx = blam_tags::iostore::unversioned::ExportContext::new(&[]);
     let props = blam_tags::iostore::unversioned::read_userdefined_struct_layout(
         ce_export0_bytes(&sbytes, &shdr)?,
         &shdr.name_map.copy_raw_names(),
+        &usmap,
+        shdr.export_map.first()?.object_flags,
+        &sctx,
     )
     .ok()?;
     usmap.register_struct(struct_name, None, props);
@@ -765,6 +769,7 @@ fn ce_decode_metahuman_table(
         &dhdr.name_map.copy_raw_names(),
         &usmap,
         struct_name,
+        dhdr.export_map.first()?.object_flags,
     )
     .ok()
 }

--- a/src/source/loading.rs
+++ b/src/source/loading.rs
@@ -235,6 +235,38 @@ fn sibling_reference_archives(root: &Path, mounted: &[PathBuf]) -> Vec<IoStoreAr
         .collect()
 }
 
+/// Reopen one mounted container from disk after it was written to.
+///
+/// Not just `IoStoreArchive::open`: an override/mod container ships no
+/// directory index, so a plain reopen comes back knowing none of its paths and
+/// every later read or save of a tag in it fails. Rebuild the file list exactly
+/// as the mount did — from the other mounted containers plus the siblings in
+/// `root` — so the recovered paths agree with the `rel_path`s already recorded
+/// in the tag entries.
+pub fn reopen_container_archive(
+    root: &Path,
+    containers: &[MountedContainer],
+    index: usize,
+) -> Result<IoStoreArchive> {
+    let target = containers
+        .get(index)
+        .ok_or_else(|| anyhow::anyhow!("container provenance is stale"))?;
+    let mut archive = IoStoreArchive::open(&target.utoc_path)?;
+    if archive.entries().is_empty() {
+        let mounted: Vec<PathBuf> = containers.iter().map(|c| c.utoc_path.clone()).collect();
+        let references = sibling_reference_archives(root, &mounted);
+        let bases: Vec<&IoStoreArchive> = containers
+            .iter()
+            .enumerate()
+            .filter(|&(i, _)| i != index)
+            .map(|(_, c)| c.archive.as_ref())
+            .chain(references.iter())
+            .collect();
+        archive.recover_entries(&bases, None);
+    }
+    Ok(archive)
+}
+
 fn build_container_set(
     root: PathBuf,
     utocs: Vec<PathBuf>,
@@ -966,12 +998,22 @@ mod mod_export_tests {
         // it matches the tag it is overriding by construction.
         let reopened =
             blam_tags::iostore::IoStoreArchive::open(&out).expect("reopen exported container");
+        // Two chunks even for a same-size edit: the tag and its paired
+        // `.uasset`. The `.uasset` rides along so the mod stays editable — in-place
+        // surgery can only repoint chunks the container already has, and without
+        // it a later size-changing edit could never rewrite the declared length.
         assert_eq!(
             reopened.chunk_count(),
-            1,
-            "a same-size override should be exactly one chunk"
+            2,
+            "an override should carry the tag and its .uasset"
         );
-        let served = reopened.read_chunk(0).expect("read the override chunk");
+        let ub_id = archive
+            .chunk_id_for(&rel_path)
+            .expect("the base names the tag's chunk");
+        let ub_chunk = reopened
+            .find_chunk(&ub_id)
+            .expect("the override reuses the base chunk id");
+        let served = reopened.read_chunk(ub_chunk).expect("read the override chunk");
         assert_eq!(
             served, edited,
             "the exported container did not carry the edited bytes for {rel_path}"
@@ -1049,6 +1091,111 @@ mod mod_export_tests {
             "mod container listed {} tag(s); found {rel_path}",
             opened.entries.len()
         );
+    }
+
+    /// Save a tag that is being served by an already-exported mod: edit, export,
+    /// reload the folder, edit again, Save. The mod outranks the base pak, so
+    /// the save writes into the MOD — which ships no directory index, and
+    /// resolving the write through a freshly opened handle failed with
+    /// `path not found in container`.
+    #[test]
+    fn a_tag_served_by_an_exported_mod_can_be_saved_into_it_again() {
+        if !Path::new(PAKS).exists() {
+            eprintln!("skipping: {PAKS} not present");
+            return;
+        }
+        let defs = Path::new(env!("CARGO_MANIFEST_DIR")).join("definitions");
+        let names = TagNameIndex::load_from_definitions(&defs);
+        let loaded =
+            load_iostore_container_set(PathBuf::from(PAKS), &names, &defs).expect("mount");
+        let TagSource::IoStoreContainerSet { ref containers, .. } = loaded.source else {
+            panic!("expected a container set");
+        };
+        let (container, rel_path, original) = loaded
+            .entries
+            .iter()
+            .find_map(|entry| match &entry.location {
+                TagEntryLocation::Container { container, rel_path } => {
+                    let archive = &containers.get(*container)?.archive;
+                    let bytes = archive.read(rel_path).ok()?;
+                    (bytes.len() > 64).then(|| (*container, rel_path.clone(), bytes))
+                }
+                _ => None,
+            })
+            .expect("a readable container tag");
+
+        let mut exported = original.clone();
+        let last = exported.len() - 1;
+        exported[last] ^= 0xFF;
+
+        // Export the mod into the game's own Paks folder, where mods live.
+        let out =
+            PathBuf::from(PAKS).join(format!("baboon-resave-test-{}_P.utoc", std::process::id()));
+        blam_tags::iostore::writer::write_mod_container_ex(
+            &[(
+                containers[container].archive.as_ref(),
+                rel_path.as_str(),
+                exported.as_slice(),
+            )],
+            &[],
+            &out,
+        )
+        .expect("write override container");
+
+        // Everything from here has to clean up after itself: the mod is sitting
+        // in the user's install and must not outlive the test.
+        let result = std::panic::catch_unwind(|| {
+            let opened = load_iostore_container(out.clone(), &names, &defs)
+                .expect("mount the exported mod");
+            let TagSource::IoStoreContainerSet {
+                ref root,
+                ref containers,
+                ..
+            } = opened.source
+            else {
+                panic!("expected a container set");
+            };
+            let (index, rel) = opened
+                .entries
+                .iter()
+                .find_map(|entry| match &entry.location {
+                    TagEntryLocation::Container { container, rel_path: p } if *p == rel_path => {
+                        Some((*container, p.clone()))
+                    }
+                    _ => None,
+                })
+                .expect("the mod serves the overridden tag");
+
+            let mut resaved = exported.clone();
+            resaved[0..4].copy_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF]);
+            let mounted = &containers[index];
+            blam_tags::iostore::writer::overwrite_tag_in_place_with(
+                &mounted.archive,
+                &mounted.utoc_path,
+                &rel,
+                &resaved,
+            )
+            .expect("save into the mod container");
+
+            // What the app does next: reopen the pak it just wrote. A plain
+            // reopen loses the recovered file list, and the tag becomes
+            // unreadable and unsaveable for the rest of the session.
+            let reopened = reopen_container_archive(root, containers, index)
+                .expect("reopen the written container");
+            assert_eq!(
+                reopened.read(&rel).expect("read the tag back"),
+                resaved,
+                "the mod did not serve the re-saved bytes"
+            );
+        });
+
+        for ext in ["utoc", "ucas", "pak"] {
+            let _ = std::fs::remove_file(out.with_extension(ext));
+        }
+        if let Err(payload) = result {
+            std::panic::resume_unwind(payload);
+        }
+        eprintln!("re-saved {rel_path} into its own exported mod");
     }
 }
 

--- a/src/window_state.rs
+++ b/src/window_state.rs
@@ -797,14 +797,34 @@ mod tests {
         }
     }
 
+    /// How far inside the frame origin the fixture window's content starts —
+    /// a left border and a title bar.
+    const DECORATION_INSET: [f32; 2] = [8.0, 32.0];
+    /// Total size the fixture window's decorations add around its content:
+    /// a border on both sides, and the title bar plus a bottom border.
+    const DECORATION_SIZE: [f32; 2] = [16.0, 40.0];
+
+    /// `restore_viewport` returns whatever `ViewportBuilder::with_position`
+    /// expects, and winit reads that as the *content* top-left on macOS but the
+    /// *frame* top-left on Windows and X11. Turn a frame origin into the value
+    /// the platform under test should produce.
+    fn expected_position(frame_origin: [f32; 2]) -> Option<[f32; 2]> {
+        let mut position = frame_origin;
+        if cfg!(target_os = "macos") {
+            position[0] += DECORATION_INSET[0];
+            position[1] += DECORATION_INSET[1];
+        }
+        Some(position)
+    }
+
     fn state(mode: WindowMode, position: [f32; 2], size: [f32; 2]) -> PersistedWindowState {
         PersistedWindowState {
             schema_version: SCHEMA_VERSION,
             mode,
             normal: NormalWindowBounds {
                 inner_position_px: Some(Point {
-                    x: position[0] + 8.0,
-                    y: position[1] + 32.0,
+                    x: position[0] + DECORATION_INSET[0],
+                    y: position[1] + DECORATION_INSET[1],
                 }),
                 outer_position_px: Some(Point {
                     x: position[0],
@@ -815,8 +835,8 @@ mod tests {
                     height: size[1],
                 },
                 outer_size_logical: Size {
-                    width: size[0] + 16.0,
-                    height: size[1] + 40.0,
+                    width: size[0] + DECORATION_SIZE[0],
+                    height: size[1] + DECORATION_SIZE[1],
                 },
                 native_scale_factor: 1.0,
                 monitor_name: Some("primary".to_owned()),
@@ -922,18 +942,18 @@ mod tests {
         let mut saved = state(WindowMode::Normal, [-1400.0, 100.0], [900.0, 600.0]);
         saved.normal.monitor_name = Some("left".to_owned());
         let restored = restore_viewport(&saved, &monitors).unwrap();
-        assert_eq!(restored.position, Some([-1400.0, 100.0]));
+        assert_eq!(restored.position, expected_position([-1400.0, 100.0]));
     }
 
     #[test]
     fn disconnected_or_barely_visible_window_is_centered_on_primary() {
         let disconnected = state(WindowMode::Normal, [4000.0, 300.0], [1000.0, 700.0]);
         let restored = restore_viewport(&disconnected, &[primary_monitor()]).unwrap();
-        assert_eq!(restored.position, Some([452.0, 150.0]));
+        assert_eq!(restored.position, expected_position([452.0, 150.0]));
 
         let barely_visible = state(WindowMode::Normal, [1910.0, 100.0], [1000.0, 700.0]);
         let restored = restore_viewport(&barely_visible, &[primary_monitor()]).unwrap();
-        assert_eq!(restored.position, Some([452.0, 150.0]));
+        assert_eq!(restored.position, expected_position([452.0, 150.0]));
 
         let secondary = monitor(
             "secondary",
@@ -945,7 +965,7 @@ mod tests {
         let mut stale_secondary = state(WindowMode::Normal, [5000.0, 300.0], [1000.0, 700.0]);
         stale_secondary.normal.monitor_name = Some("secondary".to_owned());
         let restored = restore_viewport(&stale_secondary, &[primary_monitor(), secondary]).unwrap();
-        assert_eq!(restored.position, Some([452.0, 150.0]));
+        assert_eq!(restored.position, expected_position([452.0, 150.0]));
     }
 
     #[test]
@@ -961,7 +981,7 @@ mod tests {
         );
         let restored = restore_viewport(&saved, &[scaled]).unwrap();
         assert_eq!(restored.inner_size, [900.0, 600.0]);
-        assert_eq!(restored.position, Some([50.0, 50.0]));
+        assert_eq!(restored.position, expected_position([50.0, 50.0]));
     }
 
     #[test]
@@ -976,7 +996,7 @@ mod tests {
                 &[primary_monitor()],
             )
             .unwrap();
-            assert_eq!(restored.position, Some([120.0, 80.0]));
+            assert_eq!(restored.position, expected_position([120.0, 80.0]));
             assert_eq!(restored.inner_size, [1000.0, 700.0]);
             assert_eq!(restored.maximized, maximized);
         }


### PR DESCRIPTION
## The bug

Edit a tag → Export Mod → reload the folder → edit again → Save, and Save fails with `path not found in container`.

The mod outranks the base pak, so the save correctly targets the mod. But an override container ships no directory index, and the save resolved the write through a freshly opened handle — which comes back knowing none of its own paths.

## The fix

Resolve the write through the archive that is **already mounted**, which has the rebuilt file list, and reopen through a new `reopen_container_archive` that recovers that list the same way the mount does — from the other mounted containers plus the siblings in the source root. A plain `IoStoreArchive::open` would come back empty again and break every later read of that container.

Exported overrides now carry the tag's paired `.uasset` as well as the tag itself. In-place surgery can only repoint chunks a container already has, so without it a later size-changing edit had nowhere to write the declared length back to. A mod exported by an older build has no `.uasset` to rewrite, and Save now says so (`— export this mod again instead of saving into it`) rather than reporting a bare failure.

A failed reload no longer overwrites the outcome of a successful write. The tag really was saved, and the status now says both things instead of only the reload error.

## Engine bump

`blam-tags` `cb0e6a1` → `1c3ad0c`, which supplies `overwrite_tag_in_place_with` and brings the Campaign Evolved content sweep to complete coverage: all **1,153,834** runtime Unreal exports across **103,867** packages now decode their property block and account for every byte — no decode failures, no unmodeled tails.

Two of the fixes behind that were general rather than class-specific, and are worth knowing about:

- **`TMap`/`TSet` write a delta prefix whose count is followed by that many keys.** The reader consumed the count and discarded it — correct while the count is zero, as it is in nearly every cooked asset, and a catastrophic desync when it isn't.
- **An enum reached through a container serializes as the enumerator's `FName`, not its underlying integer.** `CanSerializeAsInteger` claims `FEnumProperty` only at the top level of an unversioned property block; inside a container it goes through `SerializeItem`, which writes the name so reordering an enum can't corrupt saved data. The same property is one byte or eight depending only on where it sits.

The model preview picks up the widened `read_userdefined_struct_layout` and `read_datatable_rows` signatures that work needed.

## Docs

Two companion documents under `docs/`: the measured Campaign Evolved tag-package specification (checked against all 12,291 shipped tag packages rather than inferred from one sample) and the authoring plan that follows from it.

## Testing

New regression test `a_tag_served_by_an_exported_mod_can_be_saved_into_it_again` reproduces the reported flow end to end: edit, export, reload, edit again, save.

`cargo test --all-targets` on macOS: **404 passed, 4 failed, 18 ignored**.

The 4 failures are all in `window_state` and are **pre-existing on `main`** — I checked out `9bee1c8` clean and got the identical 4 (`disconnected_or_barely_visible_window_is_centered_on_primary`, `dpi_change_preserves_logical_size_and_clamps_physical_placement`, `negative_coordinate_monitor_is_restored_without_primary_fallback`, `special_modes_restore_without_losing_normal_bounds`). They look like the macOS side of the window-restoration work, which was noted as runtime-tested on Windows only. Nothing in this branch touches that module.

`cargo build --release` is clean.