### PR TITLE
Give poking one action, an opt-out confirmation, and a status line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,7 +415,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "baboon"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "atomic-write-file",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ default-members = ["."]
 
 [package]
 name = "baboon"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 build = "build.rs"
 default-run = "Baboon"

--- a/src/app.rs
+++ b/src/app.rs
@@ -194,6 +194,8 @@ pub struct Baboon {
     scroll_to_cycle_dropdowns: bool,
     /// Warn before Save overwrites Campaign Evolved pak files in place.
     confirm_container_overwrite: bool,
+    /// Show the preflight plan and wait for confirmation before a runtime poke.
+    confirm_runtime_poke: bool,
     expert_mode: bool,
     dark_mode: bool,
     ui_scale: f32,
@@ -426,6 +428,7 @@ impl Baboon {
             show_block_sizes: prefs.show_block_sizes,
             scroll_to_cycle_dropdowns: prefs.scroll_to_cycle_dropdowns,
             confirm_container_overwrite: prefs.confirm_container_overwrite,
+            confirm_runtime_poke: prefs.confirm_runtime_poke,
             expert_mode: prefs.expert_mode,
             dark_mode: prefs.dark_mode,
             ui_scale: prefs.ui_scale,

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -5530,6 +5530,7 @@ impl Baboon {
             show_block_sizes: self.show_block_sizes,
             scroll_to_cycle_dropdowns: self.scroll_to_cycle_dropdowns,
             confirm_container_overwrite: self.confirm_container_overwrite,
+            confirm_runtime_poke: self.confirm_runtime_poke,
             expert_mode: self.expert_mode,
             dark_mode: self.dark_mode,
             ui_scale: self.ui_scale,

--- a/src/app/prefs.rs
+++ b/src/app/prefs.rs
@@ -124,6 +124,10 @@ fn prefs_from_value(value: &Value) -> GuiPrefs {
             .get("confirm_container_overwrite")
             .and_then(Value::as_bool)
             .unwrap_or(true),
+        confirm_runtime_poke: value
+            .get("confirm_runtime_poke")
+            .and_then(Value::as_bool)
+            .unwrap_or(true),
         expert_mode: value
             .get("expert_mode")
             .and_then(Value::as_bool)
@@ -532,6 +536,7 @@ fn prefs_to_value(
         "show_block_sizes": prefs.show_block_sizes,
         "scroll_to_cycle_dropdowns": prefs.scroll_to_cycle_dropdowns,
         "confirm_container_overwrite": prefs.confirm_container_overwrite,
+        "confirm_runtime_poke": prefs.confirm_runtime_poke,
         "expert_mode": prefs.expert_mode,
         "dark_mode": prefs.dark_mode,
         "ui_scale": prefs.ui_scale,

--- a/src/app/runtime_poke.rs
+++ b/src/app/runtime_poke.rs
@@ -2582,7 +2582,14 @@ impl Baboon {
         })
     }
 
+    /// The single entry point for File → Poke Current Tag and Ctrl+P. Whether
+    /// the preflight plan is shown for confirmation first is the user's
+    /// `confirm_runtime_poke` preference, not a property of how it was invoked.
     pub(super) fn begin_poke_current_tag(&mut self, ctx: egui::Context) {
+        if !self.confirm_runtime_poke {
+            self.begin_poke_current_tag_direct(ctx);
+            return;
+        }
         if self.poke_direct_running || self.poke_undo_running {
             self.status = "A runtime poke or undo is already in progress".to_owned();
             return;
@@ -2604,6 +2611,7 @@ impl Baboon {
             prior,
         } = request;
         let tx = self.tx.clone();
+        self.status = "Preparing runtime poke…".to_owned();
         self.poke_dialog = Some(PokeDialog {
             kit,
             key: key.clone(),
@@ -2665,6 +2673,7 @@ impl Baboon {
         let kit = dialog.kit;
         let key = dialog.key.clone();
         dialog.state = PokeDialogState::Writing;
+        self.status = "Poking current tag…".to_owned();
         let tx = self.tx.clone();
         thread::spawn(move || {
             let result = platform::execute(plan);
@@ -2697,16 +2706,37 @@ impl Baboon {
         key: String,
         result: Result<PokePlan, String>,
     ) {
-        let Some(dialog) = self.poke_dialog.as_mut() else {
+        let Some(dialog) = self.poke_dialog.as_ref() else {
             return;
         };
         if dialog.kit != kit || dialog.key != key {
             return;
         }
-        dialog.state = match result {
-            Ok(plan) => PokeDialogState::Ready(plan),
-            Err(error) => PokeDialogState::Error(error),
+        // Mirror the outcome to the status line as well as the dialog, so the
+        // two poke paths report the same way and the result survives the
+        // dialog being dismissed.
+        let (state, status) = match result {
+            Ok(plan) => {
+                let status = if plan.patches.is_empty() {
+                    "Runtime poke preflight: no changed fields".to_owned()
+                } else {
+                    format!(
+                        "Runtime poke ready: {} field change(s), {} byte(s)",
+                        plan.patches.len(),
+                        plan.byte_count()
+                    )
+                };
+                (PokeDialogState::Ready(plan), status)
+            }
+            Err(error) => {
+                let status = format!("Poke failed: {error}");
+                (PokeDialogState::Error(error), status)
+            }
         };
+        if let Some(dialog) = self.poke_dialog.as_mut() {
+            dialog.state = state;
+        }
+        self.status = status;
     }
 
     pub(super) fn handle_poke_write(
@@ -2729,6 +2759,7 @@ impl Baboon {
                 self.poke_dialog = None;
             }
             Err(error) => {
+                self.status = format!("Poke failed: {error}");
                 if let Some(dialog) = self.poke_dialog.as_mut() {
                     dialog.state = PokeDialogState::Error(error);
                 }
@@ -2778,9 +2809,16 @@ impl Baboon {
     }
 
     pub(super) fn draw_poke_window(&mut self, ctx: &egui::Context) {
+        let mut dont_ask = !self.confirm_runtime_poke;
         let Some(dialog) = self.poke_dialog.as_ref() else {
             return;
         };
+        // A poke that never ran reports as cancelled; an error already put its
+        // own message on the status line, so closing that must not erase it.
+        let cancellable = matches!(
+            dialog.state,
+            PokeDialogState::Scanning | PokeDialogState::Ready(_)
+        );
         let mut open = true;
         let mut confirm = false;
         let mut close = false;
@@ -2794,7 +2832,7 @@ impl Baboon {
                     ui.horizontal(|ui| {
                         ui.spinner();
                         ui.label(
-                            "Resolving the live tag, validating CU2, and building a read-only plan…",
+                            "Resolving the live tag, validating the game build, and building a read-only plan…",
                         );
                     });
                 }
@@ -2843,6 +2881,8 @@ impl Baboon {
                         });
                     }
                     ui.separator();
+                    ui.checkbox(&mut dont_ask, "Don't ask again (changeable in Settings)");
+                    ui.add_space(4.0);
                     ui.horizontal(|ui| {
                         if ui
                             .add_enabled(!plan.patches.is_empty(), egui::Button::new("Poke"))
@@ -2858,7 +2898,16 @@ impl Baboon {
             });
         if !open || close {
             self.poke_dialog = None;
+            if cancellable {
+                self.status = "Runtime poke cancelled".to_owned();
+            }
         } else if confirm {
+            // Apply the opt-out only when the user commits to the poke, so
+            // cancelling out of the dialog never disarms the next one.
+            if dont_ask && self.confirm_runtime_poke {
+                self.confirm_runtime_poke = false;
+                self.persist_prefs_if_changed();
+            }
             self.confirm_poke(ctx.clone());
         }
     }

--- a/src/app/state/editing.rs
+++ b/src/app/state/editing.rs
@@ -7,7 +7,6 @@ pub(in crate::app) enum DeferredFileAction {
     SaveCurrentTag,
     ExportMod,
     PokeCurrentTag,
-    PokeCurrentTagDirect,
     Close(PendingCloseAction),
 }
 

--- a/src/app/state/prefs.rs
+++ b/src/app/state/prefs.rs
@@ -340,6 +340,9 @@ pub(in crate::app) struct GuiPrefs {
     pub(in crate::app) scroll_to_cycle_dropdowns: bool,
     /// Warn before Save overwrites Campaign Evolved pak files in place.
     pub(in crate::app) confirm_container_overwrite: bool,
+    /// Show the preflight plan and wait for confirmation before a runtime poke.
+    /// Cleared, a poke writes to the running game as soon as it is requested.
+    pub(in crate::app) confirm_runtime_poke: bool,
     pub(in crate::app) expert_mode: bool,
     pub(in crate::app) dark_mode: bool,
     pub(in crate::app) ui_scale: f32,
@@ -370,6 +373,7 @@ impl Default for GuiPrefs {
             show_block_sizes: false,
             scroll_to_cycle_dropdowns: true,
             confirm_container_overwrite: true,
+            confirm_runtime_poke: true,
             expert_mode: false,
             dark_mode: false,
             ui_scale: DEFAULT_UI_SCALE,

--- a/src/app/ui/settings.rs
+++ b/src/app/ui/settings.rs
@@ -114,6 +114,22 @@ impl Baboon {
 
         ui.add_space(10.0);
         ui.separator();
+        ui.label(RichText::new("Runtime poking").color(text_dark()).strong());
+        ui.add_space(4.0);
+        ui.checkbox(
+            &mut self.confirm_runtime_poke,
+            "Confirm before poking the running game",
+        );
+        ui.label(
+            RichText::new(
+                "File \u{2192} Poke Current Tag\u{2026} (Ctrl+P) shows the preflight plan and waits for confirmation. Turn this off to write to the running game as soon as the poke is requested.",
+            )
+            .color(subtle_dark())
+            .small(),
+        );
+
+        ui.add_space(10.0);
+        ui.separator();
         ui.label(RichText::new("Updates").color(text_dark()).strong());
         ui.add_space(4.0);
         self.draw_update_channel_picker(ui);

--- a/src/app/ui/shell.rs
+++ b/src/app/ui/shell.rs
@@ -108,10 +108,10 @@ impl Baboon {
                             if ui
                                 .add_enabled(
                                     self.can_poke_current_tag(),
-                                    egui::Button::new("Poke Current Tag..."),
+                                    egui::Button::new("Poke Current Tag...    Ctrl+P"),
                                 )
                                 .on_hover_text(
-                                    "Apply supported changes to this already-loaded tag in the verified Campaign Evolved CU2 process",
+                                    "Apply supported changes to this already-loaded tag in the verified Campaign Evolved process",
                                 )
                                 .clicked()
                             {
@@ -1159,12 +1159,7 @@ impl Baboon {
         match self.deferred_file_action.take() {
             Some(DeferredFileAction::SaveCurrentTag) => self.save_current_tag(),
             Some(DeferredFileAction::ExportMod) => self.export_mod(),
-            Some(DeferredFileAction::PokeCurrentTag) => {
-                self.begin_poke_current_tag(ctx.clone())
-            }
-            Some(DeferredFileAction::PokeCurrentTagDirect) => {
-                self.begin_poke_current_tag_direct(ctx.clone())
-            }
+            Some(DeferredFileAction::PokeCurrentTag) => self.begin_poke_current_tag(ctx.clone()),
             Some(DeferredFileAction::Close(action)) => self.request_close_action(action, ctx),
             None => {}
         }
@@ -1202,7 +1197,7 @@ impl Baboon {
             self.defer_file_action(DeferredFileAction::SaveCurrentTag, ctx);
         }
         if ctx.input_mut(|input| input.consume_key(egui::Modifiers::CTRL, egui::Key::P)) {
-            self.defer_file_action(DeferredFileAction::PokeCurrentTagDirect, ctx);
+            self.defer_file_action(DeferredFileAction::PokeCurrentTag, ctx);
         }
         // Undo: Ctrl+Z. Redo: Ctrl+Shift+Z or Ctrl+Y.
         if ctx.input_mut(|input| input.consume_key(egui::Modifiers::CTRL, egui::Key::Z)) {


### PR DESCRIPTION
## One action

`File → Poke Current Tag…` and `Ctrl+P` ran two different code paths:

| Invocation | Action | Behaviour |
|-|-|-|
| Menu item | `begin_poke_current_tag` | Opens the preflight dialog, waits for confirmation |
| `Ctrl+P` | `begin_poke_current_tag_direct` | Writes to the running game immediately, no confirmation |

Nothing communicated this — the menu row didn't advertise a shortcut at all, so which behaviour you got depended on how you invoked it, and the unconfirmed one was the one bound to a keystroke.

Both now enter `begin_poke_current_tag`. Whether the plan is shown for confirmation is the user's preference, not a property of how the poke was requested. `DeferredFileAction::PokeCurrentTagDirect` is gone; `begin_poke_current_tag_direct` survives as the no-confirm implementation that the preference selects.

## Opt-out

The dialog gets a **"Don't ask again (changeable in Settings)"** checkbox, mirrored by **"Confirm before poking the running game"** under a new *Runtime poking* section in Settings. This follows the shape `confirm_container_overwrite` already uses for overwriting pak files, down to applying the opt-out only when the action is committed — cancelling out of the dialog never disarms the next one.

New pref `confirm_runtime_poke`, defaults to `true`, so existing users keep the confirmation they have now.

## Status line

The dialog path only ever reported *success* to the status line. A preflight failure, a write failure, or a cancel left whatever unrelated message was there before:

| Stage | Before (dialog) | Now |
|-|-|-|
| Started | *(nothing)* | `Preparing runtime poke…` |
| Preflight ready | *(nothing)* | `Runtime poke ready: N field change(s), M byte(s)` |
| Preflight, no changes | *(nothing)* | `Runtime poke preflight: no changed fields` |
| Preflight failed | *(dialog only)* | `Poke failed: …` |
| Writing | *(nothing)* | `Poking current tag…` |
| Write failed | *(dialog only)* | `Poke failed: …` |
| Cancelled | *(nothing)* | `Runtime poke cancelled` |
| Succeeded | `report.status()` | unchanged |

Errors still show in the dialog too; closing an error dialog deliberately does *not* overwrite its message with "cancelled".

## Also

Two `CU2` mentions in poke UI text became inaccurate when #36 replaced the single profile with a table — the menu tooltip and the preflight spinner now say "the verified Campaign Evolved process" / "validating the game build".

## Checks

`cargo test`: 436 passed, 0 failed, 18 ignored. `cargo build --release` clean. No new `cargo fmt` violations (314, against a 314 baseline on this branch).

Not exercised against a running game — I don't have the new build live. The dialog/status/preference logic is all outside the Windows-only `platform` module, so it does compile and test on macOS; the poke itself does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)