### PR TITLE
Fix the export review window's runaway growth, and recover stashed new tags

### DIFF
--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -1322,7 +1322,18 @@ impl Baboon {
     /// container index plus its `.uasset` container path — the package template
     /// for a new tag of the same group.
     pub(super) fn find_container_template(&self, group_tag: u32) -> Option<(usize, String)> {
-        let source = self.source()?;
+        self.find_container_template_in(self.active, group_tag)
+    }
+
+    /// A specific kit's template. Project recovery names its kit: the container
+    /// a stashed new tag is modelled on has to come from the source that tag
+    /// belongs to, not from whichever kit happens to be focused.
+    pub(super) fn find_container_template_in(
+        &self,
+        kit: usize,
+        group_tag: u32,
+    ) -> Option<(usize, String)> {
+        let source = self.kits.get(kit)?.source.as_ref()?;
         source
             .entries
             .iter()
@@ -1342,6 +1353,18 @@ impl Baboon {
     /// entries, rebuild the folder + group trees so it shows up, open it in a
     /// **dirty** tab, and select it. Used by New Tag and Import for CE.
     pub(super) fn register_in_memory_tag(&mut self, entry: TagEntry, tag: TagFile) {
+        let key = entry.key.clone();
+        self.stash_in_memory_tag(entry, tag);
+        self.kits[self.active].open_tag_pane(&key);
+        self.kits[self.active].selected_key = Some(key);
+    }
+
+    /// The same registration without opening or selecting the tag.
+    ///
+    /// Recovering a stashed new tag at startup has to put it back in the browser
+    /// without deciding what the user is looking at: adopting two of them would
+    /// otherwise open two tabs and steal the selection on every launch.
+    pub(super) fn stash_in_memory_tag(&mut self, entry: TagEntry, tag: TagFile) {
         let key = entry.key.clone();
         if let Some(source) = self.source_mut() {
             source.entries.retain(|existing| existing.key != key);
@@ -1369,10 +1392,9 @@ impl Baboon {
         {
             index.set_tag_dependencies(key.clone(), dependencies);
         }
-        self.kits[self.active].parsed_tags
-            .insert(key.clone(), TagDocument::modified(tag));
-        self.kits[self.active].open_tag_pane(&key);
-        self.kits[self.active].selected_key = Some(key.clone());
+        self.kits[self.active]
+            .parsed_tags
+            .insert(key, TagDocument::modified(tag));
     }
 
     pub(super) fn loaded_tags_root(&self) -> Option<PathBuf> {
@@ -3751,6 +3773,7 @@ impl Baboon {
             overwrite_acknowledged: false,
             expanded: HashSet::new(),
             diffs: HashMap::new(),
+            controls_height: 0.0,
         });
     }
 

--- a/src/app/project.rs
+++ b/src/app/project.rs
@@ -127,6 +127,18 @@ pub(super) struct ActiveCampaignProject {
     pub(super) save_in_flight: Option<u64>,
     pub(super) write_lock: Arc<Mutex<()>>,
     pub(super) latest_write_revision: Arc<AtomicU64>,
+    /// Stashed *new* tags adopted from the recovery file that still have no
+    /// entry in the browser.
+    ///
+    /// A new tag exists only in memory, so a recovered overlay is all that is
+    /// left of one -- and adopting the file's overlays without recreating those
+    /// entries left the tag nowhere: absent from the tree, unresolvable, and
+    /// listed in Export Mod as "not in this source" forever, because the
+    /// overlays table is written back out every autosave. Held as a queue rather
+    /// than adopted on the spot: the recovery file is picked up as soon as the
+    /// source mounts, which can be before the names and container templates the
+    /// entry needs are loaded.
+    pub(super) pending_new_overlays: Vec<CampaignProjectOverlay>,
 }
 
 impl ActiveCampaignProject {
@@ -143,6 +155,7 @@ impl ActiveCampaignProject {
             save_in_flight: None,
             write_lock: Arc::new(Mutex::new(())),
             latest_write_revision: Arc::new(AtomicU64::new(0)),
+            pending_new_overlays: Vec::new(),
         }
     }
 
@@ -169,6 +182,12 @@ impl ActiveCampaignProject {
             save_in_flight: None,
             write_lock: Arc::new(Mutex::new(())),
             latest_write_revision: Arc::new(AtomicU64::new(0)),
+            pending_new_overlays: snapshot
+                .overlays
+                .values()
+                .filter(|overlay| overlay.kind == CampaignProjectTagKind::New)
+                .cloned()
+                .collect(),
         }
     }
 }
@@ -529,6 +548,116 @@ impl Baboon {
         }
     }
 
+    /// Rebuild the browser entry for a stashed new tag, and parse its bytes.
+    ///
+    /// `None` when this kit cannot place it: the group name, the template
+    /// container and the parse all have to succeed, and the first two depend on
+    /// how far the source has loaded. Shared by both restore paths -- the
+    /// recovery file adopted at mount and `File > Open Baboon Project` -- because
+    /// the entry a new tag is registered under decides whether it resolves at
+    /// export, and two copies of that derivation is how one path came to build it
+    /// and the other not to.
+    fn new_overlay_entry(
+        &self,
+        kit: usize,
+        overlay: &CampaignProjectOverlay,
+    ) -> Option<(TagEntry, TagFile)> {
+        let group_name = self.kits[kit]
+            .names
+            .name_for(overlay.group_tag)
+            .map(str::to_owned)?;
+        let (template_container, template_rel) =
+            self.find_container_template_in(kit, overlay.group_tag)?;
+        let tag = TagFile::read_from_bytes(&overlay.bytes).ok()?;
+        let extension = group_tag_to_extension(overlay.group_tag)
+            .unwrap_or(group_name.as_str())
+            .to_owned();
+        let package = overlay
+            .package
+            .clone()
+            .unwrap_or_else(|| format!("/Game/Tags/{}-{group_name}", overlay.logical_path));
+        Some((
+            TagEntry {
+                key: format!("newtag:{package}"),
+                display_path: format!("{}.{}", overlay.logical_path, extension),
+                group_tag: overlay.group_tag,
+                group_name: Some(group_name),
+                location: TagEntryLocation::NewContainer {
+                    template_container,
+                    template_rel,
+                    package,
+                    group_tag: overlay.group_tag,
+                },
+            },
+            tag,
+        ))
+    }
+
+    /// Put stashed new tags back into the browser.
+    ///
+    /// Runs until each queued overlay is either placed or already there. An
+    /// overlay is left queued while the source is still loading -- the names and
+    /// the template container are read from it -- and dropped once it resolves,
+    /// so a tag adopted by `File > Open Baboon Project`, which registers them
+    /// itself, is not registered twice.
+    ///
+    /// Scoped to the focused kit: registration writes through the active source.
+    /// A background kit's queue waits until that kit is focused, which is before
+    /// anything can be exported from it.
+    fn adopt_pending_new_overlays(&mut self, kit: usize) {
+        if kit != self.active
+            || self.kits[kit]
+                .campaign_project
+                .as_ref()
+                .is_none_or(|project| project.pending_new_overlays.is_empty())
+        {
+            return;
+        }
+        let queued = self.kits[kit]
+            .campaign_project
+            .as_ref()
+            .map(|project| project.pending_new_overlays.clone())
+            .unwrap_or_default();
+        let mut adopted = 0usize;
+        let mut still_pending = Vec::new();
+        for overlay in queued {
+            if self
+                .campaign_entry_for_identity(kit, &overlay.identity)
+                .is_some()
+            {
+                continue;
+            }
+            let Some((entry, tag)) = self.new_overlay_entry(kit, &overlay) else {
+                // The names and the template come off a source that may still be
+                // loading, so this is a "not yet" rather than a "no".
+                still_pending.push(overlay);
+                continue;
+            };
+            let key = entry.key.clone();
+            self.stash_in_memory_tag(entry, tag);
+            // The document was parsed from the overlay's own bytes, so the
+            // project already holds its serialization -- recording that spares
+            // the next autosave from writing every adopted tag out again.
+            if let Some(revision) = self.kits[kit]
+                .parsed_tags
+                .get(&key)
+                .map(|document| document.dirty.revision())
+            {
+                if let Some(project) = self.kits[kit].campaign_project.as_mut() {
+                    project.captured_revisions.insert(key, revision);
+                }
+            }
+            adopted += 1;
+        }
+        if let Some(project) = self.kits[kit].campaign_project.as_mut() {
+            project.pending_new_overlays = still_pending;
+        }
+        if adopted > 0 {
+            self.status =
+                format!("Restored {adopted} stashed new tag(s) from this workspace's last session");
+        }
+    }
+
     pub(super) fn capture_campaign_project(
         &mut self,
         kit: usize,
@@ -814,6 +943,7 @@ impl Baboon {
         }
         let now = ctx.input(|input| input.time);
         self.ensure_campaign_project(kit, now);
+        self.adopt_pending_new_overlays(kit);
         let due = self.kits[kit]
             .campaign_project
             .as_ref()
@@ -1012,40 +1142,11 @@ impl Baboon {
             .cloned()
             .collect::<Vec<_>>();
         for overlay in new_overlays {
-            let Some(group_name) = self.kits[kit].names.name_for(overlay.group_tag).map(str::to_owned) else {
+            let Some((entry, tag)) = self.new_overlay_entry(kit, &overlay) else {
                 missing += 1;
                 continue;
             };
-            let extension = group_tag_to_extension(overlay.group_tag)
-                .unwrap_or(group_name.as_str())
-                .to_owned();
-            let Ok(tag) = TagFile::read_from_bytes(&overlay.bytes) else {
-                missing += 1;
-                continue;
-            };
-            let Some((template_container, template_rel)) =
-                self.find_container_template(overlay.group_tag)
-            else {
-                missing += 1;
-                continue;
-            };
-            let package = overlay
-                .package
-                .clone()
-                .unwrap_or_else(|| format!("/Game/Tags/{}-{group_name}", overlay.logical_path));
-            let key = format!("newtag:{package}");
-            let entry = TagEntry {
-                key: key.clone(),
-                display_path: format!("{}.{}", overlay.logical_path, extension),
-                group_tag: overlay.group_tag,
-                group_name: Some(group_name),
-                location: TagEntryLocation::NewContainer {
-                    template_container,
-                    template_rel,
-                    package,
-                    group_tag: overlay.group_tag,
-                },
-            };
+            let key = entry.key.clone();
             self.register_in_memory_tag(entry, tag);
             identity_to_key.insert(overlay.identity.clone(), key);
         }

--- a/src/app/state/documents.rs
+++ b/src/app/state/documents.rs
@@ -409,6 +409,16 @@ pub(in crate::app) struct ModExportDialog {
     /// would make opening the review scale with how much is stashed.
     pub(in crate::app) expanded: HashSet<String>,
     pub(in crate::app) diffs: HashMap<String, ModRowDiff>,
+    /// Height of everything drawn below the list, measured on the previous
+    /// frame.
+    ///
+    /// The list is sized as "the window, less this", so the figure has to be the
+    /// real one: a hardcoded guess that came out too small grew the window by
+    /// the difference every frame, because a resizable egui window expands to
+    /// fit its contents and never shrinks back. The naming lines and the
+    /// overwrite warning appear conditionally, so there is no one number to
+    /// guess -- measuring settles in a frame and cannot run away.
+    pub(in crate::app) controls_height: f32,
 }
 
 /// Fold a mod name into a file-safe stem, keeping its capitalisation.

--- a/src/app/ui/dialogs.rs
+++ b/src/app/ui/dialogs.rs
@@ -1096,6 +1096,7 @@ impl Baboon {
         let mut set_all: Option<bool> = None;
         let mut toggled: Option<usize> = None;
         let mut expand_toggled: Option<String> = None;
+        let mut measured_controls: Option<f32> = None;
         let mut name_edit = dialog.name.clone();
 
         let review_only = dialog.review_only;
@@ -1110,7 +1111,13 @@ impl Baboon {
             .resizable(true)
             .default_width(1100.0)
             .default_height(640.0)
-            .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
+            // Centred on first open, and draggable after that. `anchor` looks
+            // like the way to centre a window and is not: it calls
+            // `movable(false)` internally and re-pins the window every frame, so
+            // the review -- the one dialog a reader wants to slide aside to look
+            // at the tag underneath -- could be resized but never moved.
+            .pivot(egui::Align2::CENTER_CENTER)
+            .default_pos(ctx.screen_rect().center())
             .show(ctx, |ui| {
                 let Some(dialog) = self.mod_export.as_ref() else {
                     return;
@@ -1140,11 +1147,26 @@ impl Baboon {
                     }
                 });
                 ui.add_space(6.0);
-                // Grows with the window: the naming and buttons below need a
-                // fixed slice, and the list takes whatever is left, so making
-                // the dialog taller shows more of the diff rather than more
-                // empty space.
-                let list_height = (ui.available_height() - 120.0).max(120.0);
+                // Grows with the window: the naming and buttons below keep the
+                // slice they measured last frame, and the list takes whatever is
+                // left, so making the dialog taller shows more of the diff
+                // rather than more empty space.
+                //
+                // The slice is measured rather than assumed. It was 120px, and
+                // the block below is 141px once the overwrite warning and the
+                // in-game-folder note are both showing -- so the contents came
+                // out 21px taller than the window, every frame, and a resizable
+                // egui window expands to fit its contents and never shrinks
+                // back. The dialog grew until it was larger than the screen,
+                // showing the extra height as empty list.
+                let reserve = if dialog.controls_height > 0.0 {
+                    dialog.controls_height
+                } else {
+                    // First frame, nothing measured yet. Over-reserving costs
+                    // one frame of a shorter list; under-reserving is the bug.
+                    160.0
+                };
+                let list_height = (ui.available_height() - reserve).max(120.0);
                 egui::ScrollArea::vertical()
                     .max_height(list_height)
                     .auto_shrink([false, false])
@@ -1233,6 +1255,11 @@ impl Baboon {
                             }
                         }
                     });
+                // Everything from here down is what `reserve` covers. Taken from
+                // the list's own bottom rather than from the cursor, so the
+                // spacing between them is inside the figure -- a few pixels
+                // short is the same runaway, only slower.
+                let controls_top = ui.min_rect().bottom();
                 if review_only {
                     ui.add_space(10.0);
                     ui.horizontal(|ui| {
@@ -1247,6 +1274,7 @@ impl Baboon {
                             save_diagnostic = true;
                         }
                     });
+                    measured_controls = Some(ui.min_rect().bottom() - controls_top);
                     return;
                 }
                 ui.add_space(10.0);
@@ -1324,6 +1352,7 @@ impl Baboon {
                         save_diagnostic = true;
                     }
                 });
+                measured_controls = Some(ui.min_rect().bottom() - controls_top);
             });
 
         // Applied after the window closes its borrow of `self`.
@@ -1355,6 +1384,14 @@ impl Baboon {
                 if !dialog.expanded.remove(identity) {
                     dialog.expanded.insert(identity.clone());
                 }
+            }
+            if let Some(height) = measured_controls {
+                // The tallest seen, not the latest. The overwrite warning comes
+                // and goes as the name is typed, and a reserve that tracked it
+                // downwards would under-reserve the frame it comes back --
+                // which, since the window cannot shrink, is a bump it keeps.
+                // Over-reserving only costs a few pixels of list.
+                dialog.controls_height = dialog.controls_height.max(height.max(0.0));
             }
         }
         // Computed outside the window, and only for rows that are open and have
@@ -2495,6 +2532,7 @@ mod mod_export_tests {
             overwrite_acknowledged: false,
             expanded: Default::default(),
             diffs: Default::default(),
+            controls_height: 0.0,
         }
     }
 


### PR DESCRIPTION
Two defects in the Campaign Evolved export/review flow, both reported from screenshots.

## The review window grew until it was bigger than the screen

The tag list reserved a hardcoded `120px` for the naming rows and buttons below it and took the rest of the window. That block is **141px** once both the overwrite warning and the in-game-folder note are showing, so the contents came out 21px taller than the window — and a resizable egui window expands to fit its contents and never shrinks back (`Resize::begin`: `desired_size = desired_size.max(last_content_size)`). Each frame the window grew, `available_height` rose, and the list grew with it: unbounded growth at a fixed rate per repaint, ending larger than the screen with its own title bar and buttons clipped off the edges. `auto_shrink([false, false])` is what made the extra height read as *empty list*.

Measured, per configuration:

| block below the list | height | before |
|---|---|---|
| no notes | 80px | stable |
| in-game-folder note | 97px | stable |
| overwrite warning | 124px | grows 4.4px/frame |
| both | 141px | grows 21.4px/frame |
| review-only ("Unexported changes") | 28px | stable |

So an export to a fresh mod name was fine and overwriting an existing mod in the game's own Paks folder ran away fast. Window height by frame, before: `709 → 733 → 758 → 782 → 806 → 831 …`, pinned at 936 on a 900px screen. After: flat at its own size in every configuration, including 15 rounds of the overwrite warning appearing and disappearing (which grew the window 183px before, 0 after).

The reserve is now the height the block actually occupied, measured from the list's own bottom so the spacing between them is inside the figure, and it keeps the tallest measurement rather than the latest — the warning comes and goes as the name is typed, and a reserve that followed it back down would under-reserve the frame it returns, which is a bump the window keeps.

**The dialog also could not be moved.** `anchor` is not just a centring call: it calls `movable(false)` internally and re-pins the window every frame. Replaced with a centre pivot and a centred `default_pos` — same placement on first open, draggable afterwards. Nine other windows still use `anchor`; left alone here.

## A stashed new tag came back as nothing

A new container tag has no `.ubulk` behind it, so the overlay in the recovery project is the only copy of it that exists. Two paths restore one and only the explicit path put it back: `File > Open Baboon Project` recreated the `NewContainer` entries, while `ensure_campaign_project` — the automatic adoption of `campaign_evolved_recovery-<hash>.baboon` when a source mounts, i.e. what happens on an ordinary launch — copied the overlays into the project and stopped.

The result was a tag that was absent from the browser, failed `campaign_entry_for_identity`, showed in Export Mod as `! not in this source`, could not be exported, and could not be discarded either (discard needs an entry to hang off) — while every autosave wrote the orphan overlay back out, making it permanent. Two had been riding along in my own recovery file for several sessions:

```
73636e72:asdf             asdf             new  /Game/Tags/asdf-scenario                78216 bytes
7472616b:my_camera_track  my_camera_track  new  /Game/Tags/my_camera_track-camera_track   746 bytes
```

Adoption is queued on the project and drained from the autosave tick rather than run at mount, because the recovery file is picked up before the group names and the template container the entry is built from have loaded; an overlay stays queued until the source can place it, and is dropped once it resolves so the explicit path's tags are not registered twice. Registration writes through the active source, so it is gated on the focused kit and gained a kit-scoped `find_container_template_in`. Both restore paths now build the entry from one shared place — deriving it twice is how they came to disagree — and adoption uses a registration that does not open a tab or take the selection, so recovering two tags no longer opens two panes on every launch.

## Verification

- The growth loop and the fix were both reproduced headlessly (`egui::Context` + `ctx.run` over 40 frames, reading the window rect per frame); the numbers above are measured, not estimated.
- Both stashed blobs parse (`scnr` v2, `trak` v2), and the container set has 70 `.camera_track` tags, so the template lookup for the queued `trak` resolves.
- 436 tests pass. `cargo fmt --check` reports 312 diffs against a 314 baseline on this branch's base — none are from these changes.
- Not exercised by hand: the recovery adoption itself needs a real launch against a mounted CE source, which is macOS-side here.
