### PR TITLE
Fix stashed-edit loss, mod-shadowed comparisons, angle units, and slashed field paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,7 +502,7 @@ dependencies = [
 [[package]]
 name = "blam-tags"
 version = "0.1.0"
-source = "git+https://github.com/camden-smallwood/blam-tags?rev=1c3ad0c#1c3ad0c75f4d2ad1fcc623d08fb86a5f652d4442"
+source = "git+https://github.com/camden-smallwood/blam-tags?rev=42e4812#42e4812e6d031c8dfa79193ff626e2e21f640620"
 dependencies = [
  "anyhow",
  "bcdec_rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1"
 atomic-write-file = "0.3"
-blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "1c3ad0c", features = ["audio", "iostore"] }
+blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "42e4812", features = ["audio", "iostore"] }
 directories = "6"
 display-info = "0.5"
 eframe = { version = "0.29", default-features = false, features = ["default_fonts", "glow"] }

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -2260,23 +2260,11 @@ impl Baboon {
     /// Whether `key` has anything to discard — unsaved edits, or bytes stashed
     /// in this kit's project from an earlier session.
     pub(super) fn tag_has_discardable_changes(&self, kit: usize, key: &str) -> bool {
-        if self.kits[kit]
+        self.kits[kit]
             .parsed_tags
             .get(key)
             .is_some_and(|document| document.dirty.is_set())
-        {
-            return true;
-        }
-        let Some(entry) = self.entry_for_key_in(kit, key) else {
-            return false;
-        };
-        let Some((identity, ..)) = campaign_entry_project_parts(entry) else {
-            return false;
-        };
-        self.kits[kit]
-            .campaign_project
-            .as_ref()
-            .is_some_and(|project| project.overlays.contains_key(&identity))
+            || self.tag_has_stashed_overlay(kit, key)
     }
 
     pub(super) fn select_entry(&mut self, key: String, ctx: egui::Context) {
@@ -2400,6 +2388,18 @@ impl Baboon {
             self.execute_close_action(action, ctx);
             return;
         }
+        // What discarding would cost, resolved here rather than described in the
+        // abstract: these edits were stashed into the workspace's project within
+        // a second of being typed, so declining to save deletes them from a file
+        // that outlives the session.
+        let stashed = dirty_tags
+            .iter()
+            .filter(|entry| self.tag_has_stashed_overlay(self.active, &entry.tag_id))
+            .count();
+        let stash_file = self.kits[self.active]
+            .campaign_project
+            .as_ref()
+            .map(|project| project.recovery_path.clone());
         self.save_changes_prompt = SaveChangesPrompt {
             visible: true,
             can_stash,
@@ -2407,6 +2407,9 @@ impl Baboon {
             pending_action: action,
             error: None,
             allow_app_close_once: self.save_changes_prompt.allow_app_close_once,
+            stash_file,
+            stashed,
+            confirm_discard: false,
         };
     }
 
@@ -2593,7 +2596,13 @@ impl Baboon {
             source_path,
             game: source.game.clone(),
             profile_id: kit.profile.as_ref().map(|profile| profile.id.clone()),
-            project_path: kit.campaign_project.as_ref().map(|project| project.path.clone()),
+            // The `.baboon` this workspace has open, if any — not its recovery
+            // file, which the next session finds from the source root anyway.
+            project_path: kit
+                .campaign_project
+                .as_ref()
+                .and_then(|project| project.project_path.clone()),
+            has_project: kit.campaign_project.is_some(),
             browser_mode: Some(kit.browser_mode),
             browser_sort: Some(kit.browser_sort),
             tags,
@@ -2613,12 +2622,15 @@ impl Baboon {
             source_path,
             profile_id,
             project_path,
+            has_project,
             browser_mode,
             browser_sort,
             tags,
         } in kits
         {
-            if tags.is_empty() && project_path.is_none() {
+            // A workspace whose only content is its stash still has to be
+            // reopened, so that its recovery file is picked back up.
+            if tags.is_empty() && !has_project {
                 continue;
             }
             match source_kind {
@@ -2667,11 +2679,12 @@ impl Baboon {
             if let Some(sort) = browser_sort {
                 self.kits[self.active].browser_sort = sort;
             }
-            // Its project is queued the same way, and opens once the source
-            // this session recorded has finished mounting.
+            // The project file it had open is queued the same way, and is
+            // attached as this workspace's save target once the source has
+            // mounted. The edits themselves come back from the recovery file.
             if let Some(project_path) = project_path {
                 let restoring = self.active;
-                self.queue_campaign_project(restoring, project_path);
+                self.queue_campaign_project_target(restoring, project_path);
             }
         }
     }
@@ -6388,6 +6401,11 @@ impl Baboon {
                 self.save_changes_prompt.visible = false;
                 self.save_changes_prompt.dirty_tags.clear();
                 self.save_changes_prompt.error = None;
+                self.save_changes_prompt.confirm_discard = false;
+            }
+            // Arming, not acting: the click that deletes is the next one.
+            SaveChangesPromptAction::ConfirmDiscard => {
+                self.save_changes_prompt.confirm_discard = true;
             }
             SaveChangesPromptAction::StashForMod => {
                 let action = self.save_changes_prompt.pending_action.clone();
@@ -6408,7 +6426,20 @@ impl Baboon {
                         self.save_changes_prompt.visible = false;
                         self.save_changes_prompt.dirty_tags.clear();
                         self.save_changes_prompt.error = None;
-                        self.status = "Stashed for Export Mod".to_owned();
+                        self.save_changes_prompt.confirm_discard = false;
+                        self.status = match self.kits[self.active]
+                            .campaign_project
+                            .as_ref()
+                            .and_then(|project| project.project_path.clone())
+                        {
+                            // Named, because the file the user thinks of as their
+                            // project is not the one this wrote.
+                            Some(path) => format!(
+                                "Stashed for Export Mod. {} is unchanged until you save it",
+                                path.display()
+                            ),
+                            None => "Stashed for Export Mod".to_owned(),
+                        };
                         self.execute_close_action(action, ctx);
                     }
                     Err(error) => {
@@ -6422,6 +6453,12 @@ impl Baboon {
                 // Discarding is explicit, so drop the dirty flags the prompt
                 // listed. Without this, a CloseApp that spans several kits
                 // would see the same unsaved work again and re-prompt forever.
+                //
+                // On a stashing workspace this also deletes the stashed copies —
+                // which is why the button is named Discard there and takes a
+                // second, confirming click. What it deletes from is the
+                // workspace's own recovery file; a `.baboon` the user opened or
+                // saved is never written by a close.
                 let kit = self.active;
                 let tag_ids: Vec<String> = self
                     .save_changes_prompt
@@ -6451,6 +6488,7 @@ impl Baboon {
                 self.save_changes_prompt.visible = false;
                 self.save_changes_prompt.dirty_tags.clear();
                 self.save_changes_prompt.error = None;
+                self.save_changes_prompt.confirm_discard = false;
                 self.execute_close_action(action, ctx);
             }
             SaveChangesPromptAction::Save(tag_ids) => {
@@ -6513,6 +6551,9 @@ impl Baboon {
                     let pending_action = self.save_changes_prompt.pending_action.clone();
                     self.save_changes_prompt.dirty_tags =
                         self.dirty_tags_for_close_action(&pending_action);
+                    // A failed save leaves the prompt up, and an armed discard
+                    // has no business surviving into it.
+                    self.save_changes_prompt.confirm_discard = false;
                     self.status = message.clone();
                     self.save_changes_prompt.error = Some(message);
                 }
@@ -6574,14 +6615,43 @@ fn reset_lazy_folder_browser(
 #[path = "tests/browser_refresh.rs"]
 mod browser_refresh_tests;
 
+#[cfg(test)]
+#[path = "tests/save_changes_prompt.rs"]
+mod save_changes_prompt_tests;
+
 enum SaveChangesPromptAction {
     None,
     Save(Vec<String>),
     /// Keep the edits in this workspace's Baboon project, ready for Export
     /// Mod, without writing anything into the game's own files.
     StashForMod,
+    /// Arm the discard. Only raised on a stashing workspace, where discarding
+    /// deletes stashed bytes rather than just dropping an in-memory edit.
+    ConfirmDiscard,
     DontSave,
     Cancel,
+}
+
+struct DiscardButton {
+    label: &'static str,
+    width: f32,
+    /// Whether this click only arms the discard. False means it deletes.
+    arming: bool,
+}
+
+/// What the prompt's discard button says and does.
+///
+/// On a workspace that stashes, this button deletes bytes that persist across
+/// sessions — an edit is stashed within a second of being typed, and exporting a
+/// mod does not clear it — so it is named for what it does and takes a second,
+/// confirming click. A loose kit has no stash to lose and keeps the one-click
+/// "Don't Save" every editor has.
+fn discard_button(can_stash: bool, confirmed: bool) -> DiscardButton {
+    match (can_stash, confirmed) {
+        (false, _) => DiscardButton { label: "Don't Save", width: 78.0, arming: false },
+        (true, false) => DiscardButton { label: "Discard...", width: 96.0, arming: true },
+        (true, true) => DiscardButton { label: "Delete Stashed Edits", width: 150.0, arming: false },
+    }
 }
 
 fn render_save_changes_prompt(
@@ -6609,7 +6679,8 @@ fn render_save_changes_prompt(
                 ui.label(
                     RichText::new(
                         "Save overwrites the game's own pak files in place. Stash for Mod keeps \
-                         the edits in this workspace's project instead, ready for Export Mod.",
+                         the edits in this workspace's project instead, ready for Export Mod. \
+                         Discard throws them away, including the copy the project is holding.",
                     )
                     .small()
                     .color(subtle_dark()),
@@ -6618,6 +6689,31 @@ fn render_save_changes_prompt(
             ui.add_space(8.0);
             if let Some(error) = prompt.error.as_deref() {
                 ui.label(RichText::new(error).color(Color32::from_rgb(180, 48, 40)));
+                ui.add_space(6.0);
+            }
+            // Spelling out what the destructive button costs, and where from.
+            // Exporting a mod does not clear these edits — the mod is a copy —
+            // so this is the prompt an exporter sees on every exit, and it used
+            // to delete the stash on one unlabelled click.
+            if prompt.confirm_discard {
+                ui.label(
+                    RichText::new(match (prompt.stashed, prompt.stash_file.as_deref()) {
+                        (0, _) => "Discard these edits? They are not stashed anywhere, so they \
+                                   cannot be recovered."
+                            .to_owned(),
+                        (count, Some(file)) => format!(
+                            "Discard deletes the stashed copy of {count} tag(s) from {}. Other \
+                             stashed tags in this workspace, and mods you have already exported, \
+                             are not affected.",
+                            file.display()
+                        ),
+                        (count, None) => format!(
+                            "Discard deletes the stashed copy of {count} tag(s). Mods you have \
+                             already exported are not affected."
+                        ),
+                    })
+                    .color(Color32::from_rgb(210, 120, 90)),
+                );
                 ui.add_space(6.0);
             }
             ScrollArea::both().max_height(150.0).show(ui, |ui| {
@@ -6636,11 +6732,20 @@ fn render_save_changes_prompt(
                 {
                     action = SaveChangesPromptAction::Cancel;
                 }
+                let DiscardButton {
+                    label,
+                    width,
+                    arming,
+                } = discard_button(prompt.can_stash, prompt.confirm_discard);
                 if ui
-                    .add(egui::Button::new("Don't Save").min_size(Vec2::new(78.0, 24.0)))
+                    .add(egui::Button::new(label).min_size(Vec2::new(width, 24.0)))
                     .clicked()
                 {
-                    action = SaveChangesPromptAction::DontSave;
+                    action = if arming {
+                        SaveChangesPromptAction::ConfirmDiscard
+                    } else {
+                        SaveChangesPromptAction::DontSave
+                    };
                 }
                 if prompt.can_stash
                     && ui
@@ -6728,6 +6833,19 @@ fn render_last_opened_windows_prompt(
                             RichText::new(format!("Missing source: {}", kit.source_path.display()))
                                 .color(Color32::from_rgb(180, 48, 40)),
                         );
+                    }
+                    // Why a workspace is listed with nothing under it: its
+                    // session is its stash, which comes back from its own
+                    // recovery file rather than from a list of tabs.
+                    if kit.entries.is_empty() && kit.has_project {
+                        ui.horizontal(|ui| {
+                            ui.add_space(10.0);
+                            ui.label(
+                                RichText::new("Unsaved changes stashed in this workspace")
+                                    .color(subtle_dark())
+                                    .small(),
+                            );
+                        });
                     }
                     for entry in &mut kit.entries {
                         ui.add_enabled_ui(entry.available, |ui| {

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -3775,6 +3775,7 @@ impl Baboon {
                     (true, CampaignProjectTagKind::New) => ModExportChange::New,
                     (true, CampaignProjectTagKind::Existing) => ModExportChange::Modified,
                 };
+                let overridden_by = self.mod_serving_tag(exporting, &overlay.identity);
                 ModExportRow {
                     identity: overlay.identity.clone(),
                     display_path: overlay.logical_path.clone(),
@@ -3784,6 +3785,7 @@ impl Baboon {
                     bytes: overlay.bytes.len(),
                     reason: (kind == ModExportChange::Unresolved)
                         .then(|| "not in this source".to_owned()),
+                    overridden_by,
                 }
             })
             .collect();
@@ -3814,10 +3816,11 @@ impl Baboon {
     /// Compute the field differences for one reviewed tag, against the tag as
     /// the game ships it.
     ///
-    /// `read_entry` reads from the container, so the baseline is the shipped
-    /// tag rather than anything the workspace has stashed -- which is the
-    /// comparison the reviewer actually wants: what this mod changes about the
-    /// game, not what changed since the last autosave.
+    /// The baseline comes from the *shipped* containers, not from whatever the
+    /// mount resolved the tag to -- which is the comparison the reviewer actually
+    /// wants: what this mod changes about the game, not what changed since the
+    /// last autosave, and not "nothing" because an earlier export of this very
+    /// mod is installed under `Paks` and now serves the tag.
     pub(super) fn diff_reviewed_tag(&self, kit: usize, identity: &str) -> ModRowDiff {
         const LIMIT: usize = 5000;
         let failed = |error: String| ModRowDiff {
@@ -3845,18 +3848,25 @@ impl Baboon {
         };
         // A tag this workspace created has no shipped counterpart to compare
         // against, so the whole tag is described instead.
-        if overlay.kind == CampaignProjectTagKind::New {
-            let (rows, truncated) = describe_tag(&edited_tag, &self.kits[kit].names, LIMIT);
-            return ModRowDiff {
+        let describe_whole = |edited_tag: TagFile, names: &TagNameIndex| {
+            let (rows, truncated) = describe_tag(&edited_tag, names, LIMIT);
+            ModRowDiff {
                 rows,
                 base: None,
                 edited: Some(edited_tag),
                 truncated,
                 error: None,
-            };
+            }
+        };
+        if overlay.kind == CampaignProjectTagKind::New {
+            return describe_whole(edited_tag, &self.kits[kit].names);
         }
-        let base = match crate::source::read_entry(&source.source, &entry) {
-            Ok(base) => base,
+        let base = match crate::source::read_shipped_entry(&source.source, &entry) {
+            Ok(Some(base)) => base,
+            // Only a mod carries this tag, so there is no shipped version to
+            // difference against — describing it whole is the honest answer, and
+            // it is what the reviewer needs to see either way.
+            Ok(None) => return describe_whole(edited_tag, &self.kits[kit].names),
             Err(error) => return failed(format!("Could not read the shipped tag: {error}")),
         };
         let (rows, truncated) = diff_tags(&base, &edited_tag, &self.kits[kit].names, LIMIT);
@@ -3957,6 +3967,170 @@ impl Baboon {
         Ok(count)
     }
 
+    /// The mounted mod currently serving this tag, if the mount resolved it to
+    /// one rather than to the game's own pack.
+    pub(super) fn mod_serving_tag(&self, kit: usize, identity: &str) -> Option<String> {
+        let source = self.kits.get(kit)?.source.as_ref()?;
+        let TagSource::IoStoreContainerSet { containers, .. } = &source.source else {
+            return None;
+        };
+        let entry = self.campaign_entry_for_identity(kit, identity)?;
+        let TagEntryLocation::Container { container, .. } = &entry.location else {
+            return None;
+        };
+        containers
+            .get(*container)
+            .filter(|container| container.is_mod)
+            .map(|container| container.chunk_label.clone())
+    }
+
+    /// The container a tag would be written into, and whether it is a mod.
+    pub(super) fn container_label_for_tag(&self, kit: usize, key: &str) -> Option<(String, bool)> {
+        let source = self.kits.get(kit)?.source.as_ref()?;
+        let TagSource::IoStoreContainerSet { containers, .. } = &source.source else {
+            return None;
+        };
+        let TagEntryLocation::Container { container, .. } = &self.entry_for_key_in(kit, key)?.location
+        else {
+            return None;
+        };
+        containers
+            .get(*container)
+            .map(|container| (container.chunk_label.clone(), container.is_mod))
+    }
+
+    /// Every mod this workspace has mounted, by container label.
+    pub(super) fn mounted_mod_labels(&self, kit: usize) -> Vec<String> {
+        let Some(source) = self.kits.get(kit).and_then(|kit| kit.source.as_ref()) else {
+            return Vec::new();
+        };
+        let TagSource::IoStoreContainerSet { containers, .. } = &source.source else {
+            return Vec::new();
+        };
+        containers
+            .iter()
+            .filter(|container| container.is_mod)
+            .map(|container| container.chunk_label.clone())
+            .collect()
+    }
+
+    /// The mounted containers an export to `output` would replace, by label.
+    ///
+    /// A mod installed under `Paks` is mounted like any other container, and
+    /// mounting memory-maps its `.ucas`. Replacing that file means releasing the
+    /// mapping first — Windows refuses to truncate a file with a mapped section
+    /// open — so this is what the review dialog says out loud and what the export
+    /// releases before it writes.
+    pub(super) fn export_replaces_mounted(&self, kit: usize, output: &Path) -> Vec<String> {
+        let Some(source) = self.kits.get(kit).and_then(|kit| kit.source.as_ref()) else {
+            return Vec::new();
+        };
+        let TagSource::IoStoreContainerSet { containers, .. } = &source.source else {
+            return Vec::new();
+        };
+        crate::source::mounted_containers_at(&source.source, output)
+            .into_iter()
+            .filter_map(|index| containers.get(index))
+            .map(|container| container.chunk_label.clone())
+            .collect()
+    }
+
+    /// Release the `.ucas` mapping of every mounted container an export to
+    /// `output` is about to replace, so the writer can truncate the file.
+    ///
+    /// `Err` when a mapping cannot be released because something else still holds
+    /// the archive — better a named refusal than a write that fails at the OS with
+    /// `ERROR_USER_MAPPED_FILE` and nothing to connect it to the mod being
+    /// installed.
+    fn release_export_target_mappings(
+        &mut self,
+        kit: usize,
+        output: &Path,
+    ) -> Result<Vec<usize>, String> {
+        let Some(source) = self.kits.get(kit).and_then(|kit| kit.source.as_ref()) else {
+            return Ok(Vec::new());
+        };
+        let targets = crate::source::mounted_containers_at(&source.source, output);
+        if targets.is_empty() {
+            return Ok(Vec::new());
+        }
+        let Some(source) = self.kits.get_mut(kit).and_then(|kit| kit.source.as_mut()) else {
+            return Ok(Vec::new());
+        };
+        let TagSource::IoStoreContainerSet { containers, .. } = &mut source.source else {
+            return Ok(Vec::new());
+        };
+        let mut released = Vec::new();
+        for index in targets {
+            let Some(mounted) = containers.get_mut(index) else {
+                continue;
+            };
+            let label = mounted.chunk_label.clone();
+            // Only the mount may hold this archive. A surviving clone — a preview
+            // still reading, a worker mid-scan — keeps the mapping alive whatever
+            // this does, and the write would fail anyway.
+            let Some(archive) = std::sync::Arc::get_mut(&mut mounted.archive) else {
+                return Err(format!(
+                    "Export Mod failed: {label} is being read by this workspace right now, so it \
+                     cannot be replaced. Try again in a moment, or export under a different name."
+                ));
+            };
+            archive.release_partition();
+            released.push(index);
+        }
+        Ok(released)
+    }
+
+    /// Put back what [`Self::release_export_target_mappings`] released, once the
+    /// files it was protecting have been rewritten.
+    ///
+    /// The container on disk is a different file now, so its index is reopened
+    /// rather than the old one remapped: an override container ships no directory
+    /// index, and `reopen_container_archive` is what rebuilds its file list from
+    /// the containers it overrides. Falls back to remapping the archive that is
+    /// already there, which at least leaves the mount readable.
+    fn restore_released_mappings(&mut self, kit: usize, released: &[usize]) -> Vec<String> {
+        if released.is_empty() {
+            return Vec::new();
+        }
+        let Some(source) = self.kits.get(kit).and_then(|kit| kit.source.as_ref()) else {
+            return Vec::new();
+        };
+        let TagSource::IoStoreContainerSet {
+            root, containers, ..
+        } = &source.source
+        else {
+            return Vec::new();
+        };
+        let (root, containers) = (root.clone(), containers.clone());
+        let mut failures = Vec::new();
+        for &index in released {
+            let reopened = crate::source::reopen_container_archive(&root, &containers, index);
+            let Some(source) = self.kits.get_mut(kit).and_then(|kit| kit.source.as_mut()) else {
+                continue;
+            };
+            let TagSource::IoStoreContainerSet { containers, .. } = &mut source.source else {
+                continue;
+            };
+            let Some(mounted) = containers.get_mut(index) else {
+                continue;
+            };
+            match reopened {
+                Ok(archive) => mounted.archive = std::sync::Arc::new(archive),
+                Err(error) => {
+                    if let Some(archive) = std::sync::Arc::get_mut(&mut mounted.archive)
+                        && archive.remap_partition().is_ok()
+                    {
+                        failures.push(format!("{}: {error}", mounted.chunk_label));
+                        continue;
+                    }
+                    failures.push(format!("{}: {error}", mounted.chunk_label));
+                }
+            }
+        }
+        failures
+    }
+
     /// Write the reviewed mod. `included` are the identities the user kept.
     pub(super) fn write_reviewed_mod(
         &mut self,
@@ -3969,7 +4143,12 @@ impl Baboon {
             self.status = "No source loaded".to_owned();
             return;
         };
-        let TagSource::IoStoreContainerSet { containers, .. } = &source.source else {
+        let TagSource::IoStoreContainerSet {
+            containers,
+            shipped,
+            ..
+        } = &source.source
+        else {
             self.status = "Export Mod is only for Campaign Evolved containers".to_owned();
             return;
         };
@@ -3987,7 +4166,13 @@ impl Baboon {
             };
             match &entry.location {
                 TagEntryLocation::Container { container, rel_path, } => {
-                    let Some(m) = containers.get(*container) else {
+                    // The base an override is built against is the game's own
+                    // pack, not whatever the mount resolved this tag to. With a
+                    // mod installed under `Paks`, the latter is that mod — so the
+                    // export read its chunk layout out of the very file it was
+                    // about to replace.
+                    let base = shipped.container_for(rel_path).unwrap_or(*container);
+                    let Some(m) = containers.get(base) else {
                         skipped += 1;
                         continue;
                     };
@@ -4017,6 +4202,17 @@ impl Baboon {
             self.status = "Nothing selected to export".to_owned();
             return;
         }
+        // The writer truncates the three files it writes, and a container this
+        // workspace has mounted has its `.ucas` mapped — which Windows will not
+        // let anyone truncate. Releasing has to happen after the bases above are
+        // collected (they are other containers) and before the writer runs.
+        let released = match self.release_export_target_mappings(exporting, &output) {
+            Ok(released) => released,
+            Err(error) => {
+                self.status = error;
+                return;
+            }
+        };
         let override_refs: Vec<(&blam_tags::iostore::IoStoreArchive, &str, &[u8])> = overrides
             .iter()
             .map(|(a, p, b)| (a.as_ref(), p.as_str(), b.as_slice()))
@@ -4030,8 +4226,14 @@ impl Baboon {
                 redirect_from: None,
             },)
             .collect();
-        match blam_tags::iostore::writer::write_mod_container_ex(&override_refs, &new_refs, &output)
-        {
+        let written =
+            blam_tags::iostore::writer::write_mod_container_ex(&override_refs, &new_refs, &output);
+        // Before anything reads through the mount again, and whether or not the
+        // write worked: a released partition refuses every payload read.
+        drop(override_refs);
+        drop(overrides);
+        let reopen_failures = self.restore_released_mappings(exporting, &released);
+        match written {
             Ok(()) => {
                 let stem = output
                     .file_stem()
@@ -4054,7 +4256,24 @@ impl Baboon {
                     .source()
                     .map(|source| source.source.root_path() == directory)
                     .unwrap_or(false);
-                self.status = format!("Exported {count} tag(s) as {stem}");
+                self.status = if !reopen_failures.is_empty() {
+                    // The mod was written; what failed is picking it back up.
+                    format!(
+                        "Exported {count} tag(s) as {stem}, but remounting failed ({}) — reload \
+                         the source",
+                        reopen_failures.join("; ")
+                    )
+                } else if released.is_empty() {
+                    format!("Exported {count} tag(s) as {stem}")
+                } else {
+                    // The container it replaced is mounted, so the browser is now
+                    // showing the mod it just wrote. Anything that mod used to
+                    // carry and no longer does still has an entry pointing at it.
+                    format!(
+                        "Exported {count} tag(s) as {stem}, replacing the mounted copy — reload \
+                         the source if its tag list changed"
+                    )
+                };
                 // Written straight into the game's own folder: there is nothing
                 // to copy, so the instructions would only be noise.
                 if !in_place {
@@ -6618,6 +6837,10 @@ mod browser_refresh_tests;
 #[cfg(test)]
 #[path = "tests/save_changes_prompt.rs"]
 mod save_changes_prompt_tests;
+
+#[cfg(test)]
+#[path = "tests/mod_overrides.rs"]
+mod mod_override_tests;
 
 enum SaveChangesPromptAction {
     None,

--- a/src/app/controller/loading.rs
+++ b/src/app/controller/loading.rs
@@ -241,6 +241,26 @@ pub(super) fn loaded_source_status(source: &LoadedSourceData) -> String {
                 source.label
             )
         }
+        // A mounted mod overrides the game's own tags, exactly as it does in
+        // game, so the browser is showing its values rather than the shipped
+        // ones. Say which mods, at the one moment the user is looking: silently
+        // serving a mod's tags as the base game is indistinguishable from the
+        // base game having those values.
+        TagSource::IoStoreContainerSet { containers, .. }
+            if containers.iter().any(|container| container.is_mod) =>
+        {
+            let mods = containers
+                .iter()
+                .filter(|container| container.is_mod)
+                .map(|container| container.chunk_label.as_str())
+                .collect::<Vec<_>>();
+            format!(
+                "Loaded {} tag(s) from {} — overridden by mounted mod(s): {}",
+                source.entries.len(),
+                source.label,
+                mods.join(", ")
+            )
+        }
         _ => format!(
             "Loaded {} tag(s) from {}",
             source.entries.len(),

--- a/src/app/editor/tests.rs
+++ b/src/app/editor/tests.rs
@@ -70,6 +70,9 @@ mod tests {
             containers.push(MountedContainer {
                 utoc_path: utoc.clone(),
                 chunk_label: utoc.file_stem().unwrap().to_string_lossy().into_owned(),
+                // Nothing on this path layers shipped against modded — it mounts
+                // everything to resolve one lookup.
+                is_mod: false,
                 archive: Arc::new(archive),
             });
         }
@@ -1304,6 +1307,149 @@ mod tests {
         assert_eq!(field_suffix(&m, "real"), "seconds [0.1-1]");
     }
 
+    /// Angle-typed fields hold radians and are edited in degrees, as Guerilla
+    /// presents them and as their own `:degrees` field names say.
+    ///
+    /// The numbers are the ones from the report that found this: an ODST weapon
+    /// whose `minimum error` read `0.01` in Guerilla and `0` in Baboon, and which
+    /// after typing `0.15` into Baboon read `8.59437` in Guerilla — a factor of
+    /// 180/π, applied to every angle field in every game.
+    #[test]
+    fn angle_fields_are_edited_in_degrees_and_stored_in_radians() {
+        use crate::app::foundation::{
+            foundation_bounds_values, format_foundation_scalar_value,
+        };
+        let tag = TagFile::new(test_definition_path("haloreach_mcc/test_tag.json")).unwrap();
+        let root = tag.root();
+        let names = TagNameIndex::default();
+
+        // Typing 0.15 means 0.15 degrees, not 0.15 radians.
+        let angle = root.field("angle").unwrap();
+        let TagFieldData::Angle(stored) = parse_gui_field_value(&angle, "0.15").unwrap() else {
+            panic!("expected an angle");
+        };
+        assert!(
+            (stored - 0.15f32.to_radians()).abs() < 1e-7,
+            "0.15 degrees stored as {stored} radians"
+        );
+
+        // And the reverse, against Guerilla's own reading of the same tag: the
+        // 0.15 radians Baboon used to write shows as 8.59437 degrees.
+        assert_eq!(
+            format_foundation_scalar_value(&names, &TagFieldData::Angle(0.15)),
+            "8.59437"
+        );
+        // The value the reporter saw as `0` — 0.01 degrees is 0.000175 radians,
+        // which the old two-decimal display rounded away entirely.
+        assert_eq!(
+            format_foundation_scalar_value(&names, &TagFieldData::Angle(0.01f32.to_radians())),
+            "0.01"
+        );
+
+        // Bounds are two angles, and get the same treatment.
+        let bounds = root.field("angle bounds").unwrap();
+        let TagFieldData::AngleBounds(stored) =
+            parse_gui_field_value(&bounds, "0.05..0.5").unwrap()
+        else {
+            panic!("expected angle bounds");
+        };
+        assert!((stored.lower - 0.05f32.to_radians()).abs() < 1e-7);
+        assert!((stored.upper - 0.5f32.to_radians()).abs() < 1e-7);
+        assert_eq!(
+            foundation_bounds_values(&TagFieldData::AngleBounds(blam_tags::math::AngleBounds {
+                lower: 0.25,
+                upper: 2.0,
+            })),
+            Some(("14.3239".to_owned(), "114.592".to_owned())),
+            "the other two values Guerilla showed for the same tag"
+        );
+    }
+
+    /// Editing an angle repeatedly must not walk it: degrees are shown to six
+    /// significant digits, so the display has to be a fixed point of
+    /// parse-then-format even though rad↔deg is not exact.
+    #[test]
+    fn angle_display_survives_repeated_edits() {
+        use crate::app::foundation::format_foundation_scalar_value;
+        let tag = TagFile::new(test_definition_path("haloreach_mcc/test_tag.json")).unwrap();
+        let field = tag.root().field("angle").unwrap();
+        let names = TagNameIndex::default();
+
+        for typed in ["0.01", "0.15", "20", "45", "70", "360", "1440", "-90", "8.59437"] {
+            let TagFieldData::Angle(stored) = parse_gui_field_value(&field, typed).unwrap() else {
+                panic!("expected an angle");
+            };
+            let shown = format_foundation_scalar_value(&names, &TagFieldData::Angle(stored));
+            assert_eq!(shown, typed, "{typed} degrees came back as {shown}");
+
+            // And again, from what was shown — the fixed point that matters when a
+            // field is opened, committed, reopened and committed again.
+            let TagFieldData::Angle(second) = parse_gui_field_value(&field, &shown).unwrap()
+            else {
+                panic!("expected an angle");
+            };
+            assert_eq!(
+                format_foundation_scalar_value(&names, &TagFieldData::Angle(second)),
+                typed,
+                "{typed} drifted on the second edit"
+            );
+        }
+    }
+
+    /// Only angle-typed fields convert. A `real` labelled `:degrees` — the ODST
+    /// weapon's `distribution angle` is one — is already in whatever unit its name
+    /// claims, which is why it was the one field in that group both tools agreed
+    /// on.
+    #[test]
+    fn plain_reals_are_left_alone() {
+        use crate::app::foundation::{
+            foundation_bounds_values, format_foundation_scalar_value,
+        };
+        let tag = TagFile::new(test_definition_path("haloreach_mcc/test_tag.json")).unwrap();
+        let root = tag.root();
+        let names = TagNameIndex::default();
+
+        let real = root.field("real").unwrap();
+        let TagFieldData::Real(stored) = parse_gui_field_value(&real, "0.15").unwrap() else {
+            panic!("expected a real");
+        };
+        assert_eq!(stored, 0.15);
+        assert_eq!(
+            format_foundation_scalar_value(&names, &TagFieldData::Real(0.15)),
+            "0.15"
+        );
+
+        let bounds = root.field("real bounds").unwrap();
+        let TagFieldData::RealBounds(stored) = parse_gui_field_value(&bounds, "0.05..0.5").unwrap()
+        else {
+            panic!("expected real bounds");
+        };
+        assert_eq!((stored.lower, stored.upper), (0.05, 0.5));
+        assert_eq!(
+            foundation_bounds_values(&TagFieldData::RealBounds(blam_tags::math::RealBounds {
+                lower: 0.25,
+                upper: 2.0,
+            })),
+            Some(("0.25".to_owned(), "2".to_owned()))
+        );
+    }
+
+    /// The editable text is what a commit writes back, so it cannot be a rounded
+    /// version of the value. Two decimals meant every real under 0.01 displayed as
+    /// `0` and became `0` the moment the field was touched.
+    #[test]
+    fn small_reals_are_not_displayed_as_zero() {
+        use crate::app::foundation::fmt_real;
+        for value in [0.001f32, 0.0001, 0.75, 1e-7, 0.123456, -0.005] {
+            let shown = fmt_real(value);
+            let parsed: f32 = shown.parse().expect("editable text parses back");
+            assert_eq!(parsed, value, "{value} displayed as {shown}");
+        }
+        assert_eq!(fmt_real(0.0), "0");
+        assert_eq!(fmt_real(-0.0), "0");
+        assert_eq!(fmt_real(70.0), "70");
+    }
+
     #[test]
     fn euler_angle_parser_accepts_complete_tuples_and_rejects_invalid_input() {
         let tag = TagFile::new(test_definition_path("haloreach_mcc/test_tag.json")).unwrap();
@@ -1311,22 +1457,23 @@ mod tests {
         let euler2d = root.field("real euler angles 2d").unwrap();
         let euler3d = root.field("real euler angles 3d").unwrap();
 
+        // Typed in degrees, stored in radians — the editor's angle contract.
         let TagFieldData::RealEulerAngles2d(value) =
             parse_gui_field_value(&euler2d, "0.25, -0.5").unwrap()
         else {
             panic!("expected real euler angles 2d");
         };
-        assert!((value.yaw - 0.25).abs() < 0.0001);
-        assert!((value.pitch + 0.5).abs() < 0.0001);
+        assert!((value.yaw - 0.25f32.to_radians()).abs() < 0.0001);
+        assert!((value.pitch + 0.5f32.to_radians()).abs() < 0.0001);
 
         let TagFieldData::RealEulerAngles3d(value) =
             parse_gui_field_value(&euler3d, "-0.65 0 1.25").unwrap()
         else {
             panic!("expected real euler angles 3d");
         };
-        assert!((value.yaw + 0.65).abs() < 0.0001);
+        assert!((value.yaw + 0.65f32.to_radians()).abs() < 0.0001);
         assert!(value.pitch.abs() < 0.0001);
-        assert!((value.roll - 1.25).abs() < 0.0001);
+        assert!((value.roll - 1.25f32.to_radians()).abs() < 0.0001);
 
         for invalid in ["1, 2", "1, 2, 3, 4", "yaw, pitch, roll"] {
             assert!(
@@ -1370,9 +1517,10 @@ mod tests {
         let TagFieldData::RealEulerAngles3d(value) = value else {
             panic!("expected real euler angles 3d");
         };
-        assert!((value.yaw + 0.65).abs() < 0.0001);
+        // The typed degrees survive as the radians they mean.
+        assert!((value.yaw + 0.65f32.to_radians()).abs() < 0.0001);
         assert!(value.pitch.abs() < 0.0001);
-        assert!((value.roll - 1.25).abs() < 0.0001);
+        assert!((value.roll - 1.25f32.to_radians()).abs() < 0.0001);
     }
 
     #[test]

--- a/src/app/editor/value_parser.rs
+++ b/src/app/editor/value_parser.rs
@@ -48,8 +48,21 @@ pub(in crate::app) fn append_field_path_for(prefix: &str, field: &TagField<'_>) 
     }
 }
 
+/// A field name as a path segment the resolver will accept.
+///
+/// The path grammar has **no escapes**: a segment is the field's *clean* name,
+/// and `blam_tags::field_name` is what defines that — including normalising a `/`
+/// inside a name to `\`, precisely so the name cannot split a path. Asking the
+/// engine is therefore the whole job.
+///
+/// This used to invent an escape, writing `int/bool` as `int\/bool`. Nothing
+/// parses that: the `/` still separated, leaving the nonsense segments `int\` and
+/// `bool`, so every write to a field with a slash in its name failed with "field
+/// path no longer resolves" — which in the shader grid meant no bool or int
+/// parameter could be created at all, since they are stored in a field named
+/// `int/bool`.
 pub(in crate::app) fn escape_field_path_segment(field_name: &str) -> String {
-    field_name.replace('\\', "\\\\").replace('/', "\\/")
+    blam_tags::field_name::clean_field_name(field_name).into_owned()
 }
 
 pub(in crate::app) fn is_text_editable_value(value: &TagFieldData) -> bool {

--- a/src/app/editor/value_parser.rs
+++ b/src/app/editor/value_parser.rs
@@ -99,7 +99,11 @@ pub(in crate::app) fn parse_gui_field_value(
         TagFieldType::Tag => parse_group_tag(trimmed)
             .map(TagFieldData::Tag)
             .ok_or_else(|| "expected 1..=4 ASCII group tag".to_owned()),
-        TagFieldType::Angle => parse_value(trimmed, "f32").map(TagFieldData::Angle),
+        // Typed in degrees, stored in radians. The display side
+        // (`foundation::fmt_degrees`) is the other half of this; the two are kept
+        // honest by `angle_fields_round_trip_through_degrees`.
+        TagFieldType::Angle => parse_value(trimmed, "f32")
+            .map(|degrees: f32| TagFieldData::Angle(degrees.to_radians())),
         TagFieldType::ShortIntegerBounds => {
             let (lower, upper) = parse_short_bounds(trimmed, "short bounds")?;
             Ok(TagFieldData::ShortIntegerBounds(
@@ -109,8 +113,8 @@ pub(in crate::app) fn parse_gui_field_value(
         TagFieldType::AngleBounds => {
             let (lower, upper) = parse_float_bounds(trimmed, "angle bounds")?;
             Ok(TagFieldData::AngleBounds(blam_tags::math::AngleBounds {
-                lower,
-                upper,
+                lower: lower.to_radians(),
+                upper: upper.to_radians(),
             }))
         }
         TagFieldType::RealBounds => {
@@ -162,16 +166,24 @@ pub(in crate::app) fn parse_gui_field_value(
                 blam_tags::math::RealQuaternion { i, j, k, w },
             ))
         }
+        // Euler angles are angles: degrees in, radians stored.
         TagFieldType::RealEulerAngles2d => {
             let [yaw, pitch] = parse_float_channels::<2>(trimmed, "real euler angles 2d")?;
             Ok(TagFieldData::RealEulerAngles2d(
-                blam_tags::math::RealEulerAngles2d { yaw, pitch },
+                blam_tags::math::RealEulerAngles2d {
+                    yaw: yaw.to_radians(),
+                    pitch: pitch.to_radians(),
+                },
             ))
         }
         TagFieldType::RealEulerAngles3d => {
             let [yaw, pitch, roll] = parse_float_channels::<3>(trimmed, "real euler angles 3d")?;
             Ok(TagFieldData::RealEulerAngles3d(
-                blam_tags::math::RealEulerAngles3d { yaw, pitch, roll },
+                blam_tags::math::RealEulerAngles3d {
+                    yaw: yaw.to_radians(),
+                    pitch: pitch.to_radians(),
+                    roll: roll.to_radians(),
+                },
             ))
         }
         TagFieldType::Real => parse_value(trimmed, "f32").map(TagFieldData::Real),

--- a/src/app/foundation/tests.rs
+++ b/src/app/foundation/tests.rs
@@ -18,28 +18,30 @@ mod tests {
         assert_eq!(block_index_value(&LongInteger(7)), None);
     }
 
+    /// Named components, and each one shown in degrees: euler angles are stored
+    /// in radians, and the editor edits degrees like every other Halo tool.
     #[test]
     fn euler_angles_use_editable_named_components() {
         let parts = foundation_editable_component_parts(&TagFieldData::RealEulerAngles2d(
             blam_tags::math::RealEulerAngles2d {
-                yaw: 0.25,
-                pitch: -0.5,
+                yaw: 45f32.to_radians(),
+                pitch: (-90f32).to_radians(),
             },
         ))
         .unwrap();
         assert_eq!(
             parts,
             vec![
-                ("yaw".to_owned(), "0.25".to_owned()),
-                ("pitch".to_owned(), "-0.5".to_owned()),
+                ("yaw".to_owned(), "45".to_owned()),
+                ("pitch".to_owned(), "-90".to_owned()),
             ]
         );
 
         let parts = foundation_editable_component_parts(&TagFieldData::RealEulerAngles3d(
             blam_tags::math::RealEulerAngles3d {
-                yaw: -0.65,
+                yaw: (-0.65f32).to_radians(),
                 pitch: 0.0,
-                roll: 1.25,
+                roll: 1.25f32.to_radians(),
             },
         ))
         .unwrap();
@@ -421,6 +423,7 @@ mod tests {
                 containers: Vec::new(),
                 index: std::sync::Arc::new(crate::source::ContainerTagIndex::default()),
                 packages: std::sync::Arc::new(crate::source::ContainerPackageIndex::default()),
+                shipped: std::sync::Arc::new(crate::source::ShippedTagIndex::default()),
             },
             names: TagNameIndex::default(),
             game: Some("haloce_evolved".to_owned()),

--- a/src/app/foundation/widgets.rs
+++ b/src/app/foundation/widgets.rs
@@ -471,9 +471,10 @@ pub(in crate::app) fn foundation_value_parts(
         TagFieldData::ShortIntegerBounds(b) => {
             pair("low", b.lower.to_string(), "high", b.upper.to_string())
         }
-        TagFieldData::AngleBounds(b)
-        | TagFieldData::RealBounds(b)
-        | TagFieldData::FractionBounds(b) => {
+        TagFieldData::AngleBounds(b) => {
+            pair("low", fmt_degrees(b.lower), "high", fmt_degrees(b.upper))
+        }
+        TagFieldData::RealBounds(b) | TagFieldData::FractionBounds(b) => {
             pair("low", fmt_real(b.lower), "high", fmt_real(b.upper))
         }
         _ => None,
@@ -483,9 +484,10 @@ pub(in crate::app) fn foundation_value_parts(
 pub(in crate::app) fn foundation_bounds_values(value: &TagFieldData) -> Option<(String, String)> {
     match value {
         TagFieldData::ShortIntegerBounds(b) => Some((b.lower.to_string(), b.upper.to_string())),
-        TagFieldData::AngleBounds(b)
-        | TagFieldData::RealBounds(b)
-        | TagFieldData::FractionBounds(b) => Some((fmt_real(b.lower), fmt_real(b.upper))),
+        TagFieldData::AngleBounds(b) => Some((fmt_degrees(b.lower), fmt_degrees(b.upper))),
+        TagFieldData::RealBounds(b) | TagFieldData::FractionBounds(b) => {
+            Some((fmt_real(b.lower), fmt_real(b.upper)))
+        }
         _ => None,
     }
 }
@@ -518,14 +520,15 @@ pub(in crate::app) fn foundation_editable_component_parts(
             ("k".to_owned(), fmt_real(q.k)),
             ("w".to_owned(), fmt_real(q.w)),
         ]),
+        // Euler angles are radians on disk too, and are edited in degrees.
         TagFieldData::RealEulerAngles2d(e) => Some(vec![
-            ("yaw".to_owned(), fmt_real(e.yaw)),
-            ("pitch".to_owned(), fmt_real(e.pitch)),
+            ("yaw".to_owned(), fmt_degrees(e.yaw)),
+            ("pitch".to_owned(), fmt_degrees(e.pitch)),
         ]),
         TagFieldData::RealEulerAngles3d(e) => Some(vec![
-            ("yaw".to_owned(), fmt_real(e.yaw)),
-            ("pitch".to_owned(), fmt_real(e.pitch)),
-            ("roll".to_owned(), fmt_real(e.roll)),
+            ("yaw".to_owned(), fmt_degrees(e.yaw)),
+            ("pitch".to_owned(), fmt_degrees(e.pitch)),
+            ("roll".to_owned(), fmt_degrees(e.roll)),
         ]),
         _ => None,
     }
@@ -607,10 +610,11 @@ pub(in crate::app) fn format_foundation_scalar_value(
     value: &TagFieldData,
 ) -> String {
     match value {
-        TagFieldData::Angle(v)
-        | TagFieldData::Real(v)
-        | TagFieldData::RealSlider(v)
-        | TagFieldData::RealFraction(v) => fmt_real(*v),
+        // Radians on disk, degrees in the editor — see `fmt_degrees`.
+        TagFieldData::Angle(v) => fmt_degrees(*v),
+        TagFieldData::Real(v) | TagFieldData::RealSlider(v) | TagFieldData::RealFraction(v) => {
+            fmt_real(*v)
+        }
         TagFieldData::RealRgbColor(c) => format!(
             "r {}  g {}  b {}",
             fmt_real(c.red),
@@ -641,17 +645,59 @@ pub(in crate::app) fn format_foundation_scalar_value(
     }
 }
 
+/// A real value as editable text.
+///
+/// The shortest decimal that reads back as the same `f32`, which is both tidy
+/// (`0.3`, `70`, `50000`) and lossless. It used to truncate to two decimals — and
+/// because this same text seeds the edit box, committing a field wrote the
+/// truncation back: anything under 0.01 displayed as `0` and became `0` the moment
+/// it was touched.
 pub(in crate::app) fn fmt_real(value: f32) -> String {
     if !value.is_finite() {
         return value.to_string();
     }
-    let truncated = (value * 100.0).trunc() / 100.0;
-    let mut text = format!("{truncated:.2}");
-    while text.contains('.') && text.ends_with('0') {
-        text.pop();
+    let text = format!("{value}");
+    if text == "-0" { "0".to_owned() } else { text }
+}
+
+/// How many significant digits an angle is shown to.
+///
+/// Guerilla's six, so a value edited in one tool and read in the other agrees
+/// digit for digit.
+const ANGLE_SIGNIFICANT_DIGITS: i32 = 6;
+
+/// An angle-typed value as editable text, in **degrees**.
+///
+/// Angle fields — `angle`, `angle_bounds`, `real_euler_angles_2d/3d` — hold
+/// radians on disk, and every Halo tool presents them in degrees; the field names
+/// themselves say `:degrees`. Showing the stored radians instead made a
+/// `0.01 degrees` field read as `0` (0.000175 rad, below the old two-decimal
+/// display) and, worse, made a `0.15` typed into a box labelled degrees mean
+/// 0.15 *radians* — 8.59°, fifty-seven times what was asked for.
+///
+/// Rounded to six significant digits rather than round-tripped exactly, because
+/// the conversion itself is inexact: 20° stored is `0.34906584`, which comes back
+/// as 19.999998. Six digits shows that as `20`, and repeated edits are stable.
+pub(in crate::app) fn fmt_degrees(radians: f32) -> String {
+    let degrees = radians.to_degrees();
+    if !degrees.is_finite() {
+        return degrees.to_string();
     }
-    if text.ends_with('.') {
-        text.pop();
+    if degrees == 0.0 {
+        return "0".to_owned();
+    }
+    // Enough decimals to leave six significant digits, whatever the magnitude:
+    // 1440.00 for a big one, 0.00001 for a small one.
+    let exponent = degrees.abs().log10().floor() as i32;
+    let decimals = (ANGLE_SIGNIFICANT_DIGITS - 1 - exponent).clamp(0, 9) as usize;
+    let mut text = format!("{degrees:.decimals$}");
+    if text.contains('.') {
+        while text.ends_with('0') {
+            text.pop();
+        }
+        if text.ends_with('.') {
+            text.pop();
+        }
     }
     if text == "-0" { "0".to_owned() } else { text }
 }

--- a/src/app/model_preview/loading.rs
+++ b/src/app/model_preview/loading.rs
@@ -1548,49 +1548,4 @@ mod ce_repro_tests {
         }
     }
 
-    /// Export a CE model to JMS through the real render-extraction path and write
-    /// it to the scratchpad (set `CE_MODEL`, default johnson). Verifies the
-    /// MetaHuman head is fused in (a non-empty `head` region). Skips without paks.
-    #[test]
-    fn ce_render_jms_export() {
-        let paks = PathBuf::from(
-            "/Users/camden/Halo/halo-campaign-evolved_pc/Meteorite/Content/Paks"
-        );
-        if !paks.exists() {
-            eprintln!("skip: CE paks not found");
-            return;
-        }
-        let defs = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("definitions");
-        let loaded = crate::source::load_iostore_container_set(paks, &TagNameIndex::default(), &defs)
-            .expect("mount CE container set");
-        let source = &loaded.source;
-        let hlmt = u32::from_be_bytes(*b"hlmt");
-        let want = std::env::var("CE_MODEL").unwrap_or_else(|_| "johnson/johnson".into());
-        let entry = loaded
-            .entries
-            .iter()
-            .chain(loaded.all_entries.iter())
-            .find(|e| e.group_tag == hlmt && e.display_path.to_ascii_lowercase().contains(&want))
-            .expect("model entry")
-            .clone();
-        let tag = read_entry(source, &entry).expect("read model");
-        let (_, skel_ref) = tag.root().read_tag_ref_with_group("skeleton model").expect("skel ref");
-        let jms = campaign_evolved_render_jms(&tag, &entry, source, &skel_ref).expect("build JMS");
-        let n_head: usize = jms
-            .materials
-            .iter()
-            .filter(|m| m.material_name.to_ascii_lowercase().contains(" head"))
-            .count();
-        eprintln!(
-            "[TEST] JMS: {} verts, {} tris, {} materials, {} head-region materials",
-            jms.vertices.len(), jms.triangles.len(), jms.materials.len(), n_head
-        );
-        let out = format!(
-            "/private/tmp/claude-501/-Users-camden-Source-Baboon-local/4803b682-de10-4887-907a-9f81ad3d13d0/scratchpad/ce_jms_{}.jms",
-            want.replace('/', "_")
-        );
-        let mut f = std::io::BufWriter::new(std::fs::File::create(&out).unwrap());
-        jms.write(&mut f, 8213).unwrap();
-        eprintln!("[TEST] wrote {out}");
-    }
 }

--- a/src/app/prefs.rs
+++ b/src/app/prefs.rs
@@ -714,6 +714,13 @@ fn parse_session_kit(value: &Value) -> Option<LastSessionKit> {
         .map(str::trim)
         .filter(|path| !path.is_empty())
         .map(PathBuf::from);
+    // Absent in sessions written while `project_path` still meant "the file this
+    // workspace autosaves to", which was set for every workspace that had a
+    // project at all — so its presence is exactly what this flag now records.
+    let has_project = source
+        .get("has_project")
+        .and_then(Value::as_bool)
+        .unwrap_or(project_path.is_some());
     // Absent in sessions written before the browser view became per-kit, and
     // in every version-1 and version-2 file. `None` means "use the default".
     let browser_mode = browser_mode_from_str(value.get("browser_mode").and_then(Value::as_str));
@@ -749,7 +756,7 @@ fn parse_session_kit(value: &Value) -> Option<LastSessionKit> {
             path,
         });
     }
-    if tags.is_empty() && project_path.is_none() {
+    if tags.is_empty() && !has_project {
         return None;
     }
     Some(LastSessionKit {
@@ -758,6 +765,7 @@ fn parse_session_kit(value: &Value) -> Option<LastSessionKit> {
         game,
         profile_id,
         project_path,
+        has_project,
         browser_mode,
         browser_sort,
         tags,
@@ -804,6 +812,7 @@ fn session_value(session: &LastSessionState) -> Value {
                     "game": kit.game,
                     "profile_id": kit.profile_id,
                     "project_path": kit.project_path.as_ref().map(|path| path.display().to_string()),
+                    "has_project": kit.has_project,
                 },
                 "browser_mode": kit.browser_mode.map(browser_mode_str),
                 "browser_sort": kit.browser_sort.map(browser_sort_str),
@@ -1150,6 +1159,7 @@ mod session_tests {
             game: None,
             profile_id: None,
             project_path: None,
+            has_project: false,
             browser_mode: mode,
             browser_sort: Some(BrowserSort::Name),
             tags: vec![LastSessionTag {
@@ -1201,6 +1211,7 @@ mod session_tests {
     fn a_projects_path_survives_the_round_trip() {
         let mut project_kit = kit("/evolved", None);
         project_kit.project_path = Some(PathBuf::from("/evolved/work.baboon"));
+        project_kit.has_project = true;
         project_kit.tags.clear();
         let session = LastSessionState {
             kits: vec![project_kit],
@@ -1210,5 +1221,43 @@ mod session_tests {
             restored.kits[0].project_path,
             Some(PathBuf::from("/evolved/work.baboon"))
         );
+        assert!(restored.kits[0].has_project);
+    }
+
+    /// A workspace whose only content is its stash records no project path — its
+    /// edits live in the recovery file, which is found from the source root — so
+    /// "carries a project" cannot be inferred from that path any more. Reading it
+    /// that way would drop such a kit from the session entirely and lose the
+    /// stash with it.
+    #[test]
+    fn a_stash_only_kit_survives_the_round_trip() {
+        let mut stash_kit = kit("/evolved", None);
+        stash_kit.has_project = true;
+        stash_kit.tags.clear();
+        let session = LastSessionState { kits: vec![stash_kit] };
+        let restored = parse_last_session(&session_value(&session)).expect("round trip");
+        assert_eq!(restored.kits[0].project_path, None);
+        assert!(restored.kits[0].has_project);
+    }
+
+    /// Sessions written before the recovery file and the project file were
+    /// separate recorded the recovery path as `project_path`, and set it for every
+    /// workspace that had a project at all. That is what `has_project` now means,
+    /// so its absence reads straight off the old field.
+    #[test]
+    fn a_legacy_sessions_recovery_path_still_restores_the_workspace() {
+        let value = serde_json::json!({
+            "version": 3,
+            "kits": [{
+                "source": {
+                    "kind": "iostore_container_set",
+                    "path": "/evolved",
+                    "project_path": "/data/campaign_evolved_recovery-abc123.baboon",
+                },
+                "tags": [],
+            }],
+        });
+        let session = parse_last_session(&value).expect("session parses");
+        assert!(session.kits[0].has_project, "the kit is still restored");
     }
 }

--- a/src/app/project.rs
+++ b/src/app/project.rs
@@ -110,14 +110,31 @@ impl CampaignProjectSnapshot {
 }
 
 pub(super) struct ActiveCampaignProject {
-    pub(super) path: PathBuf,
+    /// Where this workspace autosaves. Always derived from the mounted source
+    /// — never a file the user picked.
+    ///
+    /// The two paths are kept apart because they were once one field, and
+    /// opening a `.baboon` therefore made *that* file the autosave target: an
+    /// exported mod's sidecar became a live, self-overwriting file the moment it
+    /// was opened, and declining to save at exit deleted the stashed rows out of
+    /// it. Autosave now only ever writes the recovery file.
+    pub(super) recovery_path: PathBuf,
+    /// The `.baboon` this workspace is associated with: what `File > Open
+    /// Baboon Project` opened, or where `Save Baboon Project As...` last wrote.
+    /// It is the target of `File > Save Baboon Project`, and nothing else
+    /// writes to it.
+    pub(super) project_path: Option<PathBuf>,
     pub(super) overlays: HashMap<String, CampaignProjectOverlay>,
     /// Document key -> the `Dirty` revision its overlay bytes were written
     /// from, so an untouched document is never serialized twice.
     pub(super) captured_revisions: HashMap<String, u64>,
-    /// What is actually on disk, by identity, so a save writes only the rows
+    /// What the recovery file holds, by identity, so a save writes only the rows
     /// whose bytes changed instead of replacing every overlay.
-    pub(super) saved_digests: HashMap<String, [u8; 32]>,
+    ///
+    /// `None` when that is unknown — a fresh workspace, or a project imported
+    /// from a file the recovery has never seen — and the next write then
+    /// replaces every row rather than merging into whatever was there.
+    pub(super) saved_digests: Option<HashMap<String, [u8; 32]>>,
     /// What an in-flight write will leave on disk, promoted to `saved_digests`
     /// once it reports success.
     pub(super) pending_digests: Option<HashMap<String, [u8; 32]>>,
@@ -142,12 +159,15 @@ pub(super) struct ActiveCampaignProject {
 }
 
 impl ActiveCampaignProject {
-    pub(super) fn fresh(path: PathBuf, now: f64) -> Self {
+    pub(super) fn fresh(recovery_path: PathBuf, now: f64) -> Self {
         Self {
-            path,
+            recovery_path,
+            project_path: None,
             overlays: HashMap::new(),
             captured_revisions: HashMap::new(),
-            saved_digests: HashMap::new(),
+            // Nothing is known about whatever file may be sitting at the
+            // recovery path, so the first write replaces it outright.
+            saved_digests: None,
             pending_digests: None,
             last_saved_fingerprint: Vec::new(),
             next_autosave_at: now + CAMPAIGN_PROJECT_AUTOSAVE_SECS,
@@ -159,24 +179,52 @@ impl ActiveCampaignProject {
         }
     }
 
-    pub(super) fn from_snapshot(
-        path: PathBuf,
+    /// The recovery file's own contents, picked back up. Its digests are exactly
+    /// what is stored there, and it needs no rewrite until something changes.
+    pub(super) fn adopted(
+        recovery_path: PathBuf,
         snapshot: &CampaignProjectSnapshot,
         now: f64,
     ) -> Self {
         Self {
-            path,
-            // Restored overlays came off disk, so that is exactly what is
-            // stored there.
-            saved_digests: snapshot
-                .overlays
-                .iter()
-                .map(|(identity, overlay)| (identity.clone(), overlay.digest))
-                .collect(),
+            saved_digests: Some(snapshot.digests()),
+            last_saved_fingerprint: snapshot.fingerprint(),
+            ..Self::from_snapshot_parts(recovery_path, snapshot, now)
+        }
+    }
+
+    /// A project read from a `.baboon` the user pointed at. The recovery file has
+    /// never held these bytes, so neither the digests nor the fingerprint may
+    /// claim otherwise: leaving either behind would let the first autosave
+    /// conclude there was nothing to write and merge these overlays into
+    /// whatever the last workspace left at that path.
+    pub(super) fn imported(
+        recovery_path: PathBuf,
+        project_path: PathBuf,
+        snapshot: &CampaignProjectSnapshot,
+        now: f64,
+    ) -> Self {
+        Self {
+            project_path: Some(project_path),
+            saved_digests: None,
+            last_saved_fingerprint: Vec::new(),
+            ..Self::from_snapshot_parts(recovery_path, snapshot, now)
+        }
+    }
+
+    fn from_snapshot_parts(
+        recovery_path: PathBuf,
+        snapshot: &CampaignProjectSnapshot,
+        now: f64,
+    ) -> Self {
+        Self {
+            recovery_path,
+            project_path: None,
+            saved_digests: None,
             overlays: snapshot.overlays.clone(),
             captured_revisions: HashMap::new(),
             pending_digests: None,
-            last_saved_fingerprint: snapshot.fingerprint(),
+            last_saved_fingerprint: Vec::new(),
             next_autosave_at: now + CAMPAIGN_PROJECT_AUTOSAVE_SECS,
             revision: 0,
             save_in_flight: None,
@@ -190,11 +238,29 @@ impl ActiveCampaignProject {
                 .collect(),
         }
     }
+
+    /// What to show as this workspace's project, and where its edits actually
+    /// live. The recovery file is not something the user named, so it is
+    /// described rather than presented as an open document.
+    pub(super) fn label(&self) -> String {
+        match self.project_path.as_deref() {
+            Some(path) => path
+                .file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+                .unwrap_or_else(|| path.display().to_string()),
+            None => "unsaved".to_owned(),
+        }
+    }
 }
 
 pub(super) struct PendingCampaignProject {
     pub(super) path: PathBuf,
-    pub(super) snapshot: CampaignProjectSnapshot,
+    /// The project to open once the source mounts. `None` stages the path as
+    /// this workspace's save target *without* reading it back in, which is what
+    /// a session restore wants: the workspace's recovery file is always the
+    /// fresher copy of the same edits, so re-importing the `.baboon` the user
+    /// happened to have open would overwrite newer work with older.
+    pub(super) snapshot: Option<CampaignProjectSnapshot>,
 }
 
 /// Where a Campaign Evolved kit autosaves its recovery project.
@@ -211,7 +277,19 @@ pub(super) fn campaign_recovery_path(source_root: Option<&Path>) -> PathBuf {
     hasher.update(root.to_string_lossy().as_bytes());
     let digest = hasher.finalize();
     let tag = digest[..6].iter().map(|b| format!("{b:02x}")).collect::<String>();
-    crate::storage::data_path(&format!("campaign_evolved_recovery-{tag}.baboon"))
+    crate::storage::data_path(&format!("{CAMPAIGN_RECOVERY_STEM}-{tag}.baboon"))
+}
+
+pub(super) const CAMPAIGN_RECOVERY_STEM: &str = "campaign_evolved_recovery";
+
+/// Whether `path` is one of Baboon's own recovery files rather than a `.baboon`
+/// the user named. Recovery files are an implementation detail of a workspace —
+/// they are not offered as a save target, and a session that recorded one back
+/// when the two were the same file must not be read as having a project open.
+pub(super) fn is_campaign_recovery_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.starts_with(CAMPAIGN_RECOVERY_STEM))
 }
 
 /// Write the project to `path`.
@@ -534,7 +612,7 @@ impl Baboon {
             _ => None,
         };
         self.kits[kit].campaign_project = Some(match &restored {
-            Some(snapshot) => ActiveCampaignProject::from_snapshot(path, snapshot, now),
+            Some(snapshot) => ActiveCampaignProject::adopted(path, snapshot, now),
             None => ActiveCampaignProject::fresh(path, now),
         });
         if let Some(count) = restored
@@ -835,6 +913,21 @@ impl Baboon {
             .is_some_and(|project| project.overlays.remove(&identity).is_some())
     }
 
+    /// Whether this kit's project has bytes stashed for `key` — that is, whether
+    /// discarding the document would also delete something from disk.
+    pub(super) fn tag_has_stashed_overlay(&self, kit: usize, key: &str) -> bool {
+        let Some(entry) = self.entry_for_key_in(kit, key) else {
+            return false;
+        };
+        let Some((identity, ..)) = campaign_entry_project_parts(entry) else {
+            return false;
+        };
+        self.kits[kit]
+            .campaign_project
+            .as_ref()
+            .is_some_and(|project| project.overlays.contains_key(&identity))
+    }
+
     /// Forget every stashed overlay in this kit's project, returning how many
     /// tags were carrying one.
     pub(super) fn forget_all_campaign_overlays(&mut self, kit: usize) -> usize {
@@ -903,7 +996,7 @@ impl Baboon {
         let Some(project) = self.kits[kit].campaign_project.as_mut() else {
             return Ok(false);
         };
-        if fingerprint == project.last_saved_fingerprint && project.path.is_file() {
+        if fingerprint == project.last_saved_fingerprint && project.recovery_path.is_file() {
             project.next_autosave_at = now + CAMPAIGN_PROJECT_AUTOSAVE_SECS;
             return Ok(false);
         }
@@ -918,8 +1011,8 @@ impl Baboon {
             .lock()
             .map_err(|_| "Campaign project writer lock was poisoned".to_owned())?;
         let on_disk = project.saved_digests.clone();
-        save_campaign_project(&project.path, &snapshot, Some(&on_disk))?;
-        project.saved_digests = snapshot.digests();
+        save_campaign_project(&project.recovery_path, &snapshot, on_disk.as_ref())?;
+        project.saved_digests = Some(snapshot.digests());
         project.last_saved_fingerprint = fingerprint;
         project.next_autosave_at = now + CAMPAIGN_PROJECT_AUTOSAVE_SECS;
         if let Some(session) = self.current_session_state() {
@@ -976,12 +1069,12 @@ impl Baboon {
             let Some(project) = self.kits[kit].campaign_project.as_mut() else {
                 return;
             };
-            if fingerprint == project.last_saved_fingerprint && project.path.is_file() {
+            if fingerprint == project.last_saved_fingerprint && project.recovery_path.is_file() {
                 project.next_autosave_at = now + CAMPAIGN_PROJECT_AUTOSAVE_SECS;
             } else {
                 project.revision = project.revision.wrapping_add(1);
                 let revision = project.revision;
-                let path = project.path.clone();
+                let path = project.recovery_path.clone();
                 let write_lock = project.write_lock.clone();
                 let latest_write_revision = project.latest_write_revision.clone();
                 latest_write_revision.store(revision, Ordering::SeqCst);
@@ -1000,7 +1093,7 @@ impl Baboon {
                             if latest_write_revision.load(Ordering::SeqCst) != revision {
                                 Ok(())
                             } else {
-                                save_campaign_project(&path, &snapshot, Some(&on_disk))
+                                save_campaign_project(&path, &snapshot, on_disk.as_ref())
                             }
                         });
                     let _ = tx.send(WorkerMessage::CampaignProjectSaved {
@@ -1028,7 +1121,7 @@ impl Baboon {
         // outlives its kit is dropped instead of landing on another one.
         let Some(kit) = self.kits.iter().position(|kit| {
             kit.campaign_project.as_ref().is_some_and(|project| {
-                project.path == path && project.save_in_flight == Some(revision)
+                project.recovery_path == path && project.save_in_flight == Some(revision)
             })
         }) else {
             return true;
@@ -1045,7 +1138,7 @@ impl Baboon {
                 // the previous belief in place, so the next save reconciles
                 // against what actually got there.
                 if let Some(digests) = pending {
-                    project.saved_digests = digests;
+                    project.saved_digests = Some(digests);
                 }
                 if let Some(session) = self.current_session_state() {
                     let _ = save_last_session(&session);
@@ -1069,17 +1162,114 @@ impl Baboon {
         self.begin_open_campaign_project_path(path, ctx);
     }
 
-    /// Stage a project to be applied when a source load already in flight
-    /// completes. Session restore uses this: the kit's source is being loaded
-    /// by the restore itself, so opening the project must not start a second
-    /// load of its own.
-    pub(super) fn queue_campaign_project(&mut self, kit: usize, path: PathBuf) {
-        match load_campaign_project(&path) {
-            Ok(snapshot) => {
-                self.kits[kit].pending_campaign_project = Some(PendingCampaignProject { path, snapshot })
-            }
-            Err(error) => self.status = error,
+    /// Stage the `.baboon` a restored session had open as that workspace's save
+    /// target, to be attached once the source finishes mounting.
+    ///
+    /// Deliberately *not* an import: the workspace autosaves to its recovery
+    /// file, which is therefore at least as fresh as the project file and
+    /// usually fresher. Reading the `.baboon` back in would replace this
+    /// session's stashed edits with whatever state the file was last explicitly
+    /// saved in.
+    pub(super) fn queue_campaign_project_target(&mut self, kit: usize, path: PathBuf) {
+        // Sessions written before the recovery file and the project file were
+        // separate recorded the recovery path here. It is not a project the user
+        // named, and offering it as a save target would be wrong.
+        if is_campaign_recovery_file(&path) {
+            return;
         }
+        self.kits[kit].pending_campaign_project =
+            Some(PendingCampaignProject { path, snapshot: None });
+    }
+
+    /// Write this workspace's project to its associated `.baboon`, asking for a
+    /// destination when it has none yet.
+    pub(super) fn save_campaign_project_file(&mut self, kit: usize, now: f64) {
+        let Some(path) = self.kits[kit]
+            .campaign_project
+            .as_ref()
+            .and_then(|project| project.project_path.clone())
+        else {
+            self.save_campaign_project_file_as(kit, now);
+            return;
+        };
+        self.write_campaign_project_file(kit, path, now);
+    }
+
+    pub(super) fn save_campaign_project_file_as(&mut self, kit: usize, now: f64) {
+        if !self.current_source_is_campaign_project_capable(kit) {
+            self.status = "Baboon projects require a Campaign Evolved container source".to_owned();
+            return;
+        }
+        let current = self.kits[kit]
+            .campaign_project
+            .as_ref()
+            .and_then(|project| project.project_path.clone());
+        let mut dialog = rfd::FileDialog::new()
+            .set_title("Save Baboon Project As")
+            .add_filter("Baboon project", &["baboon"])
+            .set_file_name(
+                current
+                    .as_deref()
+                    .and_then(Path::file_name)
+                    .map(|name| name.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| "campaign-evolved.baboon".to_owned()),
+            );
+        // Next to the project it is replacing, else beside the game it edits.
+        if let Some(folder) = current
+            .as_deref()
+            .and_then(Path::parent)
+            .map(Path::to_path_buf)
+            .or_else(|| {
+                self.kits[kit]
+                    .source
+                    .as_ref()
+                    .map(|source| source.source.root_path().to_path_buf())
+            })
+        {
+            dialog = dialog.set_directory(folder);
+        }
+        let Some(path) = dialog.save_file() else {
+            return;
+        };
+        // A dialog that returns an extensionless name would otherwise write a
+        // project that `Open Baboon Project` cannot see.
+        let path = match path.extension() {
+            Some(_) => path,
+            None => path.with_extension("baboon"),
+        };
+        self.write_campaign_project_file(kit, path, now);
+    }
+
+    fn write_campaign_project_file(&mut self, kit: usize, path: PathBuf, now: f64) {
+        let snapshot = match self.capture_campaign_project(kit, now) {
+            Ok(Some(snapshot)) => snapshot,
+            Ok(None) => {
+                self.status =
+                    "Baboon projects require a Campaign Evolved container source".to_owned();
+                return;
+            }
+            Err(error) => {
+                self.status = format!("Could not save the Baboon project: {error}");
+                return;
+            }
+        };
+        // Nothing here knows what is in a file the user named, and it may be an
+        // older project entirely, so it is replaced rather than merged into.
+        if let Err(error) = save_campaign_project(&path, &snapshot, None) {
+            self.status = error;
+            return;
+        }
+        let count = snapshot.overlays.len();
+        if let Some(project) = self.kits[kit].campaign_project.as_mut() {
+            project.project_path = Some(path.clone());
+        }
+        // The recovery file stays the live copy, so it is brought level with what
+        // was just written out.
+        if let Err(error) = self.checkpoint_campaign_project(kit, now) {
+            self.status = format!("Saved {}, but the recovery file failed: {error}", path.display());
+            return;
+        }
+        self.status = format!("Saved {count} modified tag(s) to {}", path.display());
     }
 
     pub(super) fn begin_open_campaign_project_path(&mut self, path: PathBuf, ctx: egui::Context) {
@@ -1109,8 +1299,10 @@ impl Baboon {
         self.begin_load_folder_path(source_path, ctx);
         // Staged after the load starts: the loader has routed to a kit and
         // left it active, so this lands on the kit the source will mount into.
-        self.kits[self.active].pending_campaign_project =
-            Some(PendingCampaignProject { path, snapshot });
+        self.kits[self.active].pending_campaign_project = Some(PendingCampaignProject {
+            path,
+            snapshot: Some(snapshot),
+        });
     }
 
     pub(super) fn apply_pending_campaign_project(
@@ -1127,6 +1319,17 @@ impl Baboon {
             self.status = "Baboon projects require a Campaign Evolved container source".to_owned();
             return;
         }
+        // A restored session stages its project file as a save target only; the
+        // recovery file this workspace has been autosaving to is the live copy,
+        // and `ensure_campaign_project` has just picked it back up.
+        let Some(snapshot) = pending.snapshot else {
+            self.ensure_campaign_project(kit, now);
+            if let Some(project) = self.kits[kit].campaign_project.as_mut() {
+                project.project_path = Some(pending.path);
+            }
+            return;
+        };
+        let project_path = pending.path;
 
         let mut identity_to_key = HashMap::<String, String>::new();
         let mut restored_revisions = HashMap::<String, u64>::new();
@@ -1134,8 +1337,7 @@ impl Baboon {
 
         // Recreate new project tags first, including ones that are currently
         // closed but must remain part of future exports.
-        let new_overlays = pending
-            .snapshot
+        let new_overlays = snapshot
             .overlays
             .values()
             .filter(|overlay| overlay.kind == CampaignProjectTagKind::New)
@@ -1151,7 +1353,7 @@ impl Baboon {
             identity_to_key.insert(overlay.identity.clone(), key);
         }
 
-        for tab in &pending.snapshot.tabs {
+        for tab in &snapshot.tabs {
             if identity_to_key.contains_key(&tab.identity) {
                 continue;
             }
@@ -1168,11 +1370,11 @@ impl Baboon {
         self.kits[kit].tag_tree = egui_tiles::Tree::empty(tag_tree_id(kit_id));
         self.kits[kit].open_tabs.clear();
         self.kits[kit].selected_key = None;
-        for tab in &pending.snapshot.tabs {
+        for tab in &snapshot.tabs {
             let Some(key) = identity_to_key.get(&tab.identity).cloned() else {
                 continue;
             };
-            if let Some(overlay) = pending.snapshot.overlays.get(&tab.identity) {
+            if let Some(overlay) = snapshot.overlays.get(&tab.identity) {
                 if let Ok(tag) = TagFile::read_from_bytes(&overlay.bytes) {
                     let document = TagDocument::modified(tag);
                     // The document was parsed from the overlay's own bytes, so
@@ -1190,8 +1392,7 @@ impl Baboon {
             }
             self.kits[kit].open_tag_pane(&key);
         }
-        self.kits[kit].selected_key = pending
-            .snapshot
+        self.kits[kit].selected_key = snapshot
             .selected_identity
             .as_ref()
             .and_then(|identity| identity_to_key.get(identity))
@@ -1202,15 +1403,27 @@ impl Baboon {
         if let Some(key) = self.kits[kit].selected_key.clone() {
             self.kits[kit].open_tag_pane(&key);
         }
-        let mut project = ActiveCampaignProject::from_snapshot(pending.path, &pending.snapshot, now);
+        let root = self.kits[kit]
+            .source
+            .as_ref()
+            .map(|source| source.source.root_path().to_path_buf());
+        let recovery_path = campaign_recovery_path(root.as_deref());
+        let mut project =
+            ActiveCampaignProject::imported(recovery_path, project_path, &snapshot, now);
         project.captured_revisions = restored_revisions;
+        let tabs = snapshot.tabs.len();
+        let stashed = snapshot.overlays.len();
         self.kits[kit].campaign_project = Some(project);
+        // These overlays have only ever existed in the file the user opened. The
+        // recovery file is what every later autosave writes and what the next
+        // session picks up, so it is brought level with them now rather than at
+        // the mercy of whether anything is edited afterwards.
+        if let Err(error) = self.checkpoint_campaign_project(kit, now) {
+            self.status = format!("Opened the project, but its recovery file failed: {error}");
+            return;
+        }
         self.status = if missing == 0 {
-            format!(
-                "Restored Campaign Evolved project ({} tab(s), {} modified tag(s))",
-                pending.snapshot.tabs.len(),
-                pending.snapshot.overlays.len()
-            )
+            format!("Restored Campaign Evolved project ({tabs} tab(s), {stashed} modified tag(s))")
         } else {
             format!(
                 "Restored Campaign Evolved project; skipped {missing} missing or incompatible item(s)"
@@ -1347,6 +1560,115 @@ mod tests {
         let changed = snapshot_of(vec![overlay("a", b"other")]);
         assert_eq!(before.fingerprint(), same.fingerprint());
         assert_ne!(before.fingerprint(), changed.fingerprint());
+    }
+
+    fn temp_project(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "baboon-{name}-{}-{}.baboon",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
+
+    fn identities_in(path: &Path) -> Vec<String> {
+        let mut identities: Vec<String> = load_campaign_project(path)
+            .unwrap()
+            .overlays
+            .into_keys()
+            .collect();
+        identities.sort();
+        identities
+    }
+
+    /// A `.baboon` the user opened is not what the workspace writes to. It was,
+    /// and so an exported mod's sidecar became a live file the moment it was
+    /// opened: autosave rewrote it, and declining to save at exit deleted the
+    /// stashed rows straight out of it — which is how an exported mod's project
+    /// came back empty two sessions later.
+    #[test]
+    fn an_opened_project_is_never_the_autosave_target() {
+        let recovery = temp_project("recovery");
+        let opened = temp_project("opened");
+        let snapshot = snapshot_of(vec![overlay("a", b"one")]);
+        let project =
+            ActiveCampaignProject::imported(recovery.clone(), opened.clone(), &snapshot, 0.0);
+        assert_eq!(project.recovery_path, recovery);
+        assert_eq!(project.project_path, Some(opened.clone()));
+        assert_eq!(
+            project.label(),
+            opened.file_name().unwrap().to_string_lossy(),
+            "the workspace is labelled with the project the user opened"
+        );
+    }
+
+    /// An imported project's overlays have never been in the recovery file, so
+    /// neither the digests nor the fingerprint may claim they have. Either one
+    /// would let the first autosave decide there was nothing to write — leaving
+    /// the workspace's live copy as whatever the last session left there.
+    #[test]
+    fn an_imported_project_replaces_a_stale_recovery_file() {
+        let recovery = temp_project("stale-recovery");
+        // What an earlier session of this workspace left behind.
+        save_campaign_project(&recovery, &snapshot_of(vec![overlay("old", b"x")]), None).unwrap();
+
+        let imported = snapshot_of(vec![overlay("new", b"y")]);
+        let project = ActiveCampaignProject::imported(
+            recovery.clone(),
+            temp_project("opened"),
+            &imported,
+            0.0,
+        );
+        assert!(
+            project.saved_digests.is_none(),
+            "nothing is known about the recovery file, so it must be replaced whole"
+        );
+        assert_ne!(
+            project.last_saved_fingerprint,
+            imported.fingerprint(),
+            "the recovery file does not hold these bytes yet, so a write is due"
+        );
+        // Exactly what `checkpoint_campaign_project` then does with them.
+        save_campaign_project(&recovery, &imported, project.saved_digests.as_ref()).unwrap();
+        assert_eq!(
+            identities_in(&recovery),
+            vec!["new"],
+            "the stale row was replaced, not merged into"
+        );
+        let _ = fs::remove_file(&recovery);
+    }
+
+    /// The recovery file the workspace autosaves to is picked back up as-is, so
+    /// it needs neither a rewrite nor a full replace until something changes.
+    #[test]
+    fn an_adopted_recovery_file_is_believed() {
+        let recovery = temp_project("adopted");
+        let snapshot = snapshot_of(vec![overlay("a", b"one")]);
+        let project = ActiveCampaignProject::adopted(recovery, &snapshot, 0.0);
+        assert_eq!(project.saved_digests, Some(snapshot.digests()));
+        assert_eq!(project.last_saved_fingerprint, snapshot.fingerprint());
+        assert_eq!(project.project_path, None);
+        assert_eq!(
+            project.label(),
+            "unsaved",
+            "a recovery file is not a project the user named"
+        );
+    }
+
+    /// Baboon's own recovery files are not save targets, and a session that
+    /// recorded one — every session written while the two were the same file —
+    /// must not come back reading as though the user had a project open.
+    #[test]
+    fn recovery_files_are_recognized_as_baboons_own() {
+        assert!(is_campaign_recovery_file(&campaign_recovery_path(Some(
+            Path::new("/games/evolved/Paks")
+        ))));
+        assert!(is_campaign_recovery_file(&campaign_recovery_path(None)));
+        assert!(!is_campaign_recovery_file(Path::new(
+            "/games/evolved/Paks/~mods/mymod_P.baboon"
+        )));
     }
 
     #[test]

--- a/src/app/shader/h2.rs
+++ b/src/app/shader/h2.rs
@@ -2368,10 +2368,17 @@ fn classic_shader_row_edit(
         }),
         TagFieldData::Real(value)
         | TagFieldData::RealSlider(value)
-        | TagFieldData::RealFraction(value)
-        | TagFieldData::Angle(value) => Some(ShaderRowEdit {
+        | TagFieldData::RealFraction(value) => Some(ShaderRowEdit {
             path: path.to_owned(),
             current: value.to_string(),
+            kind: ShaderRowEditKind::Scalar,
+        }),
+        // Degrees, like every other angle box in the editor. This grid commits
+        // through the same parser, so showing the stored radians here would mean
+        // typing back what was shown divided the value by 57.3.
+        TagFieldData::Angle(value) => Some(ShaderRowEdit {
+            path: path.to_owned(),
+            current: crate::app::foundation::fmt_degrees(*value),
             kind: ShaderRowEditKind::Scalar,
         }),
         TagFieldData::CharInteger(value) => classic_int_edit(path, *value as i64, formatted),

--- a/src/app/shader/rows.rs
+++ b/src/app/shader/rows.rs
@@ -103,7 +103,9 @@ pub(in crate::app) fn shader_param_field_path(
     field: &str,
 ) -> Option<String> {
     let i = param_index?;
-    let escaped = field.replace('/', "\\/");
+    // `int/bool` is a real field name; the resolver takes clean names, in which
+    // that slash is a backslash. Anything else leaves the slash separating.
+    let escaped = escape_field_path_segment(field);
     Some(append_field_path(
         prefix,
         &format!("parameters[{i}]/{escaped}"),

--- a/src/app/shader/tests.rs
+++ b/src/app/shader/tests.rs
@@ -80,3 +80,113 @@ mod phase4_tests {
         assert!(reset_op_for_row(&row).is_none());
     }
 }
+
+#[cfg(test)]
+mod slashed_field_names {
+    use super::*;
+
+    /// A shader bool or int parameter is stored in a field literally named
+    /// `int/bool`, and the path grammar has no escapes: a segment is the field's
+    /// *clean* name, in which that slash is a backslash. Inventing an escape left
+    /// the slash separating, so the segment became `int\` + `bool` and every write
+    /// failed with "field path no longer resolves" — which is what made
+    /// `no_dynamic_lights`, `use_material_texture` and `order3_area_specular`
+    /// impossible to enable.
+    #[test]
+    fn a_slash_in_a_field_name_becomes_a_backslash_not_an_escape() {
+        assert_eq!(escape_field_path_segment("int/bool"), "int\\bool");
+        assert_eq!(
+            shader_param_field_path("render_method", Some(3), "int/bool").as_deref(),
+            Some("render_method/parameters[3]/int\\bool")
+        );
+        // Ordinary names are untouched, and markup is cleaned exactly as the
+        // engine's own addressing does.
+        assert_eq!(escape_field_path_segment("parameter type"), "parameter type");
+        assert_eq!(escape_field_path_segment("parameter name^"), "parameter name");
+        // Whatever the engine says a clean name is, this has to agree with it.
+        for raw in ["int/bool", "aiming/looking", "max nodes/vertex", "Densities (g/mL)"] {
+            assert_eq!(
+                escape_field_path_segment(raw),
+                blam_tags::field_name::clean_field_name(raw).into_owned(),
+                "{raw} disagreed with the engine's clean name"
+            );
+        }
+    }
+
+    /// End to end against the shipped H3 tags: create a bool parameter the way the
+    /// grid's "Override Default" does, and read back what landed.
+    #[test]
+    fn enabling_a_bool_shader_parameter_writes_it() {
+        let path = std::path::Path::new(
+            "/Users/camden/Halo/halo3_mcc/tags/objects/characters/brute/shaders/armor_lights.shader",
+        );
+        if !path.exists() {
+            eprintln!("skipping: no H3 editing kit");
+            return;
+        }
+        let bytes = std::fs::read(path).expect("read shader");
+        let mut tag = blam_tags::TagFile::read_from_bytes(&bytes).expect("parse shader");
+        let prefix = render_method_edit_prefix(&tag);
+        let block = append_field_path(&prefix, "parameters");
+
+        for name in ["no_dynamic_lights", "use_material_texture", "order3_area_specular"] {
+            let op = ShaderParamOp {
+                parameters_block_path: block.clone(),
+                parameter_name: name.to_owned(),
+                initial_fields: vec![
+                    ShaderParamInitialField {
+                        field: "parameter type".to_owned(),
+                        // `bool` in the parameter-type enum.
+                        input: "4".to_owned(),
+                    },
+                    ShaderParamInitialField {
+                        field: "int/bool".to_owned(),
+                        input: "1".to_owned(),
+                    },
+                ],
+                animated_parameters: Vec::new(),
+            };
+            let message = apply_one_shader_param_op(&mut tag, &op)
+                .unwrap_or_else(|error| panic!("enabling {name} failed: {error}"));
+            eprintln!("{message}");
+        }
+
+        // The values have to survive a save, not just the in-memory write.
+        let saved = tag.write_to_bytes().expect("serialize");
+        let reopened = blam_tags::TagFile::read_from_bytes(&saved).expect("reparse");
+        let root = reopened.root();
+        let parameters = root
+            .field_path(&block)
+            .and_then(|field| field.as_block())
+            .expect("parameters block");
+        let mut enabled = Vec::new();
+        for index in 0..parameters.len() {
+            let Some(element) = parameters.element(index) else { continue };
+            let name = element
+                .field("parameter name")
+                .and_then(|field| field.value())
+                .and_then(|value| match value {
+                    blam_tags::TagFieldData::StringId(s)
+                    | blam_tags::TagFieldData::OldStringId(s) => Some(s.string.clone()),
+                    _ => None,
+                })
+                .unwrap_or_default();
+            let value = element
+                .field_path("int\\bool")
+                .and_then(|field| field.value())
+                .and_then(|value| match value {
+                    blam_tags::TagFieldData::LongInteger(v) => Some(v),
+                    _ => None,
+                });
+            if value == Some(1) {
+                enabled.push(name);
+            }
+        }
+        for expected in ["no_dynamic_lights", "use_material_texture", "order3_area_specular"] {
+            assert!(
+                enabled.iter().any(|name| name == expected),
+                "{expected} is not enabled in the saved tag; enabled: {enabled:?}"
+            );
+        }
+    }
+}

--- a/src/app/state/documents.rs
+++ b/src/app/state/documents.rs
@@ -387,6 +387,19 @@ pub(in crate::app) struct ModExportRow {
     pub(in crate::app) bytes: usize,
     /// Why this tag cannot be exported, when it cannot.
     pub(in crate::app) reason: Option<String>,
+    /// The mounted mod currently serving this tag, if one is. The comparison
+    /// below the row is against the game's own pack either way, so without this
+    /// there is nothing to explain why the editor is showing the mod's values.
+    pub(in crate::app) overridden_by: Option<String>,
+}
+
+impl ModExportDialog {
+    /// The container this export would write, which may be one this workspace has
+    /// mounted — that is what makes a re-export of an installed mod impossible
+    /// while it is open.
+    pub(in crate::app) fn output_utoc(&self) -> PathBuf {
+        self.folder.join(format!("{}.utoc", self.stem()))
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/app/state/documents.rs
+++ b/src/app/state/documents.rs
@@ -103,6 +103,16 @@ pub(in crate::app) struct SaveChangesPrompt {
     pub(in crate::app) pending_action: PendingCloseAction,
     pub(in crate::app) error: Option<String>,
     pub(in crate::app) allow_app_close_once: bool,
+    /// Where discarding would delete from, and how many of the listed tags have
+    /// a stashed copy there. Discarding on a stashing workspace is not "close
+    /// without writing anything" — it deletes rows out of a file that persists
+    /// across sessions — so the prompt has to be able to name both.
+    pub(in crate::app) stash_file: Option<PathBuf>,
+    pub(in crate::app) stashed: usize,
+    /// Set by the first click on Discard. The second click is the one that acts,
+    /// which is what keeps a one-click "no thanks" on a quit dialog from
+    /// deleting work the user believed was already exported.
+    pub(in crate::app) confirm_discard: bool,
 }
 
 impl Default for SaveChangesPrompt {
@@ -114,6 +124,9 @@ impl Default for SaveChangesPrompt {
             pending_action: PendingCloseAction::CloseApp,
             error: None,
             allow_app_close_once: false,
+            stash_file: None,
+            stashed: 0,
+            confirm_discard: false,
         }
     }
 }
@@ -162,7 +175,13 @@ pub(in crate::app) struct LastSessionKit {
     pub(in crate::app) source_path: PathBuf,
     pub(in crate::app) game: Option<String>,
     pub(in crate::app) profile_id: Option<String>,
+    /// The `.baboon` this kit had open, to reattach as its save target. `None`
+    /// for a workspace whose edits only ever lived in its recovery file.
     pub(in crate::app) project_path: Option<PathBuf>,
+    /// Whether this kit carried a Baboon project at all. A workspace with a
+    /// stash but no named project file is still worth reopening — the project
+    /// *is* the session — and that no longer follows from `project_path`.
+    pub(in crate::app) has_project: bool,
     /// The browser view this kit was in, or `None` when the session predates
     /// per-kit views — the restored kit then falls back to the saved default.
     pub(in crate::app) browser_mode: Option<BrowserMode>,
@@ -181,6 +200,7 @@ pub(in crate::app) struct RestoreKit {
     pub(in crate::app) source_path: PathBuf,
     pub(in crate::app) profile_id: Option<String>,
     pub(in crate::app) project_path: Option<PathBuf>,
+    pub(in crate::app) has_project: bool,
     /// The browser view this kit was in, or `None` when the session predates
     /// per-kit views — the restored kit then falls back to the saved default.
     pub(in crate::app) browser_mode: Option<BrowserMode>,
@@ -202,6 +222,7 @@ pub(in crate::app) struct LastOpenedWindowsKit {
     pub(in crate::app) profile_id: Option<String>,
     pub(in crate::app) source_available: bool,
     pub(in crate::app) project_path: Option<PathBuf>,
+    pub(in crate::app) has_project: bool,
     /// The browser view this kit was in, or `None` when the session predates
     /// per-kit views — the restored kit then falls back to the saved default.
     pub(in crate::app) browser_mode: Option<BrowserMode>,
@@ -253,7 +274,7 @@ impl LastOpenedWindowsKit {
                 }
             })
             .collect::<Vec<_>>();
-        if entries.is_empty() && saved.project_path.is_none() {
+        if entries.is_empty() && !saved.has_project {
             return None;
         }
         Some(Self {
@@ -263,6 +284,7 @@ impl LastOpenedWindowsKit {
             profile_id: saved.profile_id,
             source_available,
             project_path: saved.project_path,
+            has_project: saved.has_project,
             browser_mode: saved.browser_mode,
             browser_sort: saved.browser_sort,
             entries,
@@ -304,11 +326,12 @@ impl LastOpenedWindowsPrompt {
             .iter()
             .filter_map(|kit| {
                 let tags = kit.checked_tags();
-                (!tags.is_empty() || kit.project_path.is_some()).then(|| RestoreKit {
+                (!tags.is_empty() || kit.has_project).then(|| RestoreKit {
                     source_kind: kit.source_kind,
                     source_path: kit.source_path.clone(),
                     profile_id: kit.profile_id.clone(),
                     project_path: kit.project_path.clone(),
+                    has_project: kit.has_project,
                     browser_mode: kit.browser_mode,
                     browser_sort: kit.browser_sort,
                     tags,
@@ -320,7 +343,7 @@ impl LastOpenedWindowsPrompt {
     pub(in crate::app) fn has_checked_tags(&self) -> bool {
         self.kits
             .iter()
-            .any(|kit| !kit.checked_tags().is_empty() || kit.project_path.is_some())
+            .any(|kit| !kit.checked_tags().is_empty() || kit.has_project)
     }
 }
 

--- a/src/app/state/editing.rs
+++ b/src/app/state/editing.rs
@@ -5,6 +5,11 @@ use super::*;
 
 pub(in crate::app) enum DeferredFileAction {
     SaveCurrentTag,
+    /// Write this workspace's Baboon project to the `.baboon` it is associated
+    /// with, asking for one when it has none. Deferred like the other saves, so
+    /// an edit still focused in the editor is committed before the capture.
+    SaveProject,
+    SaveProjectAs,
     ExportMod,
     PokeCurrentTag,
     Close(PendingCloseAction),

--- a/src/app/tests/mod_overrides.rs
+++ b/src/app/tests/mod_overrides.rs
@@ -1,0 +1,283 @@
+//! Separating the game's own packs from mods installed into the same tree.
+//!
+//! Baboon mounts the pak folder recursively, exactly as the game does, so a mod
+//! in `Paks/~mods` -- or loose in `Paks` -- is mounted and wins every collision.
+//! That is correct for reading, and it silently redefined "as the game ships it"
+//! to mean "as this install currently loads it": every comparison against a
+//! modded tag came back empty, including a mod compared against an earlier export
+//! of itself.
+
+use super::*;
+
+const PAKS: &str = "/Users/camden/Halo/halo-campaign-evolved_pc/Meteorite/Content/Paks";
+
+fn mount() -> Option<crate::source::LoadedSourceData> {
+    if !std::path::Path::new(PAKS).exists() {
+        eprintln!("skipping: Campaign Evolved not present");
+        return None;
+    }
+    let defs = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("definitions");
+    let names = crate::format::TagNameIndex::load_from_definitions(&defs);
+    Some(
+        crate::source::load_iostore_container_set(std::path::PathBuf::from(PAKS), &names, &defs)
+            .expect("mount container set"),
+    )
+}
+
+/// The game's own packs must not be mistaken for mods, or every tag would be
+/// compared against nothing and the whole shipped layer would be empty.
+#[test]
+fn the_games_own_packs_are_not_mods() {
+    let Some(loaded) = mount() else { return };
+    let TagSource::IoStoreContainerSet {
+        containers,
+        shipped,
+        ..
+    } = &loaded.source
+    else {
+        panic!("not a container set");
+    };
+    let pakchunks = containers
+        .iter()
+        .filter(|container| container.chunk_label.starts_with("pakchunk"))
+        .collect::<Vec<_>>();
+    assert!(!pakchunks.is_empty(), "the install has pakchunk containers");
+    for container in pakchunks {
+        assert!(
+            !container.is_mod,
+            "{} is one of the game's own packs",
+            container.chunk_label
+        );
+    }
+    assert!(
+        !shipped.is_empty(),
+        "the shipped layer holds the game's own payloads"
+    );
+}
+
+/// Every tag the browser serves from a mod must still resolve to the game's own
+/// copy, or "what does this change about the game?" answers itself with
+/// "nothing" -- which is exactly what a user reported after installing an
+/// earlier export of their own mod.
+#[test]
+fn a_modded_tag_still_resolves_to_the_shipped_copy() {
+    let Some(loaded) = mount() else { return };
+    let TagSource::IoStoreContainerSet {
+        containers,
+        shipped,
+        ..
+    } = &loaded.source
+    else {
+        panic!("not a container set");
+    };
+    let mods = containers
+        .iter()
+        .enumerate()
+        .filter(|(_, container)| container.is_mod)
+        .map(|(index, container)| (index, container.chunk_label.clone()))
+        .collect::<Vec<_>>();
+    if mods.is_empty() {
+        eprintln!("skipping: no mod is installed in this Paks folder");
+        return;
+    }
+    eprintln!(
+        "{} mod container(s): {}",
+        mods.len(),
+        mods.iter()
+            .map(|(_, label)| label.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    let mod_indices = mods.iter().map(|(index, _)| *index).collect::<Vec<_>>();
+    let mut checked = 0usize;
+    for entry in &loaded.entries {
+        let TagEntryLocation::Container {
+            container,
+            rel_path,
+        } = &entry.location
+        else {
+            continue;
+        };
+        if !mod_indices.contains(container) {
+            continue;
+        }
+        checked += 1;
+        // The mod is what the mount resolved the tag to -- that part is correct,
+        // it is what the game loads.
+        let mounted = crate::source::read_entry(&loaded.source, entry)
+            .unwrap_or_else(|error| panic!("read {} as mounted: {error}", entry.display_path));
+        // ...and the game's own copy has to remain reachable beside it.
+        let base = crate::source::read_shipped_entry(&loaded.source, entry)
+            .unwrap_or_else(|error| panic!("read {} as shipped: {error}", entry.display_path));
+        let Some(base) = base else {
+            eprintln!(
+                "{} exists only in the mod, nothing shipped to compare",
+                entry.display_path
+            );
+            continue;
+        };
+        let shipped_container = shipped
+            .container_for(rel_path)
+            .expect("a shipped copy was just read");
+        assert!(
+            !mod_indices.contains(&shipped_container),
+            "{} resolved its shipped copy to a mod",
+            entry.display_path
+        );
+        assert_ne!(
+            shipped_container, *container,
+            "{} must read its baseline from a different container than the mod \
+             serving it, or the comparison is the mod against itself",
+            entry.display_path
+        );
+        // Whether the mod actually changed anything is up to the mod; what
+        // matters is that both sides are now readable and distinct.
+        let (base_bytes, mounted_bytes) = (
+            base.write_to_bytes().expect("serialize shipped"),
+            mounted.write_to_bytes().expect("serialize mounted"),
+        );
+        eprintln!(
+            "{}: shipped {} bytes from container {shipped_container}, mounted {} bytes from \
+             container {container} ({})",
+            entry.display_path,
+            base_bytes.len(),
+            mounted_bytes.len(),
+            if base_bytes == mounted_bytes {
+                "identical"
+            } else {
+                "differs"
+            }
+        );
+    }
+    assert!(checked > 0, "at least one tag is served from a mod");
+}
+
+/// Exporting a mod over an installed copy of itself: the whole sequence the
+/// export performs, on a copy of a real mod container so nothing in the install
+/// is touched.
+///
+/// The mount holds the only reference to each archive — which is what lets the
+/// mapping be released at all — and the container has to come back readable
+/// afterwards, since the browser reads through it.
+#[test]
+fn a_mounted_container_can_be_released_replaced_and_remounted() {
+    if !std::path::Path::new(PAKS).exists() {
+        eprintln!("skipping: Campaign Evolved not present");
+        return;
+    }
+    // A real mod container, copied out of the install. Any non-pakchunk container
+    // will do; without one there is nothing index-less to exercise.
+    let Some(donor) = std::fs::read_dir(PAKS)
+        .expect("read Paks")
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .find(|path| {
+            path.extension().is_some_and(|ext| ext == "utoc")
+                && !path
+                    .file_stem()
+                    .is_some_and(|stem| stem.to_string_lossy().starts_with("pakchunk"))
+                && path.file_name().is_some_and(|name| name != "global.utoc")
+        })
+    else {
+        eprintln!("skipping: no mod container in this Paks folder to copy");
+        return;
+    };
+    let scratch = std::env::temp_dir().join(format!("baboon-remount-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&scratch);
+    std::fs::create_dir_all(&scratch).expect("scratch dir");
+    let target = scratch.join("copied_mod_P.utoc");
+    for extension in ["utoc", "ucas", "pak"] {
+        let from = donor.with_extension(extension);
+        if from.exists() {
+            std::fs::copy(&from, target.with_extension(extension)).expect("copy container");
+        }
+    }
+
+    let defs = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("definitions");
+    let names = crate::format::TagNameIndex::load_from_definitions(&defs);
+    // Mounted against the real Paks, as the app does: an override container ships
+    // no directory index, so only the containers it overrides can name its chunks.
+    let mut loaded = crate::source::load_iostore_container(
+        target.clone(),
+        Some(std::path::PathBuf::from(PAKS)),
+        &names,
+        &defs,
+    )
+    .expect("mount the copied mod");
+
+    assert_eq!(
+        crate::source::mounted_containers_at(&loaded.source, &target),
+        vec![0],
+        "the export target is recognised as a mounted container"
+    );
+    let entry = loaded.entries.first().cloned().expect("the mod carries a tag");
+    crate::source::read_entry(&loaded.source, &entry).expect("read while mapped");
+
+    let root = match &loaded.source {
+        TagSource::IoStoreContainerSet { root, .. } => root.clone(),
+        _ => panic!("not a container set"),
+    };
+    {
+        let TagSource::IoStoreContainerSet { containers, .. } = &mut loaded.source else {
+            panic!("not a container set");
+        };
+        assert_eq!(
+            std::sync::Arc::strong_count(&containers[0].archive),
+            1,
+            "the mount holds the only reference, so the mapping can be released"
+        );
+        std::sync::Arc::get_mut(&mut containers[0].archive)
+            .expect("uniquely held archive")
+            .release_partition();
+        assert!(!containers[0].archive.is_partition_mapped());
+    }
+    assert!(
+        crate::source::read_entry(&loaded.source, &entry).is_err(),
+        "a read through a released partition is refused rather than served stale"
+    );
+
+    // What the release is for: the container is rewritten where it stands.
+    let mut writer = blam_tags::iostore::writer::OverrideContainerWriter::new("../../../");
+    let mut id = [0u8; 12];
+    id[..8].copy_from_slice(&0x0bad_f00d_dead_beefu64.to_le_bytes());
+    id[11] = blam_tags::iostore::CHUNK_TYPE_BULK_DATA;
+    writer.add_chunk(blam_tags::iostore::FIoChunkId(id), vec![7u8; 2048]);
+    writer.write(&target).expect("replace the mounted container");
+
+    let containers_snapshot = match &loaded.source {
+        TagSource::IoStoreContainerSet { containers, .. } => containers.clone(),
+        _ => panic!("not a container set"),
+    };
+    let reopened = crate::source::reopen_container_archive(&root, &containers_snapshot, 0)
+        .expect("reopen the replaced container");
+    assert!(
+        reopened.is_partition_mapped(),
+        "the remounted container is readable again"
+    );
+
+    let _ = std::fs::remove_dir_all(&scratch);
+}
+
+/// The export target has to be recognised as a mounted container before the
+/// writer runs, since that is what decides whether a mapping must be released.
+#[test]
+fn an_export_over_a_mounted_container_is_detected() {
+    let Some(loaded) = mount() else { return };
+    let TagSource::IoStoreContainerSet { containers, .. } = &loaded.source else {
+        panic!("not a container set");
+    };
+    let target = containers
+        .first()
+        .expect("the install mounts containers")
+        .utoc_path
+        .clone();
+    assert_eq!(
+        crate::source::mounted_containers_at(&loaded.source, &target),
+        vec![0],
+        "exporting over a mounted container is detected"
+    );
+    let free = target.with_file_name("a-name-nothing-has-taken_P.utoc");
+    assert!(
+        crate::source::mounted_containers_at(&loaded.source, &free).is_empty(),
+        "an unused name is free to write"
+    );
+}

--- a/src/app/tests/save_changes_prompt.rs
+++ b/src/app/tests/save_changes_prompt.rs
@@ -1,0 +1,36 @@
+//! The close prompt's discard button, which used to be one click from deleting
+//! a workspace's stashed edits.
+
+use super::*;
+
+/// No single click may delete a stash. The button that did was labelled "Don't
+/// Save" on a quit dialog, and because Export Mod leaves its tags dirty, that is
+/// the dialog an exporter sees on every exit -- so "no thanks, I already
+/// exported" deleted the very edits the mod was made from.
+#[test]
+fn no_single_click_deletes_a_stash() {
+    let fresh = discard_button(true, false);
+    assert!(fresh.arming, "the first click on a stashing workspace arms");
+    assert_ne!(
+        fresh.label, "Don't Save",
+        "it is named for what it does, not for what it declines"
+    );
+    let armed = discard_button(true, true);
+    assert!(!armed.arming, "the second click acts");
+    assert!(
+        armed.label.contains("Stashed"),
+        "and says what it is deleting: {}",
+        armed.label
+    );
+}
+
+/// A workspace with nowhere to stash to loses nothing beyond the open document,
+/// so it keeps the one-click discard every editor has.
+#[test]
+fn a_workspace_without_a_stash_keeps_one_click_discard() {
+    let button = discard_button(false, false);
+    assert_eq!(button.label, "Don't Save");
+    assert!(!button.arming);
+    // Even a stale confirmation flag cannot turn this into two clicks.
+    assert_eq!(discard_button(false, true).label, "Don't Save");
+}

--- a/src/app/tests/shader_option_reads.rs
+++ b/src/app/tests/shader_option_reads.rs
@@ -5,8 +5,6 @@
 //! surfaces. That made three of the H3 kit's own option tags unreadable, and in a
 //! GUI an unreadable option tag is a dead process rather than a message.
 
-use super::*;
-
 const H3_SHADERS: &str = "/Users/camden/Halo/halo3_mcc/tags/shaders";
 
 /// Every `render_method_option` in the kit must decode through the typed reader

--- a/src/app/tests/shader_option_reads.rs
+++ b/src/app/tests/shader_option_reads.rs
@@ -1,0 +1,64 @@
+//! Reading the shipped H3 shader option tags.
+//!
+//! `source extern` resolves by the option name embedded in the tag, and the
+//! engine panics on a name it has no variant for — deliberately, so a decode gap
+//! surfaces. That made three of the H3 kit's own option tags unreadable, and in a
+//! GUI an unreadable option tag is a dead process rather than a message.
+
+use super::*;
+
+const H3_SHADERS: &str = "/Users/camden/Halo/halo3_mcc/tags/shaders";
+
+/// Every `render_method_option` in the kit must decode through the typed reader
+/// the shader grid uses. Named tags are called out because they are the ones that
+/// used to panic, and because a regression here is silent until someone opens a
+/// shader that happens to use them.
+#[test]
+fn every_shipped_h3_shader_option_decodes() {
+    let root = std::path::Path::new(H3_SHADERS);
+    if !root.exists() {
+        eprintln!("skipping: no H3 editing kit");
+        return;
+    }
+    const PREVIOUSLY_PANICKING: [&str; 3] = [
+        "albedo_two_change_color_anim",
+        "albedo_two_change_color_chameleon",
+        "illum_detail_world_space_four_cc",
+    ];
+
+    let mut decoded = 0usize;
+    let mut failed: Vec<String> = Vec::new();
+    let mut covered: Vec<String> = Vec::new();
+    for entry in walkdir::WalkDir::new(root).into_iter().filter_map(|e| e.ok()) {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("render_method_option") {
+            continue;
+        }
+        let Ok(bytes) = std::fs::read(path) else { continue };
+        let Ok(tag) = blam_tags::TagFile::read_from_bytes(&bytes) else {
+            continue;
+        };
+        let stem = path.file_stem().unwrap().to_string_lossy().into_owned();
+        // Caught rather than propagated: a panic here is exactly the defect, and
+        // one failing tag should report itself instead of ending the test.
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            blam_tags::render_method::RenderMethodOption::from_tag(&tag).is_ok()
+        }));
+        match outcome {
+            Ok(true) => decoded += 1,
+            Ok(false) => failed.push(format!("{stem} (error)")),
+            Err(_) => failed.push(format!("{stem} (panic)")),
+        }
+        if PREVIOUSLY_PANICKING.contains(&stem.as_str()) {
+            covered.push(stem);
+        }
+    }
+
+    assert!(decoded > 100, "only {decoded} option tag(s) decoded — kit incomplete?");
+    assert!(failed.is_empty(), "{} option tag(s) failed: {failed:?}", failed.len());
+    assert_eq!(
+        covered.len(),
+        PREVIOUSLY_PANICKING.len(),
+        "the tags this test exists for are missing from the kit: found {covered:?}"
+    );
+}

--- a/src/app/tests/ui_scale_slider.rs
+++ b/src/app/tests/ui_scale_slider.rs
@@ -1,0 +1,128 @@
+//! The welcome screen's UI scale slider, driven with real pointer input.
+//!
+//! The slider sets the zoom factor of the window it is drawn in. Applying the
+//! value while the drag was live rescaled the slider under the pointer, so the
+//! handle slid away from the cursor and the scale could not be aimed at all.
+
+use super::*;
+
+/// One frame with `events` delivered to it, standing in for the wizard: the
+/// slider edits `pending`, and the rule decides when that reaches `live`.
+fn frame(
+    ctx: &egui::Context,
+    pending: &mut f32,
+    live: &mut f32,
+    events: Vec<egui::Event>,
+    pointer: Option<egui::Pos2>,
+) -> egui::Rect {
+    let mut rect = egui::Rect::NOTHING;
+    let mut events = events;
+    if let Some(pos) = pointer {
+        events.insert(0, egui::Event::PointerMoved(pos));
+    }
+    let _ = ctx.run(
+        egui::RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(
+                egui::Pos2::ZERO,
+                Vec2::new(600.0, 200.0),
+            )),
+            events,
+            ..Default::default()
+        },
+        |ctx| {
+            egui::CentralPanel::default().show(ctx, |ui| {
+                let response = ui.add(
+                    egui::Slider::new(pending, MIN_UI_SCALE..=MAX_UI_SCALE).show_value(false),
+                );
+                rect = response.rect;
+                if crate::app::ui::first_run::commit_ui_scale_now(&response, *pending, *live) {
+                    *live = *pending;
+                }
+            });
+        },
+    );
+    rect
+}
+
+fn button(pos: egui::Pos2, pressed: bool) -> egui::Event {
+    egui::Event::PointerButton {
+        pos,
+        button: egui::PointerButton::Primary,
+        pressed,
+        modifiers: egui::Modifiers::default(),
+    }
+}
+
+/// The reported interaction: grab the handle, drag it, let go. The window must
+/// not be rescaled until the release, however many frames the drag spans.
+#[test]
+fn the_scale_is_applied_when_the_drag_ends_not_while_it_lasts() {
+    let ctx = egui::Context::default();
+    let (mut pending, mut live) = (DEFAULT_UI_SCALE, DEFAULT_UI_SCALE);
+
+    // Lay out once to learn where the slider is.
+    let rect = frame(&ctx, &mut pending, &mut live, Vec::new(), None);
+    assert!(rect.width() > 20.0, "the slider was laid out");
+
+    let start = egui::pos2(rect.center().x, rect.center().y);
+    frame(
+        &ctx,
+        &mut pending,
+        &mut live,
+        vec![button(start, true)],
+        Some(start),
+    );
+
+    // Drag in steps, as a pointer does. Every frame that moves the value is a
+    // frame that must not rescale the window.
+    let mut moved = false;
+    for step in 1..=4 {
+        let at = egui::pos2(start.x - step as f32 * 12.0, start.y);
+        let before = pending;
+        frame(&ctx, &mut pending, &mut live, Vec::new(), Some(at));
+        moved |= pending != before;
+        assert_eq!(
+            live, DEFAULT_UI_SCALE,
+            "frame {step} of the drag rescaled the window mid-drag (slider {before} -> {pending})"
+        );
+    }
+    assert!(
+        moved,
+        "the drag actually moved the slider — otherwise this proves nothing"
+    );
+
+    let end = egui::pos2(start.x - 48.0, start.y);
+    frame(
+        &ctx,
+        &mut pending,
+        &mut live,
+        vec![button(end, false)],
+        Some(end),
+    );
+    assert_eq!(
+        live, pending,
+        "releasing applies exactly the scale the user aimed at"
+    );
+    assert_ne!(live, DEFAULT_UI_SCALE, "and that is not where it started");
+}
+
+/// A click that never crosses the drag threshold still has to arrive. Waiting for
+/// a drag-stopped event that never comes would leave the slider showing a scale
+/// the window never took.
+/// Press and release are separate frames: a click lasts tens of milliseconds and
+/// the app redraws throughout. (egui moves a slider on the frames *after* the
+/// press, so a press and release collapsed into one frame moves nothing at all —
+/// that is the synthetic input being unrealistic, not the widget.)
+#[test]
+fn a_click_on_the_track_is_not_swallowed() {
+    let ctx = egui::Context::default();
+    let (mut pending, mut live) = (DEFAULT_UI_SCALE, DEFAULT_UI_SCALE);
+    let rect = frame(&ctx, &mut pending, &mut live, Vec::new(), None);
+    let at = egui::pos2(rect.left() + rect.width() * 0.85, rect.center().y);
+
+    frame(&ctx, &mut pending, &mut live, vec![button(at, true)], Some(at));
+    frame(&ctx, &mut pending, &mut live, vec![button(at, false)], Some(at));
+
+    assert_ne!(pending, DEFAULT_UI_SCALE, "the click moved the slider");
+    assert_eq!(live, pending, "and the window followed it");
+}

--- a/src/app/ui.rs
+++ b/src/app/ui.rs
@@ -376,6 +376,10 @@ fn monitor_commands_for_game(game: Option<&str>) -> &'static [&'static str] {
 #[path = "ui/tests.rs"]
 mod tests;
 
+#[cfg(test)]
+#[path = "../app/tests/shader_option_reads.rs"]
+mod shader_option_read_tests;
+
 /// A clickable tag entry row in the Content Explorer. Returns true on click.
 fn explorer_entry_row(ui: &mut Ui, entry: &TagEntry) -> bool {
     ui.add(

--- a/src/app/ui.rs
+++ b/src/app/ui.rs
@@ -377,6 +377,10 @@ fn monitor_commands_for_game(game: Option<&str>) -> &'static [&'static str] {
 mod tests;
 
 #[cfg(test)]
+#[path = "../app/tests/ui_scale_slider.rs"]
+mod ui_scale_slider_tests;
+
+#[cfg(test)]
 #[path = "../app/tests/shader_option_reads.rs"]
 mod shader_option_read_tests;
 

--- a/src/app/ui/dialogs.rs
+++ b/src/app/ui/dialogs.rs
@@ -1086,6 +1086,24 @@ impl Baboon {
                 _ => None,
             });
         let expert_mode = self.expert_mode;
+        // Mods installed under `Paks` are mounted like any other container, so
+        // they serve their tags in place of the game's. Both facts below follow
+        // from that and neither was visible: comparisons here are against the
+        // game's own packs, and the file this would write may be one of those
+        // mounts — which cannot be replaced while it is mapped.
+        let export_target = self
+            .mod_export
+            .as_ref()
+            .filter(|dialog| !dialog.review_only)
+            .map(ModExportDialog::output_utoc);
+        let mounted_mods = kit_index
+            .map(|index| self.mounted_mod_labels(index))
+            .unwrap_or_default();
+        let replaces_mounted = export_target
+            .as_deref()
+            .zip(kit_index)
+            .map(|(target, index)| self.export_replaces_mounted(index, target))
+            .unwrap_or_default();
 
         let mut open = true;
         let mut cancel = false;
@@ -1146,6 +1164,19 @@ impl Baboon {
                         });
                     }
                 });
+                if !mounted_mods.is_empty() {
+                    ui.add_space(4.0);
+                    ui.label(
+                        RichText::new(format!(
+                            "Mounted mod(s) in this install: {}. Changes are compared against the \
+                             game's own packs, so a tag one of these already provides still shows \
+                             what it changes.",
+                            mounted_mods.join(", ")
+                        ))
+                        .small()
+                        .color(subtle_dark()),
+                    );
+                }
                 ui.add_space(6.0);
                 // Grows with the window: the naming and buttons below keep the
                 // slice they measured last frame, and the list takes whatever is
@@ -1226,6 +1257,21 @@ impl Baboon {
                                             ui.label(
                                                 RichText::new(reason).color(subtle_dark()).small(),
                                             );
+                                        }
+                                        // The editor is showing this mod's values
+                                        // for this tag, which is why an edit can
+                                        // look like it was already there.
+                                        if let Some(mod_label) = row.overridden_by.as_deref() {
+                                            ui.label(
+                                                RichText::new(format!("in {mod_label}"))
+                                                    .color(modified_text())
+                                                    .small(),
+                                            )
+                                            .on_hover_text(format!(
+                                                "This install's {mod_label} already provides this \
+                                                 tag, so the editor reads its values. The \
+                                                 comparison below is against the game's own pack.",
+                                            ));
                                         }
                                     },
                                 );
@@ -1323,6 +1369,21 @@ impl Baboon {
                     {
                         acknowledge = Some(acknowledged);
                     }
+                }
+                // Said as the name is typed, because it is the difference between
+                // writing a new mod and replacing one this workspace is reading
+                // from. The export releases the mapping to do it, and the browser
+                // then shows what was just written.
+                if !replaces_mounted.is_empty() {
+                    ui.label(
+                        RichText::new(format!(
+                            "Replaces {}, which is mounted here — the browser will show what this \
+                             writes. Reload the source afterwards if the tag list changed.",
+                            replaces_mounted.join(", ")
+                        ))
+                        .small()
+                        .color(egui::Color32::from_rgb(210, 120, 90)),
+                    );
                 }
                 ui.add_space(10.0);
                 ui.horizontal(|ui| {
@@ -1653,6 +1714,12 @@ impl Baboon {
         let mut do_export = false;
         let mut cancel = false;
         let mut dont_ask = !self.confirm_container_overwrite;
+        // Which container this would actually be written into. With a mod mounted
+        // over the tag, that is the mod — not the game's shipped pak, which is
+        // what this dialog used to promise in every case.
+        let target = self
+            .resolve_kit(kit)
+            .and_then(|index| self.container_label_for_tag(index, &key));
         egui::Window::new("Overwrite game files?")
             .id(egui::Id::new("overwrite_confirm"))
             .open(&mut open)
@@ -1662,8 +1729,19 @@ impl Baboon {
             .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
             .show(ctx, |ui| {
                 ui.label(
-                    RichText::new("Save will overwrite this tag inside the game's shipped pak files, in place:")
-                        .color(text_dark()),
+                    RichText::new(match target.as_ref() {
+                        Some((label, true)) => format!(
+                            "Save will overwrite this tag inside the mounted mod {label}, in place:"
+                        ),
+                        Some((label, false)) => format!(
+                            "Save will overwrite this tag inside the game's shipped pak {label}, \
+                             in place:"
+                        ),
+                        None => "Save will overwrite this tag inside the game's shipped pak files, \
+                                 in place:"
+                            .to_owned(),
+                    })
+                    .color(text_dark()),
                 );
                 ui.add_space(5.0);
                 ui.label(RichText::new(&key).color(text_dark()).monospace());

--- a/src/app/ui/first_run.rs
+++ b/src/app/ui/first_run.rs
@@ -2,6 +2,24 @@
 
 use super::*;
 
+/// Whether the scale the slider is showing should be applied to the window yet.
+///
+/// The value this slider edits is the zoom factor of the window the slider is
+/// drawn in, so applying it every frame of a drag rescaled the slider under the
+/// pointer: the handle slid away from the cursor and the value could not be aimed
+/// at all. Deferring to the end of the interaction fixes that.
+///
+/// Phrased as "the two disagree and nothing is holding the widget" rather than as
+/// an event, because the events do not cover it. `drag_stopped()` never fires for
+/// a click that moves the handle without crossing the drag threshold, and
+/// `changed()` is true only on the frame the value moves — which for a click is
+/// the frame the button is still down. Either one alone leaves a value showing in
+/// the slider that never reaches the window. A difference, by contrast, cannot be
+/// missed: whatever frame the pointer comes up on, it is applied then.
+pub(super) fn commit_ui_scale_now(response: &egui::Response, pending: f32, live: f32) -> bool {
+    pending != live && !response.is_pointer_button_down_on()
+}
+
 impl Baboon {
     pub(super) fn draw_first_run_wizard(&mut self, ctx: &egui::Context) {
         let Some(page) = self.first_run_wizard.as_ref().map(|state| state.page) else {
@@ -122,13 +140,11 @@ impl Baboon {
         ui.checkbox(&mut self.dark_mode, "Dark mode");
         ui.horizontal(|ui| {
             ui.label("UI scale");
-            if ui
-                .add(egui::Slider::new(
-                    &mut self.pending_ui_scale,
-                    MIN_UI_SCALE..=MAX_UI_SCALE,
-                ))
-                .changed()
-            {
+            let response = ui.add(egui::Slider::new(
+                &mut self.pending_ui_scale,
+                MIN_UI_SCALE..=MAX_UI_SCALE,
+            ));
+            if commit_ui_scale_now(&response, self.pending_ui_scale, self.ui_scale) {
                 self.ui_scale = self.pending_ui_scale;
             }
         });

--- a/src/app/ui/shell.rs
+++ b/src/app/ui/shell.rs
@@ -59,6 +59,44 @@ impl Baboon {
                             ui.close_menu();
                             self.begin_open_campaign_project(ctx.clone());
                         }
+                        // A workspace's edits are autosaved to a recovery file
+                        // whether or not they are ever saved anywhere else, so
+                        // these write a copy the user owns and can move, back up
+                        // or hand to someone. Before them, the only way to get a
+                        // `.baboon` out of Baboon was to export a mod.
+                        let can_save_project =
+                            self.current_source_is_campaign_project_capable(self.active);
+                        let project_target = self.kits[self.active]
+                            .campaign_project
+                            .as_ref()
+                            .and_then(|project| project.project_path.clone());
+                        if ui
+                            .add_enabled(
+                                can_save_project,
+                                egui::Button::new("Save Baboon Project"),
+                            )
+                            .on_hover_text(match project_target.as_deref() {
+                                Some(path) => format!("Write this workspace's changes to {}", path.display()),
+                                None => "Choose a .baboon file to keep this workspace's changes in".to_owned(),
+                            })
+                            .on_disabled_hover_text(
+                                "Baboon projects hold changes to Campaign Evolved containers",
+                            )
+                            .clicked()
+                        {
+                            ui.close_menu();
+                            self.defer_file_action(DeferredFileAction::SaveProject, ctx);
+                        }
+                        if ui
+                            .add_enabled(
+                                can_save_project,
+                                egui::Button::new("Save Baboon Project As..."),
+                            )
+                            .clicked()
+                        {
+                            ui.close_menu();
+                            self.defer_file_action(DeferredFileAction::SaveProjectAs, ctx);
+                        }
                         ui.separator();
                         let has_loaded_folder = self.loaded_tags_root().is_some();
                         if ui
@@ -142,7 +180,7 @@ impl Baboon {
                                     egui::Button::new("Export Mod..."),
                                 )
                                 .on_hover_text(
-                                    "Bundle every modified project tag into one portable mod overlay and .baboon recovery file",
+                                    "Bundle every modified project tag into one portable mod overlay, with a copy of this project saved beside it",
                                 )
                                 .clicked()
                             {
@@ -710,29 +748,63 @@ impl Baboon {
                     // status line expires on a timer, so an update found by the
                     // silent startup check would otherwise scroll past unread;
                     // this link stays until the next check clears it.
-                    if let Some(update) = self.available_update.as_ref() {
-                        let label = format!("Update available: {}", update.short_name());
-                        let url = update.release_url.clone();
-                        let hover = match update.channel {
-                            UpdateChannel::Stable => "Open the release page on GitHub",
-                            UpdateChannel::Development => {
-                                "Open the latest development build on GitHub"
-                            }
-                        };
+                    let update = self.available_update.clone();
+                    // Which `.baboon` this workspace's changes belong to, and
+                    // where they are actually being kept. Autosave and Save write
+                    // different files, and a workspace that has never been saved
+                    // writes only the recovery file — none of which was visible
+                    // anywhere before.
+                    let project = self
+                        .current_source_is_campaign_project_capable(self.active)
+                        .then(|| self.kits[self.active].campaign_project.as_ref())
+                        .flatten()
+                        // A workspace with neither a project file nor a stash has
+                        // nothing to say here, and saying it anyway on every
+                        // Campaign Evolved kit would just be furniture.
+                        .filter(|project| {
+                            project.project_path.is_some() || !project.overlays.is_empty()
+                        })
+                        .map(|project| {
+                            let mut hover = match project.project_path.as_deref() {
+                                Some(path) => format!("Baboon project: {}", path.display()),
+                                None => "This workspace has no saved Baboon project yet — use \
+                                         File > Save Baboon Project"
+                                    .to_owned(),
+                            };
+                            hover.push_str(&format!(
+                                "\nAutosaved to {}",
+                                project.recovery_path.display()
+                            ));
+                            (format!("Project: {}", project.label()), hover)
+                        });
+                    if update.is_some() || project.is_some() {
                         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                            // An explicit colour beats the app-wide
-                            // `override_text_color`, which would otherwise
-                            // flatten both this and the link colour to
-                            // ordinary body text. `strong()` only brightens;
-                            // the weight comes from the bold family, at the
-                            // body size of the row it sits in.
-                            ui.hyperlink_to(
-                                RichText::new(label)
-                                    .font(bold_font(12.0))
-                                    .color(good_news()),
-                                &url,
-                            )
-                            .on_hover_text(hover);
+                            if let Some(update) = update {
+                                let label = format!("Update available: {}", update.short_name());
+                                let hover = match update.channel {
+                                    UpdateChannel::Stable => "Open the release page on GitHub",
+                                    UpdateChannel::Development => {
+                                        "Open the latest development build on GitHub"
+                                    }
+                                };
+                                // An explicit colour beats the app-wide
+                                // `override_text_color`, which would otherwise
+                                // flatten both this and the link colour to
+                                // ordinary body text. `strong()` only brightens;
+                                // the weight comes from the bold family, at the
+                                // body size of the row it sits in.
+                                ui.hyperlink_to(
+                                    RichText::new(label)
+                                        .font(bold_font(12.0))
+                                        .color(good_news()),
+                                    &update.release_url,
+                                )
+                                .on_hover_text(hover);
+                            }
+                            if let Some((label, hover)) = project {
+                                ui.label(RichText::new(label).small().color(subtle_dark()))
+                                    .on_hover_text(hover);
+                            }
                         });
                     }
                 });
@@ -1158,6 +1230,14 @@ impl Baboon {
     pub(super) fn run_deferred_file_action(&mut self, ctx: &egui::Context) {
         match self.deferred_file_action.take() {
             Some(DeferredFileAction::SaveCurrentTag) => self.save_current_tag(),
+            Some(DeferredFileAction::SaveProject) => {
+                let (kit, now) = (self.active, ctx.input(|input| input.time));
+                self.save_campaign_project_file(kit, now);
+            }
+            Some(DeferredFileAction::SaveProjectAs) => {
+                let (kit, now) = (self.active, ctx.input(|input| input.time));
+                self.save_campaign_project_file_as(kit, now);
+            }
             Some(DeferredFileAction::ExportMod) => self.export_mod(),
             Some(DeferredFileAction::PokeCurrentTag) => self.begin_poke_current_tag(ctx.clone()),
             Some(DeferredFileAction::Close(action)) => self.request_close_action(action, ctx),

--- a/src/source/ce_audio.rs
+++ b/src/source/ce_audio.rs
@@ -587,6 +587,9 @@ mod tests {
             containers.push(MountedContainer {
                 utoc_path: utoc.clone(),
                 chunk_label: utoc.file_stem().unwrap().to_string_lossy().into_owned(),
+                // Nothing on this path layers shipped against modded — it mounts
+                // everything to resolve one lookup.
+                is_mod: false,
                 archive: Arc::new(archive),
             });
         }
@@ -737,6 +740,9 @@ mod tests {
             containers.push(MountedContainer {
                 utoc_path: utoc.clone(),
                 chunk_label: utoc.file_stem().unwrap().to_string_lossy().into_owned(),
+                // Nothing on this path layers shipped against modded — it mounts
+                // everything to resolve one lookup.
+                is_mod: false,
                 archive: Arc::new(archive),
             });
         }

--- a/src/source/loading.rs
+++ b/src/source/loading.rs
@@ -305,6 +305,8 @@ fn build_container_set(
     let mut index = ContainerTagIndex::default();
     // Cooked package names over the same containers, for following UE imports.
     let mut packages = ContainerPackageIndex::default();
+    // The same payloads as the game's own packs have them, mods excluded.
+    let mut shipped = ShippedTagIndex::default();
     let mut opened_any = false;
 
     // Open every container up front. A mod/override container addresses its
@@ -320,6 +322,15 @@ fn build_container_set(
     }
     let needs_recovery = |slot: &Option<IoStoreArchive>|
         matches!(slot, Some(archive) if archive.entries().is_empty());
+    // Which of these are mods, decided before recovery fills in the missing
+    // names: shipping no directory index at all is the strongest signal there
+    // is, and it is gone the moment `recover_entries` runs.
+    let is_mod: Vec<bool> = opened
+        .iter()
+        .map(|(utoc, archive)| {
+            needs_recovery(archive) || !is_shipped_container_path(&root, utoc)
+        })
+        .collect();
     // Naming an index-less container's chunks means resolving their ids against
     // the containers it overrides. On the "open one chunk" path — a mod sitting
     // in the game's own Paks folder — those aren't in the set, so pull the
@@ -345,8 +356,9 @@ fn build_container_set(
         opened[i].1 = Some(archive);
     }
 
-    for (utoc, archive) in opened {
+    for (position, (utoc, archive)) in opened.into_iter().enumerate() {
         let Some(archive) = archive else { continue };
+        let is_mod = is_mod.get(position).copied().unwrap_or(false);
         opened_any = true;
         let chunk_label = utoc
             .file_stem()
@@ -408,6 +420,11 @@ fn build_container_set(
             let dedup_key = format!("{group_tag:08x}:{logical}");
             // Later packs win, matching the `entries[existing] = entry` override.
             index.insert(dedup_key.clone(), container_index, e.path.clone());
+            // The shipped layer records only the game's own packs, so a mod
+            // taking over a tag leaves the base copy reachable.
+            if !is_mod {
+                shipped.insert(&e.path, container_index);
+            }
             match seen.get(&dedup_key) {
                 Some(&existing) => {
                     // Overlap should be near-zero; note it rather than hide it.
@@ -432,6 +449,7 @@ fn build_container_set(
             containers.push(MountedContainer {
                 utoc_path: utoc,
                 chunk_label,
+                is_mod,
                 archive,
             });
         }
@@ -442,12 +460,18 @@ fn build_container_set(
     }
 
     entries.sort_by(|a, b| natural_key(&a.display_path).cmp(&natural_key(&b.display_path)));
+    let mods = containers.iter().filter(|c| c.is_mod).count();
     let label = format!(
-        "{} ({} packs)",
+        "{} ({} packs{})",
         root.file_name()
             .and_then(|s| s.to_str())
             .unwrap_or("Campaign Evolved"),
-        containers.len()
+        containers.len(),
+        match mods {
+            0 => String::new(),
+            1 => ", 1 mod".to_owned(),
+            n => format!(", {n} mods"),
+        }
     );
     let tree = build_tree(&entries);
     let group_tree = build_group_tree(&entries);
@@ -458,6 +482,7 @@ fn build_container_set(
             containers,
             index: Arc::new(index),
             packages: Arc::new(packages),
+            shipped: Arc::new(shipped),
         },
         names,
         game: Some(CAMPAIGN_EVOLVED_GAME.to_string()),
@@ -539,6 +564,112 @@ fn strip_tags_root(path: &str) -> &str {
 
 /// Parse the chunk id from a `pakchunk<N>-...utoc` filename (u32::MAX if none),
 /// so `pakchunk0` sorts first as the base.
+/// Whether `utoc` looks like one of the game's own containers rather than a mod
+/// installed into the same tree.
+///
+/// Two independent signals, both of which a mod fails: the game's packs are named
+/// `pakchunk<N>[-platform]`, and they sit directly in `Paks`. Mods are named
+/// whatever their author chose — and the convention the game itself relies on is
+/// to drop them in a subfolder like `~mods`, which is why they are found at all.
+/// A third and stronger signal (shipping no directory index) is checked at the
+/// mount, where it is still observable.
+fn is_shipped_container_path(paks_root: &Path, utoc: &Path) -> bool {
+    chunk_number(utoc) != u32::MAX
+        && utoc
+            .parent()
+            .is_some_and(|parent| paths_are_same_dir(parent, paks_root))
+}
+
+/// Directory comparison that survives the two forms the same folder arrives in:
+/// the walked path under a mounted root, and the root the caller configured.
+fn paths_are_same_dir(left: &Path, right: &Path) -> bool {
+    if left == right {
+        return true;
+    }
+    match (left.canonicalize(), right.canonicalize()) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => false,
+    }
+}
+
+/// Whether two paths name the same file, including when it does not exist yet —
+/// which is the case that matters for an export about to create one.
+pub fn paths_are_same_file(left: &Path, right: &Path) -> bool {
+    // Names first, because they decide it without touching the disk: this runs
+    // once per mounted container on every frame the export review is open, and
+    // an install can mount ninety of them.
+    match (left.file_name(), right.file_name()) {
+        (Some(left_name), Some(right_name)) if left_name.eq_ignore_ascii_case(right_name) => {}
+        _ => return false,
+    }
+    if left == right {
+        return true;
+    }
+    if let (Ok(left), Ok(right)) = (left.canonicalize(), right.canonicalize()) {
+        return left == right;
+    }
+    // The target does not exist yet, so compare the directories instead. Names
+    // are compared case-insensitively throughout: Windows, the only platform
+    // where writing over a mapped container fails at all, folds case, and
+    // erring towards "same file" refuses an export rather than breaking one.
+    match (left.parent(), right.parent()) {
+        (Some(left_dir), Some(right_dir)) => paths_are_same_dir(left_dir, right_dir),
+        _ => false,
+    }
+}
+
+/// Read a container tag as the **game's own packs** have it, ignoring any mod
+/// mounted over it.
+///
+/// `Ok(None)` for a tag no shipped pack carries: a mod added it, so there is
+/// nothing to compare against rather than nothing changed. Every "what does this
+/// change about the game?" answer has to come from here, because [`read_entry`]
+/// deliberately reads what the *game* would load, mods included.
+pub fn read_shipped_entry(source: &TagSource, entry: &TagEntry) -> Result<Option<TagFile>> {
+    let (
+        TagEntryLocation::Container { rel_path, .. },
+        TagSource::IoStoreContainerSet {
+            containers,
+            shipped,
+            ..
+        },
+    ) = (&entry.location, source)
+    else {
+        return Ok(None);
+    };
+    let Some(index) = shipped.container_for(rel_path) else {
+        return Ok(None);
+    };
+    let mounted = containers
+        .get(index)
+        .context("shipped container index out of range")?;
+    let bytes = mounted
+        .archive
+        .read(rel_path)
+        .map_err(|e| anyhow!("failed to read {rel_path} from {}: {e}", mounted.chunk_label))?;
+    TagFile::read_from_bytes(&bytes)
+        .map(Some)
+        .map_err(|e| anyhow!("failed to parse {}: {e}", entry.display_path))
+}
+
+/// The mounted containers an export to `out_utoc` would overwrite.
+///
+/// Mounting maps a container's `.ucas` into memory, and the export replaces that
+/// file wholesale; on Windows, truncating a mapped file fails outright
+/// (`ERROR_USER_MAPPED_FILE`, os error 1224). Since mods installed under `Paks`
+/// are mounted, re-exporting a mod over itself is exactly that collision.
+pub fn mounted_containers_at(source: &TagSource, out_utoc: &Path) -> Vec<usize> {
+    let TagSource::IoStoreContainerSet { containers, .. } = source else {
+        return Vec::new();
+    };
+    containers
+        .iter()
+        .enumerate()
+        .filter(|(_, container)| paths_are_same_file(&container.utoc_path, out_utoc))
+        .map(|(index, _)| index)
+        .collect()
+}
+
 fn chunk_number(utoc: &Path) -> u32 {
     utoc.file_stem()
         .and_then(|s| s.to_str())

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -116,6 +116,12 @@ pub enum TagSource {
         /// Cooked package-name lookup over the same containers, for following
         /// UE package imports (Campaign Evolved's audio binding).
         packages: Arc<ContainerPackageIndex>,
+        /// Where the *game's own* copy of each mounted tag lives, ignoring any
+        /// mod mounted over it. The mount layers mods last-wins, exactly as the
+        /// game does, so without this the only reachable copy of a modded tag is
+        /// the mod's — and every "what does this change about the game?"
+        /// question answered itself with "nothing".
+        shipped: Arc<ShippedTagIndex>,
     },
 }
 
@@ -127,7 +133,44 @@ pub struct MountedContainer {
     pub utoc_path: PathBuf,
     /// e.g. `pakchunk240-WinGDK` — the pak this tag was read from.
     pub chunk_label: String,
+    /// Whether this is a mod rather than one of the game's own packs. Mods mount
+    /// last and win every collision, so this is what separates "the game ships
+    /// it this way" from "something installed here changed it".
+    pub is_mod: bool,
     pub archive: Arc<IoStoreArchive>,
+}
+
+/// The game's own copy of each mounted tag payload: container-relative path
+/// (lowercased) → the highest-priority **non-mod** container carrying it.
+///
+/// Keyed by path rather than by tag identity because a mod's entries are
+/// recovered from the very containers it overrides, so both sides name the same
+/// payload by the same path. A path absent here is a tag that only a mod
+/// provides — there is nothing shipped to compare it against.
+#[derive(Default)]
+pub struct ShippedTagIndex {
+    by_path: HashMap<String, usize>,
+}
+
+impl ShippedTagIndex {
+    /// Record a payload carried by one of the game's own packs. Later inserts
+    /// win, matching the mount loop's later-pack override.
+    pub fn insert(&mut self, rel_path: &str, container: usize) {
+        self.by_path
+            .insert(rel_path.to_ascii_lowercase(), container);
+    }
+
+    pub fn container_for(&self, rel_path: &str) -> Option<usize> {
+        self.by_path.get(&rel_path.to_ascii_lowercase()).copied()
+    }
+
+    pub fn len(&self) -> usize {
+        self.by_path.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.by_path.is_empty()
+    }
 }
 
 /// Maps a tag reference (group + Halo-relative path) to the container payload


### PR DESCRIPTION
Four reported defects, each with its own commit, plus the engine bump they need.

## Stashed edits were deleted by the exit prompt, and by the file they were saved into

A workspace autosaves to a recovery file keyed by its source root. That was the same field as the `.baboon` the user opened, which had two consequences: opening a project — including the sidecar Export Mod leaves beside the mod — made that file the live autosave target, and declining to save at exit deleted the stashed overlays out of whichever file was live. The first exit wiped the recovery file, so the sidecar still had the edits and reopening looked fine; the second exit wiped the sidecar. Reported as "everything saved this time, then reverted the next".

`recovery_path` and `project_path` are now separate, and nothing but an explicit save writes the latter. Discarding at exit is a named, two-click action that says which file it deletes from — worth noting that exporting a mod does not clear the dirty flags, so that prompt is the one an exporter sees on *every* exit, and it was one unlabelled click from deleting the work the mod was made from.

Also adds **File > Save Baboon Project / Save As…**, which the reporter asked for: before them, exporting a mod was the only way to get a `.baboon` out of Baboon.

Session compatibility: "carries a project" no longer follows from `project_path`, so the session format gained `has_project`. Sessions written before the split set `project_path` for every workspace that had a project at all, which is exactly what the new flag means, so they read correctly.

## A mod mounted over a tag became the baseline every comparison used

Mounting the pak tree recursively means a mod in `Paks/~mods` — or loose in `Paks` — is mounted and wins every collision. Right for reading; it also redefined "as the game ships it" as "as this install currently loads it". For someone iterating on their own mod the baseline became their own earlier export: Review Changes showed nothing, new edits diffed against the mod, and discarding "reverted" to the mod's values — while the workspace marker and the Export Mod list, which come from the stash, still said the tags were modified.

Containers are classified at mount (no directory index, or not named `pakchunkN`, or below the `Paks` root), a `ShippedTagIndex` keeps the game's own copy reachable, and diff baselines *and export bases* both read through it. The export was previously building an override against the winning container — which for a re-export is the file it is about to replace.

Mounted mods are now named in the load status, the review, per row as "in \<mod\>", and in the overwrite confirmation, which claimed it was writing the game's shipped paks when the tag came from a mod.

Re-exporting over a mounted mod also failed with a bare "os error 1224": the mount memory-maps the `.ucas` and the writer truncates it, which Windows refuses while a mapped section is open. The export now releases that mapping, writes, and reopens the container.

## The welcome screen's UI scale slider could not be aimed

It applied the value on every frame it changed, and the value is the zoom factor of the window the slider is in — so the wizard rescaled mid-drag and the handle slid out from under the pointer. Now applied when the interaction ends. Settings never had this; it has an explicit Apply button.

## Angle fields were shown and written as radians under a "degrees" label

`angle`, `angle_bounds` and both euler types hold radians. Guerilla converts; the field names say `:degrees` themselves. An ODST weapon's `minimum error` of 0.01 degrees read as `0`, and typing 0.15 into a box labelled degrees stored 8.59 degrees' worth — 57.3× — silently, across 1,916 fields in eight games.

Settled against shipped tags rather than by reading types: over 246 stock H3 tags, `angle` values are round in degrees 38.2% of the time and as-stored 0.2%; `euler2d` 46.3% against 0.0%; the control `real` inverts at 24.1% against 0.4%. `camera field of view` is 1.2217305 = 70°.

Separately in the same code: `fmt_real` truncated to two decimals, and that string seeds the edit box — so every real under 0.01 displayed as `0` and became `0` when touched.

## No bool or int shader parameter could be created, in any game

Reported as the H3 parameters `order3_area_specular`, `use_material_texture` and `no_dynamic_lights` erroring when enabled. The field-path grammar has no escapes — a segment is the field's clean name, in which a `/` inside a name is a `\` — but `escape_field_path_segment` invented `\/`. Nothing parses that, so the slash still separated and every write to a slashed field failed with "field path no longer resolves". A shader bool's value lives in a field named exactly `int/bool`; those three are simply the bools H3's common material options declare. 334 fields across the shipped definitions have a slash in the name.

## Engine

blam-tags `1c3ad0c` → `42e4812`, both commits pushed to `camden-smallwood/blam-tags` master before this bump:

- `54ee5ff` — a container can release and remap its `.ucas` mapping, so a mounted container can be rewritten.
- `42e4812` — the fifteen `source extern` names shipped H3 tags actually offer. That field resolves by the name embedded in the tag and the engine panics on a name it has no variant for, so three of the H3 kit's own option tags (`albedo_two_change_color_anim`, `albedo_two_change_color_chameleon`, `illum_detail_world_space_four_cc`) took the process down when read. Three were selected by shipped tags; the other twelve were one edit away.

## Tests

457 pass. New coverage, all skip-if-absent where they need an editing kit:

- the discard button cannot delete a stash in one click;
- the recovery/project split, including that an imported project replaces a stale recovery file rather than merging into it;
- a modded tag still resolves to its shipped copy, and the release/replace/remount sequence run end-to-end on a *copy* of a real mod container;
- the UI scale slider driven with real pointer input across a multi-frame drag;
- angle display and parsing, using the reporter's own Guerilla screenshots as the oracle (0.15 rad must show as 8.59437; bounds 0.25–2.0 as 14.3239–114.592);
- every shipped H3 `render_method_option` decodes through the typed reader;
- the three shader bools enable, save, and read back enabled.

The suite is green. `ce_render_jms_export` used to fail on any machine with a CE install — it built its JMS fine and then panicked dumping the result to a hardcoded absolute scratchpad path from the session it was written in — and it skipped on any machine without one, so CI never saw it either way. It also never asserted the head-region count its own comment described as the point of the test. Deleted in the last commit; the failure predates this branch (identical on a clean `cbbefde`).
