### PR TITLE
Custom fields occupy no runtime bytes, so poke must not verify them

### DIFF
--- a/src/app/runtime_poke.rs
+++ b/src/app/runtime_poke.rs
@@ -1211,7 +1211,6 @@ impl Planner<'_> {
                 | TagFieldType::VertexBuffer
                 | TagFieldType::Pointer
                 | TagFieldType::NonCacheRuntimeValue
-                | TagFieldType::Custom
                 | TagFieldType::Unknown => {
                     let before = raw_span(baseline, offset, span)?;
                     let after = raw_span(edited, offset, span)?;
@@ -1225,6 +1224,7 @@ impl Planner<'_> {
                 | TagFieldType::UselessPad
                 | TagFieldType::Skip
                 | TagFieldType::Explanation
+                | TagFieldType::Custom
                 | TagFieldType::Terminator => {}
                 _ => {
                     let before = raw_span(baseline, offset, span)?;


### PR DESCRIPTION
A `custom` field declares a size of zero — it is an editor-side hint (`hide`/`edih`/`filt`/`sled`/…), not storage. But `field_span` derives a field's extent from the offset of the next field that starts *after* it, so a zero-sized custom is handed the span of whatever real field follows it.

The poke planner routed `Custom` into the strict arm that compares the raw span before and after the edit. With the borrowed span, any edit to the field *following* a custom read as a change underneath the custom, and the whole poke aborted with `unverified field representation at <path>` — pointing at a path the user never touched.

The fix skips customs the way `Pad`, `UselessPad`, `Skip`, `Explanation` and `Terminator` are already skipped. `probe_inline_scalars` has had `Custom` in its skip list all along; this makes the planner agree with the probe.

One file, one line moved between match arms.

Tested: `cargo test --all-targets` — 457 passed, 0 failed, 18 ignored.