### PR TITLE
Take the iostore rewrite, and fix two ways the review reported changes nobody made

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,7 +502,7 @@ dependencies = [
 [[package]]
 name = "blam-tags"
 version = "0.1.0"
-source = "git+https://github.com/camden-smallwood/blam-tags?rev=42e4812#42e4812e6d031c8dfa79193ff626e2e21f640620"
+source = "git+https://github.com/camden-smallwood/blam-tags?rev=06b1d4e#06b1d4e0e383e862dd7962cc98135651453b0b8b"
 dependencies = [
  "anyhow",
  "bcdec_rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1"
 atomic-write-file = "0.3"
-blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "42e4812", features = ["audio", "iostore"] }
+blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "06b1d4e", features = ["audio", "iostore"] }
 directories = "6"
 display-info = "0.5"
 eframe = { version = "0.29", default-features = false, features = ["default_fonts", "glow"] }

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -4224,6 +4224,9 @@ impl Baboon {
                 tag_bytes: bytes.as_slice(),
                 new_package_path: package.as_str(),
                 redirect_from: None,
+                // A new tag's wrapper is built from the template with the
+                // donor's own bindings stripped; nothing here chooses one.
+                asset_reference: None,
             },)
             .collect();
         let written =

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -167,6 +167,25 @@ fn explorer_select_args(path: &Path) -> [std::ffi::OsString; 2] {
     ]
 }
 
+/// What a stashed overlay is, for the export review.
+///
+/// Pure so the rule can be tested without a mounted game, which is what
+/// reproducing the report needed: a tag stashed as modified whose bytes turn
+/// out to equal the game's own copy.
+pub(in crate::app) fn classify_overlay(
+    resolvable: bool,
+    kind: CampaignProjectTagKind,
+    matches_shipped: bool,
+) -> ModExportChange {
+    match (resolvable, kind) {
+        (false, _) => ModExportChange::Unresolved,
+        (true, CampaignProjectTagKind::New) => ModExportChange::New,
+        (true, CampaignProjectTagKind::Existing) if matches_shipped => ModExportChange::Unchanged,
+        (true, CampaignProjectTagKind::Existing) => ModExportChange::Modified,
+    }
+}
+
+
 impl Baboon {
     /// Resolve (and cache) the Wwise media a Campaign Evolved `sound` tag binds
     /// to. Returns `None` for every other game and source kind.
@@ -3770,21 +3789,33 @@ impl Baboon {
                 let resolvable = self
                     .campaign_entry_for_identity(exporting, &overlay.identity)
                     .is_some();
-                let kind = match (resolvable, overlay.kind) {
-                    (false, _) => ModExportChange::Unresolved,
-                    (true, CampaignProjectTagKind::New) => ModExportChange::New,
-                    (true, CampaignProjectTagKind::Existing) => ModExportChange::Modified,
-                };
+                let kind = classify_overlay(
+                    resolvable,
+                    overlay.kind,
+                    // Only asked where the answer can matter, so a review does
+                    // not read shipped payloads it has no use for.
+                    resolvable
+                        && overlay.kind == CampaignProjectTagKind::Existing
+                        && self.overlay_matches_shipped(exporting, overlay),
+                );
                 let overridden_by = self.mod_serving_tag(exporting, &overlay.identity);
                 ModExportRow {
                     identity: overlay.identity.clone(),
                     display_path: overlay.logical_path.clone(),
                     group_tag: overlay.group_tag,
                     kind,
-                    include: kind != ModExportChange::Unresolved,
+                    include: !matches!(
+                        kind,
+                        ModExportChange::Unresolved | ModExportChange::Unchanged
+                    ),
                     bytes: overlay.bytes.len(),
-                    reason: (kind == ModExportChange::Unresolved)
-                        .then(|| "not in this source".to_owned()),
+                    reason: match kind {
+                        ModExportChange::Unresolved => Some("not in this source".to_owned()),
+                        ModExportChange::Unchanged => {
+                            Some("identical to the game's copy".to_owned())
+                        }
+                        _ => None,
+                    },
                     overridden_by,
                 }
             })
@@ -3811,6 +3842,28 @@ impl Baboon {
             diffs: HashMap::new(),
             controls_height: 0.0,
         });
+    }
+
+    /// Whether a stashed overlay is byte-for-byte what the game already ships.
+    ///
+    /// Answered on bytes rather than by diffing parsed tags: a diff can come
+    /// back empty for two tags that are not identical (a field the differ does
+    /// not reach), and "nothing to export" has to mean *nothing*, not "nothing
+    /// I looked at".
+    ///
+    /// A tag only a mod provides has no shipped counterpart, so it is never
+    /// unchanged -- there is nothing for it to be identical to.
+    fn overlay_matches_shipped(&self, kit: usize, overlay: &CampaignProjectOverlay) -> bool {
+        let Some(entry) = self.campaign_entry_for_identity(kit, &overlay.identity) else {
+            return false;
+        };
+        let Some(source) = self.kits.get(kit).and_then(|kit| kit.source.as_ref()) else {
+            return false;
+        };
+        matches!(
+            crate::source::read_shipped_entry_bytes(&source.source, &entry),
+            Ok(Some(bytes)) if bytes == *overlay.bytes
+        )
     }
 
     /// Compute the field differences for one reviewed tag, against the tag as
@@ -3942,6 +3995,7 @@ impl Baboon {
                     ModExportChange::New => "new",
                     ModExportChange::Modified => "modified",
                     ModExportChange::Unresolved => "unresolved",
+                    ModExportChange::Unchanged => "unchanged",
                 },
                 "bytes": row.bytes,
                 "error": diff.error,

--- a/src/app/foundation/containers.rs
+++ b/src/app/foundation/containers.rs
@@ -1967,12 +1967,112 @@ pub(in crate::app) fn dropdown_wheel_delta(
     if !hovered {
         return None;
     }
+    // Hovering is not enough. A wheel gesture belongs to whoever it started on,
+    // and a gesture that began as panel scrolling keeps the wheel for its whole
+    // duration -- otherwise scrolling down a tag silently retunes every dropdown
+    // that passes under the cursor, which is exactly what it did.
+    if !claim_wheel_gesture(ui.ctx(), response.id) {
+        return None;
+    }
     let delta = wheel_event_delta_from_context(ui.ctx());
     consume_mouse_wheel(ui);
     if delta == 0 {
         return None;
     }
     Some(delta)
+}
+
+/// Who the in-flight wheel gesture belongs to.
+#[derive(Clone, Copy, PartialEq)]
+enum WheelOwner {
+    /// A gesture is in flight and nothing has claimed it yet, because the frame
+    /// it started on has not finished drawing.
+    Undecided,
+    /// A dropdown claimed it and keeps it until the gesture ends.
+    Dropdown(egui::Id),
+    /// Nothing claimed it, so it is panel scrolling and stays that way.
+    Panel,
+}
+
+#[derive(Clone, Copy)]
+struct WheelGesture {
+    /// When a wheel event was last seen. A quiet gap ends the gesture.
+    last: f64,
+    owner: WheelOwner,
+}
+
+/// How long the wheel must be still before the next event starts a new gesture.
+///
+/// Long enough to span the gaps between physical wheel detents, short enough
+/// that deliberately stopping and pointing at a dropdown starts a fresh one.
+const WHEEL_GESTURE_GAP: f64 = 0.25;
+
+fn wheel_gesture_id() -> egui::Id {
+    egui::Id::new("wheel_gesture")
+}
+
+fn wheel_is_turning(ctx: &egui::Context) -> bool {
+    ctx.input(|input| {
+        input
+            .events
+            .iter()
+            .any(|event| matches!(event, egui::Event::MouseWheel { .. }))
+    })
+}
+
+/// Open a wheel gesture, or continue the one already in flight. Call once per
+/// frame **before** anything that might claim the wheel.
+pub(in crate::app) fn begin_wheel_gesture(ctx: &egui::Context) {
+    if !wheel_is_turning(ctx) {
+        return;
+    }
+    let now = ctx.input(|input| input.time);
+    let previous = ctx.data(|data| data.get_temp::<WheelGesture>(wheel_gesture_id()));
+    let owner = match previous {
+        Some(g) if now - g.last <= WHEEL_GESTURE_GAP => g.owner,
+        // First event after a quiet spell: a new gesture, up for grabs.
+        _ => WheelOwner::Undecided,
+    };
+    ctx.data_mut(|data| data.insert_temp(wheel_gesture_id(), WheelGesture { last: now, owner }));
+}
+
+/// Settle an unclaimed gesture as panel scrolling. Call once per frame **after**
+/// everything that might claim the wheel.
+///
+/// This is what makes ownership sticky: a gesture nothing claimed on its first
+/// frame is the panel's, and stays the panel's even when the cursor later slides
+/// over a dropdown.
+pub(in crate::app) fn end_wheel_gesture(ctx: &egui::Context) {
+    ctx.data_mut(|data| {
+        if let Some(gesture) = data.get_temp::<WheelGesture>(wheel_gesture_id()) {
+            if gesture.owner == WheelOwner::Undecided {
+                data.insert_temp(
+                    wheel_gesture_id(),
+                    WheelGesture { owner: WheelOwner::Panel, ..gesture },
+                );
+            }
+        }
+    });
+}
+
+/// Whether `id` may act on this frame's wheel events.
+fn claim_wheel_gesture(ctx: &egui::Context, id: egui::Id) -> bool {
+    let Some(gesture) = ctx.data(|data| data.get_temp::<WheelGesture>(wheel_gesture_id())) else {
+        return false;
+    };
+    match gesture.owner {
+        WheelOwner::Dropdown(owner) => owner == id,
+        WheelOwner::Panel => false,
+        WheelOwner::Undecided => {
+            ctx.data_mut(|data| {
+                data.insert_temp(
+                    wheel_gesture_id(),
+                    WheelGesture { owner: WheelOwner::Dropdown(id), ..gesture },
+                );
+            });
+            true
+        }
+    }
 }
 
 fn wheel_event_delta_from_context(ctx: &egui::Context) -> i32 {
@@ -2811,5 +2911,110 @@ mod palette_repro_tests {
             eprintln!("{game}: checked {checked} block(s), {stale} stale");
         }
         assert!(failures.is_empty(), "{} failure(s):\n{failures:#?}", failures.len());
+    }
+}
+
+#[cfg(test)]
+mod wheel_gesture_tests {
+    use super::*;
+
+    /// One frame: optionally a wheel event, and a dropdown at `rect` asking
+    /// whether it may cycle. Returns whether it was allowed to.
+    fn frame(ctx: &egui::Context, wheel: bool, pointer: egui::Pos2, rect: egui::Rect) -> bool {
+        let mut events = vec![egui::Event::PointerMoved(pointer)];
+        if wheel {
+            events.push(egui::Event::MouseWheel {
+                unit: egui::MouseWheelUnit::Line,
+                delta: egui::Vec2::new(0.0, -1.0),
+                modifiers: Default::default(),
+            });
+        }
+        let mut claimed = false;
+        ctx.run(
+            egui::RawInput {
+                screen_rect: Some(egui::Rect::from_min_size(
+                    egui::Pos2::ZERO,
+                    egui::Vec2::new(400.0, 400.0),
+                )),
+                events,
+                ..Default::default()
+            },
+            |ctx| {
+                begin_wheel_gesture(ctx);
+                egui::CentralPanel::default().show(ctx, |ui| {
+                    let response = ui.allocate_rect(rect, egui::Sense::hover());
+                    claimed = dropdown_wheel_delta(ui, &response, false).is_some();
+                });
+                end_wheel_gesture(ctx);
+            },
+        );
+        claimed
+    }
+
+    fn ctx() -> egui::Context {
+        let ctx = egui::Context::default();
+        set_combo_scroll_cycle_enabled(&ctx, true);
+        ctx
+    }
+
+    const BOX_RECT: egui::Rect = egui::Rect {
+        min: egui::Pos2::new(10.0, 100.0),
+        max: egui::Pos2::new(200.0, 120.0),
+    };
+    const OVER_BOX: egui::Pos2 = egui::Pos2::new(100.0, 110.0);
+    const ABOVE_BOX: egui::Pos2 = egui::Pos2::new(100.0, 20.0);
+
+    /// The reported defect: scrolling a tag pane, the cursor passes over a
+    /// dropdown, and the dropdown silently changes value. The gesture started as
+    /// panel scrolling and must stay panel scrolling.
+    #[test]
+    fn a_dropdown_scrolled_past_mid_gesture_does_not_change() {
+        let ctx = ctx();
+        // The gesture begins away from any dropdown.
+        assert!(!frame(&ctx, true, ABOVE_BOX, BOX_RECT));
+        // Now the cursor slides over one while the wheel is still turning.
+        for _ in 0..5 {
+            assert!(
+                !frame(&ctx, true, OVER_BOX, BOX_RECT),
+                "a dropdown claimed a wheel gesture that began as panel scrolling"
+            );
+        }
+    }
+
+    /// Deliberate use still works: point at a dropdown, then scroll.
+    #[test]
+    fn a_dropdown_pointed_at_first_still_cycles() {
+        let ctx = ctx();
+        assert!(
+            frame(&ctx, true, OVER_BOX, BOX_RECT),
+            "a gesture starting on a dropdown should be the dropdown's"
+        );
+        // ...and keeps it for the rest of the gesture.
+        assert!(frame(&ctx, true, OVER_BOX, BOX_RECT));
+    }
+
+    /// After the wheel goes quiet the next turn is a fresh gesture, so stopping
+    /// and pointing at a dropdown works without moving the mouse away first.
+    #[test]
+    fn a_pause_starts_a_new_gesture() {
+        let ctx = ctx();
+        assert!(!frame(&ctx, true, ABOVE_BOX, BOX_RECT));
+        assert!(!frame(&ctx, true, OVER_BOX, BOX_RECT));
+        // Frames with no wheel event: the gesture goes stale.
+        for _ in 0..40 {
+            frame(&ctx, false, OVER_BOX, BOX_RECT);
+        }
+        assert!(
+            frame(&ctx, true, OVER_BOX, BOX_RECT),
+            "a new gesture over a dropdown should be claimable"
+        );
+    }
+
+    /// The preference still wins outright.
+    #[test]
+    fn the_preference_disables_it_entirely() {
+        let ctx = egui::Context::default();
+        set_combo_scroll_cycle_enabled(&ctx, false);
+        assert!(!frame(&ctx, true, OVER_BOX, BOX_RECT));
     }
 }

--- a/src/app/model_preview/loading.rs
+++ b/src/app/model_preview/loading.rs
@@ -8,7 +8,9 @@ use blam_tags::iostore::container_header::EIoContainerHeaderVersion;
 use blam_tags::iostore::skeletal_mesh::SkeletalMesh;
 use blam_tags::iostore::static_mesh::StaticMesh;
 use blam_tags::iostore::ue_types::{EIoStoreTocVersion, FPackageObjectIndex};
-use blam_tags::iostore::unversioned::{MeshRef, MeshSyncRegions, Permutation, PropValue, Region};
+use blam_tags::iostore::unversioned::{
+    MeshRef, MeshSyncRegions, Permutation, PropValue, PropertyBlock, Region,
+};
 use blam_tags::iostore::usmap::Usmap;
 use blam_tags::iostore::zen::FZenPackageHeader;
 use blam_tags::jms::{UeMeshPart, UeStaticPart, UeWorldPart};
@@ -748,7 +750,7 @@ fn ce_decode_metahuman_table(
     struct_basename: &str,
     struct_name: &str,
     table_basename: &str,
-) -> Option<Vec<(String, std::collections::BTreeMap<String, PropValue>)>> {
+) -> Option<Vec<(String, PropertyBlock)>> {
     let mut usmap = Usmap::meteorite().ok()?;
     let sbytes = ce_find_uasset_by_basename(containers, struct_basename)?;
     let shdr = FZenPackageHeader::deserialize(&mut Cursor::new(&sbytes[..]), None, CE_CV, CE_HV, None).ok()?;
@@ -776,7 +778,7 @@ fn ce_decode_metahuman_table(
 
 /// A non-empty soft-object path as `(package, asset)`.
 fn ce_soft(sp: &blam_tags::iostore::unversioned::SoftObjectPath) -> Option<(String, String)> {
-    (!sp.is_empty()).then(|| (sp.package.clone(), sp.asset.clone()))
+    (!sp.is_empty()).then(|| (sp.package.as_str().to_string(), sp.asset.as_str().to_string()))
 }
 
 /// Decode `DT_MetaHumanHeads` → per-row face + facial-hair mesh references.

--- a/src/app/state/documents.rs
+++ b/src/app/state/documents.rs
@@ -408,6 +408,14 @@ pub(in crate::app) enum ModExportChange {
     New,
     /// An edit to a tag the game ships.
     Modified,
+    /// In the workspace's stash, but byte-identical to what the game ships.
+    ///
+    /// Reaching this state does not require the user to have undone anything
+    /// deliberately: a value nudged and put back, or an edit that re-encodes to
+    /// the same bytes, leaves the document flagged as modified with nothing to
+    /// show for it. Listing that as an unexported change is how a review ends up
+    /// asserting the user made a change they did not.
+    Unchanged,
     /// In the workspace's project, but no longer resolvable in this source.
     Unresolved,
 }

--- a/src/app/tests/mod_overrides.rs
+++ b/src/app/tests/mod_overrides.rs
@@ -281,3 +281,37 @@ fn an_export_over_a_mounted_container_is_detected() {
         "an unused name is free to write"
     );
 }
+
+/// A tag stashed as modified whose bytes turn out to be exactly what the game
+/// ships is not an unexported change.
+///
+/// From a user report: the export review listed seven modified tags, one of
+/// which had byte-identical content to the shipped copy and produced an empty
+/// diff. Listing it asserts the user made a change they did not make, and it
+/// would have been written into the mod as a redundant override. Reaching that
+/// state needs no deliberate undo — a value nudged and put back, or an edit that
+/// re-encodes identically, leaves the document flagged with nothing to show.
+#[test]
+fn an_overlay_identical_to_the_shipped_tag_is_not_a_change() {
+    use super::super::controller::classify_overlay;
+
+    assert_eq!(
+        classify_overlay(true, CampaignProjectTagKind::Existing, true),
+        ModExportChange::Unchanged
+    );
+    assert_eq!(
+        classify_overlay(true, CampaignProjectTagKind::Existing, false),
+        ModExportChange::Modified
+    );
+    // A tag this workspace created has no shipped counterpart, so it can never
+    // be "identical to the game's copy" -- there is no copy.
+    assert_eq!(
+        classify_overlay(true, CampaignProjectTagKind::New, true),
+        ModExportChange::New
+    );
+    // Unresolvable wins over everything: it cannot be written at all.
+    assert_eq!(
+        classify_overlay(false, CampaignProjectTagKind::Existing, true),
+        ModExportChange::Unresolved
+    );
+}

--- a/src/app/ui/dialogs.rs
+++ b/src/app/ui/dialogs.rs
@@ -922,10 +922,12 @@ impl Baboon {
         ui.add_space(6.0);
         if !element.is_empty() {
             // `Unresolved` stands in for "gone", the only way an element leaves.
+            // `Unchanged` is a whole-tag verdict and never labels an element,
+            // so it reads as a plain change here rather than inventing a marker.
             let (marker, heading) = match kind {
                 ModExportChange::New => ("+", added_text()),
                 ModExportChange::Unresolved => ("-", removed_text()),
-                ModExportChange::Modified => ("~", modified_text()),
+                ModExportChange::Modified | ModExportChange::Unchanged => ("~", modified_text()),
             };
             // The container above already names the block, so this only has to
             // say which element of it, and what happened to it.
@@ -1016,7 +1018,7 @@ impl Baboon {
             match kind {
                 ModExportChange::New => pane(ui, available, false, "added"),
                 ModExportChange::Unresolved => pane(ui, available, true, "removed"),
-                ModExportChange::Modified => {
+                ModExportChange::Modified | ModExportChange::Unchanged => {
                     ui.horizontal_top(|ui| {
                         pane(ui, half, true, "before");
                         // Not a separator: in a horizontal layout it stretches
@@ -1056,6 +1058,11 @@ impl Baboon {
             .rows
             .iter()
             .filter(|row| row.kind == ModExportChange::Unresolved)
+            .count();
+        let unchanged_count = dialog
+            .rows
+            .iter()
+            .filter(|row| row.kind == ModExportChange::Unchanged)
             .count();
         let stem = dialog.stem();
         let existing = dialog.existing_files();
@@ -1147,6 +1154,19 @@ impl Baboon {
                         ))
                         .color(text_dark()),
                     );
+                    if unchanged_count > 0 {
+                        // Named rather than silently dropped: these are tags the
+                        // workspace still has stashed, and a user who remembers
+                        // touching one deserves to see that it came to nothing.
+                        ui.label(
+                            RichText::new(format!("· {unchanged_count} unchanged"))
+                                .color(subtle_dark()),
+                        )
+                        .on_hover_text(
+                            "Byte-identical to the game's own copy, so there is nothing \
+                             to export. They stay stashed.",
+                        );
+                    }
                     if unresolved_count > 0 {
                         ui.label(
                             RichText::new(format!("· {unresolved_count} excluded"))
@@ -1238,6 +1258,10 @@ impl Baboon {
                                     ModExportChange::Modified => ("~", modified_text()),
                                     ModExportChange::Unresolved => {
                                         ("!", egui::Color32::from_rgb(210, 120, 90))
+                                    }
+                                    // Nothing to write, so nothing to mark.
+                                    ModExportChange::Unchanged => {
+                                        ("=", egui::Color32::from_gray(130))
                                     }
                                 };
                                 // A marker as well as a colour: this is a

--- a/src/app/ui/shell.rs
+++ b/src/app/ui/shell.rs
@@ -1267,6 +1267,9 @@ impl Baboon {
         set_dark_mode(self.dark_mode);
         ctx.set_visuals(foundation_visuals());
         set_combo_scroll_cycle_enabled(ctx, self.scroll_to_cycle_dropdowns);
+        // Opened before any pane draws and settled after the last one, so a
+        // dropdown can only claim a gesture on the frame it began.
+        begin_wheel_gesture(ctx);
         self.handle_app_close_request(ctx);
         if ctx.input_mut(|input| input.consume_key(egui::Modifiers::CTRL, egui::Key::F)) {
             self.find.open = true;
@@ -1325,6 +1328,7 @@ impl Baboon {
         self.draw_find_window(ctx);
         self.draw_tsv_paste_window(ctx);
         self.draw_rename_tag_window(ctx);
+        end_wheel_gesture(ctx);
     }
 }
 

--- a/src/source/loading.rs
+++ b/src/source/loading.rs
@@ -625,6 +625,32 @@ pub fn paths_are_same_file(left: &Path, right: &Path) -> bool {
 /// nothing to compare against rather than nothing changed. Every "what does this
 /// change about the game?" answer has to come from here, because [`read_entry`]
 /// deliberately reads what the *game* would load, mods included.
+/// The shipped payload bytes for `entry`, without parsing them.
+///
+/// Parsing a 7 MB scenario to answer "is this byte-identical to what ships?" is
+/// most of the cost of the question. Used by the export review, which asks it
+/// for every stashed tag.
+pub fn read_shipped_entry_bytes(source: &TagSource, entry: &TagEntry) -> Result<Option<Vec<u8>>> {
+    let (
+        TagEntryLocation::Container { rel_path, .. },
+        TagSource::IoStoreContainerSet { containers, shipped, .. },
+    ) = (&entry.location, source)
+    else {
+        return Ok(None);
+    };
+    let Some(index) = shipped.container_for(rel_path) else {
+        return Ok(None);
+    };
+    let mounted = containers
+        .get(index)
+        .context("shipped container index out of range")?;
+    mounted
+        .archive
+        .read(rel_path)
+        .map(Some)
+        .map_err(|e| anyhow!("failed to read {rel_path} from {}: {e}", mounted.chunk_label))
+}
+
 pub fn read_shipped_entry(source: &TagSource, entry: &TagEntry) -> Result<Option<TagFile>> {
     let (
         TagEntryLocation::Container { rel_path, .. },


### PR DESCRIPTION
Three commits: the `blam-tags` engine bump, and two correctness fixes that came
out of a user report on Discord.

## 1. Take the iostore rewrite — `42e4812` → `06b1d4e`

The largest thing here by a wide margin, and almost none of it is Baboon code.

`iostore` was a one-way reader: ~70 helpers shaped "advance a cursor, return
nothing", 228 `take(n)` calls that discarded their bytes, and no writer
anywhere. Adding writing was never about adding functions — the shape of every
function forbade it. It is now a codec: every cooked export in the shipped game,
**1,243,749 of 1,243,749**, reads apart and writes back byte-exactly, and a
property can be changed with the package rebuilt around it.

**Baboon's own side of 114 engine commits is thirteen lines.** `read_datatable`
now returns a `PropertyBlock`, `SoftObjectPath` fields are `FName`, and
`NewPackage` gained a field. The three separate bump commits are squashed into
one so this reads as a single deliberate adoption.

Two user-visible consequences arrive with it:

- **An override container can now replace a tag's paired `.uasset`,** not only
  its `.ubulk`. A Campaign Evolved tag is two files and only one of them was
  ever writable.
- **A brand-new tag no longer inherits its donor's Unreal bindings.**
  `add_new_package_to_writer` clones a same-group template and copied its export
  payload verbatim — including `AssetReference` and
  `CookedAssetsReferencedByTag`, which are properties of the *donor*, not of the
  group. Creating a new biped produced a tag that presented as whichever biped
  supplied the template and declared that tag's dependencies, with nothing
  anywhere saying so. Right for the 47 bare groups, wrong for the other 54.

## 2. A stashed tag identical to the game's copy is no longer reported as changed

From the report: the Export Mod review listed seven modified tags, one of which
was byte-identical to the shipped copy and produced an empty diff. The review
asserted the user had changed a tag they had not, and the export would have
written it into the mod as a redundant override.

The modified set is driven by a document's dirty *flag*, never by whether its
content actually differs. Reaching that state needs no deliberate undo — nudge a
value and put it back and the flag stays set — and overlays persist in the
`.baboon` project file, so it stays listed across sessions.

Such a row is now `Unchanged`: excluded from the export, and counted separately
rather than dropped, because someone who remembers touching the tag should see
that it came to nothing. The comparison is on **bytes**, not on the diff — a
diff can come back empty for two tags that are not identical, and "nothing to
export" has to mean nothing rather than nothing-I-looked-at. The new
`read_shipped_entry_bytes` skips parsing, which for a 7 MB scenario is most of
the cost of the question.

## 3. Scrolling past a dropdown no longer changes it

Same report, and the more damaging half: scrolling a tag pane silently retuned
every dropdown the cursor happened to pass over. Circumstantially, that user's
`ai_globals` vision traits had all moved by exactly +1.0 — wheel detents, not
intent.

Worth stating plainly, because it is easy to assume otherwise: **this is not
egui's doing.** In egui 0.29 no widget reads scroll deltas at all — only
`ScrollArea` does — and there is no API for a widget to decline one
(emilk/egui#5406 is the open request). Scroll-to-cycle is ours, so the fix is
ours.

A wheel gesture now has one owner. The first event after a quarter-second of
stillness opens an unclaimed gesture; a dropdown under the cursor claims it on
that frame and keeps it; anything unclaimed by the end of the frame becomes the
panel's and *stays* the panel's, so a cursor that later slides over a dropdown
cannot take it. Deliberately stopping and pointing at a dropdown still cycles
it, which is the feature working as intended, and the existing "scroll to cycle
dropdowns" preference still disables the whole thing.

This is a known bug in every framework that has tried the feature — Adobe,
MuseScore, Xfce and WinForms all have the same report — and gesture ownership is
where they all landed.

## Verification

- **462 tests pass**, `--all-targets --keep-going` clean, no new warnings.
- Both fixes were mutation-checked: the change was reverted to confirm the test
  actually fails. The scroll test drives the reported sequence — start scrolling
  away from any dropdown, then move over one while the wheel keeps turning.
- The engine bump's own claims are gated over the shipped corpus in `blam-tags`
  (`CE_PAKS=<Content/Paks> cargo test --features iostore -- --ignored`):
  12,329/12,329 import arrays re-derived byte-exactly, and a new tag built from a
  real donor verified to declare none of that donor's imports.

## Not included

The Campaign Evolved tag↔Unreal bridge UI that this engine work was originally
for is deliberately left out — it is still being shaped. Nothing in this PR
depends on it.
