### PR TITLE
Let a monolithic build's tags be edited, never saved

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,7 +502,7 @@ dependencies = [
 [[package]]
 name = "blam-tags"
 version = "0.1.0"
-source = "git+https://github.com/camden-smallwood/blam-tags?rev=06b1d4e#06b1d4e0e383e862dd7962cc98135651453b0b8b"
+source = "git+https://github.com/camden-smallwood/blam-tags?rev=22cdc0e#22cdc0ecd0c9f7ff68a84c9b4a8987772f6382a9"
 dependencies = [
  "anyhow",
  "bcdec_rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1"
 atomic-write-file = "0.3"
-blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "06b1d4e", features = ["audio", "iostore"] }
+blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "22cdc0e", features = ["audio", "iostore"] }
 directories = "6"
 display-info = "0.5"
 eframe = { version = "0.29", default-features = false, features = ["default_fonts", "glow"] }

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -2355,14 +2355,7 @@ impl Baboon {
     /// inside its own source, so resolving it against the active kit silently
     /// finds nothing and the caller skips the tag.
     pub(super) fn entry_for_key_in(&self, kit: usize, key: &str) -> Option<&TagEntry> {
-        let kit = self.kits.get(kit)?;
-        let source = kit.source.as_ref()?;
-        source
-            .entries
-            .iter()
-            .chain(source.all_entries.iter())
-            .chain(kit.active_favorite_entries.iter())
-            .find(|entry| entry.key == key)
+        self.kits.get(kit)?.entry_for_key(key)
     }
 
     pub(super) fn close_tab(&mut self, key: &str) {
@@ -2461,6 +2454,14 @@ impl Baboon {
             .filter_map(|key| {
                 let doc = self.kits[self.active].parsed_tags.get(&key)?;
                 if !doc.dirty.is_set() {
+                    return None;
+                }
+                // Edits to a tag that has no writer (a monolithic build, a
+                // big-endian tag) are session-scratch by construction. Listing
+                // them here would offer a Save that always fails, and — for
+                // CloseApp, which re-checks for dirty work after the prompt —
+                // a close that never terminates.
+                if !document_edits_are_saveable(&self.kits[self.active], &key, doc) {
                     return None;
                 }
                 Some(DirtyTagEntry {
@@ -3550,8 +3551,8 @@ impl Baboon {
         let Some(doc) = self.kits[self.active].parsed_tags.get(key) else {
             return Err("Load the selected tag before saving".to_owned());
         };
-        if doc.tag.classic_engine().is_none() && doc.tag.endian != Endian::Le {
-            return Err("Only little-endian MCC tags can be saved".to_owned());
+        if let Some(reason) = unsaveable_reason(&entry, &doc.tag) {
+            return Err(reason.to_owned());
         }
         let TagEntryLocation::LooseFile(path) = &entry.location else {
             // Container tags are writable, just not through the loose-file
@@ -4464,8 +4465,8 @@ impl Baboon {
             self.status = "Load the selected tag before saving".to_owned();
             return;
         };
-        if doc.tag.classic_engine().is_none() && doc.tag.endian != Endian::Le {
-            self.status = "Only little-endian MCC tags can be saved".to_owned();
+        if let Some(reason) = unsaveable_reason(&entry, &doc.tag) {
+            self.status = reason.to_owned();
             return;
         }
 

--- a/src/app/editor.rs
+++ b/src/app/editor.rs
@@ -52,7 +52,7 @@ pub(super) fn draw_tag(
         is_material_tag(entry) || is_material_shader_tag(entry) || is_shader_tag(entry);
     let is_model = is_model_group(entry.group_tag, names);
 
-    draw_tag_metadata(ui, tag, names);
+    draw_tag_metadata(ui, tag, entry, names);
     if !is_object_family {
         draw_object_model_summary(ui, tag, entry, names, edit);
     }

--- a/src/app/editor/bitmap.rs
+++ b/src/app/editor/bitmap.rs
@@ -14,7 +14,7 @@ pub(in crate::app) fn draw_bitmap_tag(
     expert_mode: bool,
     edit: &mut FieldEditContext<'_>,
 ) {
-    draw_tag_metadata(ui, tag, names);
+    draw_tag_metadata(ui, tag, entry, names);
     ui.add_space(6.0);
     ui.horizontal(|ui| {
         let can_reimport = bitmap_reimport_data_path(entry, edit.tags_root).is_some();

--- a/src/app/editor/model.rs
+++ b/src/app/editor/model.rs
@@ -150,7 +150,12 @@ pub(in crate::app) fn format_reference_path(
     }
 }
 
-pub(in crate::app) fn draw_tag_metadata(ui: &mut Ui, tag: &TagFile, names: &TagNameIndex) {
+pub(in crate::app) fn draw_tag_metadata(
+    ui: &mut Ui,
+    tag: &TagFile,
+    entry: &TagEntry,
+    names: &TagNameIndex,
+) {
     ui.horizontal(|ui| {
         ui.label(RichText::new("Header group:").color(subtle_dark()));
         ui.monospace(RichText::new(group_label(names, tag.group().tag)).color(text_dark()));
@@ -165,5 +170,21 @@ pub(in crate::app) fn draw_tag_metadata(ui: &mut Ui, tag: &TagFile, names: &TagN
             })
             .color(text_dark()),
         );
+        // The fields below are live either way; this says what happens to what
+        // is typed into them, at the one moment the user is looking at where
+        // this tag came from.
+        if let Some(reason) = unsaveable_reason(entry, tag) {
+            ui.label(
+                RichText::new("Cannot be saved")
+                    .color(READ_ONLY_BADGE_COLOR)
+                    .strong(),
+            )
+            .on_hover_text(reason);
+        }
     });
 }
+
+/// Amber, for the header note on a tag whose edits have nowhere to be written.
+/// Warning-coloured rather than error-coloured: nothing is wrong, and the tag
+/// is fully editable — the edits just do not outlive the session.
+pub(in crate::app) const READ_ONLY_BADGE_COLOR: Color32 = Color32::from_rgb(210, 145, 60);

--- a/src/app/editor/tests.rs
+++ b/src/app/editor/tests.rs
@@ -1879,4 +1879,266 @@ mod tag_diff_tests {
             Some(1)
         );
     }
+
+    fn camera_track_entry(location: TagEntryLocation) -> TagEntry {
+        TagEntry {
+            key: "cache:trak:test\\example".into(),
+            display_path: "test/example.camera_track".into(),
+            group_tag: u32::from_be_bytes(*b"trak"),
+            group_name: Some("camera_track".into()),
+            location,
+        }
+    }
+
+    /// A tag carrying the wire marker a Xbox 360 / monolithic build parses as.
+    /// Only the file-level marker — the one the save gate reads — is flipped;
+    /// the block data underneath is still whatever the schema built, which is
+    /// why the byte-order behaviour is checked against a real build instead.
+    fn camera_track_with_wire_endian(endian: Endian) -> TagFile {
+        let mut tag = TagFile::new(test_definition_path("halo4_mcc/camera_track.json")).unwrap();
+        tag.endian = endian;
+        tag
+    }
+
+    /// A monolithic build's tags are fully editable and never saveable, and the
+    /// two answers come from different questions.
+    ///
+    /// They used to come from one: editability was gated on saveability, so a
+    /// tag build rendered as painted text — its values could not be typed into,
+    /// and (the actual complaint) could not be selected and copied either.
+    #[test]
+    fn a_monolithic_tag_is_editable_but_never_saveable() {
+        let tag = camera_track_with_wire_endian(Endian::Be);
+        let monolithic = camera_track_entry(TagEntryLocation::Monolithic {
+            name: "test\\example".into(),
+            group_tag: tag.header.group_tag,
+        });
+
+        assert!(
+            is_editable_tag(&monolithic, &tag),
+            "a monolithic build's fields and block controls must be live"
+        );
+        assert!(!is_saveable_tag(&monolithic, &tag));
+        assert!(
+            unsaveable_reason(&monolithic, &tag)
+                .is_some_and(|reason| reason.contains("monolithic")),
+            "the refusal has to name the build, not the byte order"
+        );
+
+        // The same tag out of a loose folder is refused for the other reason —
+        // the MCC writer emits a little-endian header, so there is no
+        // round-trip for these bytes wherever they came from.
+        let loose_be = camera_track_entry(TagEntryLocation::LooseFile("example.camera_track".into()));
+        assert!(is_editable_tag(&loose_be, &tag));
+        assert!(
+            unsaveable_reason(&loose_be, &tag)
+                .is_some_and(|reason| reason.contains("big-endian"))
+        );
+
+        // And the gate can still say yes: an ordinary little-endian loose tag
+        // saves exactly as it did before.
+        let le = camera_track_with_wire_endian(Endian::Le);
+        assert!(is_saveable_tag(&loose_be, &le));
+    }
+
+    /// A little-endian tag holds an edit little-endian — the anchor for the
+    /// big-endian claim below, and the reason that claim needs real data:
+    /// element bytes are stored in the source wire order, so an edit's byte
+    /// order is a property of the tag it was read from, not of the editor.
+    #[test]
+    fn an_edit_is_stored_in_the_tags_own_byte_order() {
+        let mut tag = TagFile::new(test_definition_path("halo4_mcc/camera_track.json")).unwrap();
+        add_block_element(&mut tag, "control points").unwrap();
+        apply_field_edit(&mut tag, "control points[0]/position", "1.5, 2.5, 3.5").unwrap();
+
+        let bytes = tag.write_to_bytes().unwrap();
+        let mut wanted = Vec::new();
+        for value in [1.5f32, 2.5, 3.5] {
+            wanted.extend_from_slice(&value.to_le_bytes());
+        }
+        assert!(
+            bytes.windows(wanted.len()).any(|window| window == wanted),
+            "a little-endian tag must hold the edit little-endian"
+        );
+    }
+
+    /// Skip-if-absent, and the only place the big-endian edit path can actually
+    /// be exercised: a tag's element bytes carry the byte order they were read
+    /// in, and nothing here can manufacture those — flipping `TagFile::endian`
+    /// on a tag built from a schema changes the file's wire marker and not one
+    /// byte of its block data, so a synthetic "big-endian" tag would agree with
+    /// a broken encoder.
+    ///
+    /// Sweeps the whole build (or `BABOON_MONOLITHIC_TAGS` tags of it) and
+    /// reports a ledger: every tag counted before anything is filtered, and
+    /// every skip named, so a run that reached almost nothing cannot read as a
+    /// clean pass.
+    ///
+    /// Run against a real Halo 4 development build:
+    ///   BABOON_MONOLITHIC="/path/to/tag_cache/blob_index.dat" \
+    ///     cargo test a_monolithic_tag_edit -- --ignored --nocapture
+    #[test]
+    #[ignore = "requires a monolithic tag build; set BABOON_MONOLITHIC"]
+    fn a_monolithic_tag_edit_is_stored_big_endian() {
+        let Ok(blob_index) = std::env::var("BABOON_MONOLITHIC") else {
+            eprintln!("skip: BABOON_MONOLITHIC not set");
+            return;
+        };
+        let blob_index = std::path::PathBuf::from(blob_index);
+        if !blob_index.exists() {
+            eprintln!("skip: no monolithic build at {}", blob_index.display());
+            return;
+        }
+        let limit = std::env::var("BABOON_MONOLITHIC_TAGS")
+            .ok()
+            .and_then(|count| count.parse::<usize>().ok())
+            .unwrap_or(usize::MAX);
+        let names = TagNameIndex::load_from_definitions(&locate_definitions_root());
+        let loaded = crate::source::load_monolithic_blob_index(blob_index, &names)
+            .expect("open the monolithic build");
+
+        let total = loaded.entries.len().min(limit);
+        let (mut unreadable, mut no_real_field, mut edited) = (0usize, 0usize, 0usize);
+        let mut read_panics = Vec::new();
+        let mut failures = Vec::new();
+        // Reading a tag can panic inside the engine's geometry decoder on this
+        // build. That is not what this test is about, so it is caught, counted,
+        // and named rather than allowed to end the sweep at the first one.
+        let previous_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        // Distinctive enough that finding its 4 bytes in a tag is not a
+        // coincidence, and asymmetric under byte-swap.
+        let value = 1234.5677f32;
+        let big = value.to_be_bytes();
+        let little = value.to_le_bytes();
+
+        for entry in loaded.entries.iter().take(limit) {
+            let read = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                crate::source::read_entry(&loaded.source, entry)
+            }));
+            let mut tag = match read {
+                Ok(Ok(tag)) => tag,
+                // Counted and named, not silently passed over: a build Baboon
+                // cannot parse is a different result from one it edits cleanly.
+                Ok(Err(_)) => {
+                    unreadable += 1;
+                    continue;
+                }
+                Err(_) => {
+                    read_panics.push(entry.display_path.clone());
+                    continue;
+                }
+            };
+            assert_eq!(tag.endian, Endian::Be, "a monolithic build is big-endian");
+            assert!(
+                is_editable_tag(entry, &tag),
+                "every tag in the build must be editable"
+            );
+            assert!(
+                !is_saveable_tag(entry, &tag),
+                "and none of them saveable: {}",
+                entry.display_path
+            );
+            let Some(path) = first_real_field_path(tag.root(), 0, "") else {
+                no_real_field += 1;
+                continue;
+            };
+
+            if let Err(error) = apply_field_edit(&mut tag, &path, &value.to_string()) {
+                failures.push(format!("{} / {path}: edit failed: {error}", entry.display_path));
+                continue;
+            }
+            let read_back = tag.root().field_path(&path).and_then(|field| field.value());
+            if !matches!(read_back, Some(TagFieldData::Real(back)) if (back - value).abs() < 0.001) {
+                failures.push(format!(
+                    "{} / {path}: read back as {read_back:?}, not the value typed",
+                    entry.display_path
+                ));
+                continue;
+            }
+
+            let bytes = tag.write_to_bytes().unwrap();
+            if !bytes.windows(4).any(|window| window == big) {
+                failures.push(format!(
+                    "{} / {path}: the edit did not land big-endian",
+                    entry.display_path
+                ));
+                continue;
+            }
+            if bytes.windows(4).any(|window| window == little) {
+                failures.push(format!(
+                    "{} / {path}: the value also appears little-endian",
+                    entry.display_path
+                ));
+                continue;
+            }
+            edited += 1;
+        }
+
+        std::panic::set_hook(previous_hook);
+        eprintln!(
+            "{total} tag(s) in the build: {edited} edited big-endian, {no_real_field} with no \
+             real field to type into, {unreadable} unreadable, {} panicked on read, {} failed",
+            read_panics.len(),
+            failures.len()
+        );
+        // Caught so one bad tag cannot end the sweep, but still a failure: the
+        // whole build read clean once `half_to_f32` stopped overflowing on
+        // subnormal halves, and a tag that panics on read is a tag whose tab
+        // sits on "Loading…" forever.
+        assert!(
+            read_panics.is_empty(),
+            "{} tag(s) panicked while being read: {}",
+            read_panics.len(),
+            read_panics
+                .iter()
+                .take(10)
+                .cloned()
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+        assert!(
+            failures.is_empty(),
+            "{} failure(s):\n{}",
+            failures.len(),
+            failures
+                .iter()
+                .take(20)
+                .cloned()
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+        assert!(edited > 0, "no tag in the build had a real field to edit");
+    }
+
+    /// Path of the first plain `real` field in `tag_struct`, searching nested
+    /// structs and the first element of each block.
+    fn first_real_field_path(
+        tag_struct: TagStruct<'_>,
+        depth: usize,
+        prefix: &str,
+    ) -> Option<String> {
+        if depth > 3 {
+            return None;
+        }
+        for field in tag_struct.fields() {
+            let path = append_field_path(prefix, field.name());
+            if matches!(field.value(), Some(TagFieldData::Real(_))) {
+                return Some(path);
+            }
+            if let Some(nested) = field.as_struct() {
+                if let Some(found) = first_real_field_path(nested, depth + 1, &path) {
+                    return Some(found);
+                }
+            } else if let Some(block) = field.as_block() {
+                if let Some(element) = block.element(0) {
+                    let element_path = format!("{path}[0]");
+                    if let Some(found) = first_real_field_path(element, depth + 1, &element_path) {
+                        return Some(found);
+                    }
+                }
+            }
+        }
+        None
+    }
 }

--- a/src/app/editor/value_parser.rs
+++ b/src/app/editor/value_parser.rs
@@ -3,21 +3,62 @@
 
 use super::*;
 
-pub(in crate::app) fn is_editable_tag(entry: &TagEntry, tag: &TagFile) -> bool {
-    // Loose tags are edited in place; container (Campaign Evolved) tags are
-    // edited in memory and written out as an override on Save/Save As/Rename.
-    // A brand-new container tag (New Tag / Import of a new path) has no backing
-    // `.ubulk` at all — the in-memory document IS the tag — so it is the most
-    // editable of the three, not the least. Leaving it out made every new CE
-    // tag render read-only: no field could be typed into and no block element
-    // added, until the user exported it as a mod and remounted it as a real
-    // `Container` entry.
-    matches!(
-        entry.location,
+/// Whether this document's fields and block controls are live.
+///
+/// Every parsed tag is editable in memory, whatever it was read out of and
+/// whichever byte order it is in: an edit is a write into the document's own
+/// bytes ([`blam_tags`] encodes each field in the tag's own endian), so there
+/// is nothing about a big-endian tag out of a monolithic build that makes
+/// typing into it incoherent. Whether those edits can be written back
+/// afterwards is a separate question, answered by [`unsaveable_reason`] and
+/// enforced by the save paths.
+///
+/// Editability used to be gated on saveability, which made a monolithic tag
+/// build viewable and nothing else — its values could not even be selected and
+/// copied, because a read-only row is painted text rather than a text box.
+pub(in crate::app) fn is_editable_tag(entry: &TagEntry, _tag: &TagFile) -> bool {
+    // Matched rather than defaulted so a new location has to state its answer.
+    match entry.location {
+        // Loose tags are edited in place; container (Campaign Evolved) tags are
+        // edited in memory and written out as an override on Save/Save
+        // As/Rename. A brand-new container tag (New Tag / Import of a new path)
+        // has no backing `.ubulk` at all — the in-memory document IS the tag.
         TagEntryLocation::LooseFile(_)
-            | TagEntryLocation::Container { .. }
-            | TagEntryLocation::NewContainer { .. }
-    ) && (tag.classic_engine().is_some() || tag.endian == Endian::Le)
+        | TagEntryLocation::Container { .. }
+        | TagEntryLocation::NewContainer { .. } => true,
+        // A monolithic build has no writer, so its edits live and die with the
+        // session — which is the point: you edit to read values back out, to
+        // copy them, and to try a number against the rest of the tag.
+        TagEntryLocation::Monolithic { .. } => true,
+    }
+}
+
+/// Why this document's edits can never be written back, or `None` when they
+/// can. The single source of truth behind every save path's refusal, the
+/// read-only badge on the tag header, and the close prompt's decision not to
+/// treat these edits as unsaved work.
+pub(in crate::app) fn unsaveable_reason(entry: &TagEntry, tag: &TagFile) -> Option<&'static str> {
+    if matches!(entry.location, TagEntryLocation::Monolithic { .. }) {
+        return Some(
+            "Tags in a monolithic build are read-only — edits stay in this session and are \
+             lost when the tag is closed",
+        );
+    }
+    // The MCC tag writer emits a little-endian header, so a big-endian tag
+    // (Xbox 360 / legacy debug build) has no round-trip. Classic tags carry
+    // their own writer and are fine either way.
+    if tag.classic_engine().is_none() && tag.endian != Endian::Le {
+        return Some(
+            "Only little-endian MCC tags can be saved — edits to this big-endian tag stay in \
+             this session",
+        );
+    }
+    None
+}
+
+/// Whether edits to this document can be written back anywhere.
+pub(in crate::app) fn is_saveable_tag(entry: &TagEntry, tag: &TagFile) -> bool {
+    unsaveable_reason(entry, tag).is_none()
 }
 
 pub(in crate::app) fn append_field_path(prefix: &str, field_name: &str) -> String {

--- a/src/app/foundation/tests.rs
+++ b/src/app/foundation/tests.rs
@@ -599,4 +599,93 @@ mod tests {
             assert_eq!(edit.resolve_open("some/block", true), None);
         });
     }
+
+    /// The reported complaint, at the layer that causes it: a value the editor
+    /// considers uneditable is *painted text* — there is no cursor to place in
+    /// it, nothing to drag a selection across, and nothing to copy. A value in
+    /// an editable context is a text box, which is what makes retyping a tag
+    /// build's numbers somewhere else possible at all.
+    ///
+    /// Driven through real pointer input rather than by asking which branch was
+    /// taken: what matters is whether clicking the cell puts a caret in it.
+    #[test]
+    fn only_an_editable_value_row_can_be_clicked_into() {
+        assert!(
+            click_across_value_row(true),
+            "an editable value row must take a caret, or its text cannot be selected or copied"
+        );
+        assert!(
+            !click_across_value_row(false),
+            "a read-only row is painted text — nothing there can take focus"
+        );
+    }
+
+    /// Render one `real_vector_3d` row (the `Point 0 / x y z` shape from the
+    /// report) and click along it until something takes keyboard focus.
+    /// Returns whether anything ever did.
+    fn click_across_value_row(editable: bool) -> bool {
+        let ctx = egui::Context::default();
+        let mut tag =
+            TagFile::new(crate::app::test_definition_path("halo4_mcc/camera_track.json")).unwrap();
+        crate::app::add_block_element(&mut tag, "control points").unwrap();
+        let mut focused = false;
+
+        with_test_edit_context(|edit| {
+            edit.editable = editable;
+            // Sweep the row rather than trusting a hand-computed cell position:
+            // the widths are layout details, and a click that lands on the label
+            // by accident would report "not editable" for the wrong reason.
+            for step in 0..90 {
+                let pointer = egui::Pos2::new(step as f32 * 10.0, 12.0);
+                let click = |pressed| egui::Event::PointerButton {
+                    pos: pointer,
+                    button: egui::PointerButton::Primary,
+                    pressed,
+                    modifiers: Default::default(),
+                };
+                let input = egui::RawInput {
+                    screen_rect: Some(egui::Rect::from_min_size(
+                        egui::Pos2::ZERO,
+                        egui::Vec2::new(900.0, 200.0),
+                    )),
+                    events: vec![
+                        egui::Event::PointerMoved(pointer),
+                        click(true),
+                        click(false),
+                    ],
+                    ..Default::default()
+                };
+                let _ = ctx.run(input, |ctx| {
+                    egui::CentralPanel::default().show(ctx, |ui| {
+                        let field = tag
+                            .root()
+                            .field_path("control points[0]/position")
+                            .expect("the control point's position field");
+                        let value = field.value().expect("position has a value");
+                        let meta = field_display_meta(field.name());
+                        draw_foundation_value_row(
+                            ui,
+                            field,
+                            &meta,
+                            field.type_name(),
+                            &value,
+                            &TagNameIndex::default(),
+                            0,
+                            "control points[0]/position",
+                            edit,
+                            None,
+                            None,
+                            300.0,
+                        );
+                    });
+                });
+                if ctx.memory(|memory| memory.focused()).is_some() {
+                    focused = true;
+                    break;
+                }
+            }
+        });
+
+        focused
+    }
 }

--- a/src/app/kit.rs
+++ b/src/app/kit.rs
@@ -437,7 +437,22 @@ impl Baboon {
 }
 
 fn kit_has_dirty_documents(kit: &Kit) -> bool {
-    kit.parsed_tags.values().any(|document| document.dirty.is_set())
+    kit.parsed_tags
+        .iter()
+        .any(|(key, document)| {
+            document.dirty.is_set() && document_edits_are_saveable(kit, key, document)
+        })
+}
+
+/// Whether this kit's edits to `key` could be written back at all.
+///
+/// A monolithic build (and any other tag with no writer) is editable but never
+/// saveable, so its dirty flag is not unsaved *work*: counting it as such would
+/// raise a save prompt on every close whose only honest answer is Discard.
+pub(super) fn document_edits_are_saveable(kit: &Kit, key: &str, document: &TagDocument) -> bool {
+    // An entry the kit can no longer find is not one this can rule out.
+    kit.entry_for_key(key)
+        .is_none_or(|entry| is_saveable_tag(entry, &document.tag))
 }
 
 /// Label for a kit in the kit strip: the game's display name where one was
@@ -469,8 +484,75 @@ fn active_after_removal(active: usize, removed: usize, new_len: usize) -> usize 
 
 #[cfg(test)]
 mod tests {
-    use super::{ Kit, KitId, active_after_removal};
+    use super::{Kit, KitId, TagDocument, active_after_removal, kit_has_dirty_documents};
+    use crate::app::test_definition_path;
+    use crate::source::{LoadedSourceData, TagEntry, TagEntryLocation, TagSource, build_tree};
+    use blam_tags::TagFile;
     use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    fn kit_holding(location: TagEntryLocation, endian: blam_tags::Endian) -> Kit {
+        let mut tag = TagFile::new(test_definition_path("halo4_mcc/camera_track.json")).unwrap();
+        tag.endian = endian;
+        let entry = TagEntry {
+            key: "tag".to_owned(),
+            display_path: "test/example.camera_track".to_owned(),
+            group_tag: tag.header.group_tag,
+            group_name: Some("camera_track".to_owned()),
+            location,
+        };
+        let entries = vec![entry];
+        let mut kit = Kit::empty(KitId(0), Default::default());
+        kit.source = Some(LoadedSourceData {
+            label: "test".to_owned(),
+            // Irrelevant to the question asked: what decides an edit's fate is
+            // the entry's location, not how the browser was opened.
+            source: TagSource::SingleFile {
+                path: PathBuf::from("example.camera_track"),
+            },
+            names: Default::default(),
+            game: None,
+            tree: build_tree(&entries),
+            group_tree: build_tree(&entries),
+            entries,
+            all_entries: Vec::new(),
+            reverse_dependencies: None,
+            initial_tag: None,
+        });
+        kit.parsed_tags
+            .insert("tag".to_owned(), TagDocument::modified(tag));
+        kit
+    }
+
+    /// Edits to a tag with nowhere to be written are not unsaved *work*, and
+    /// must not raise the close prompt.
+    ///
+    /// The prompt's only outcomes are Save and Discard. Save on a monolithic
+    /// build fails by construction, and `CloseApp` re-checks for dirty
+    /// documents after the prompt closes — so counting these would put a quit
+    /// behind a dialog whose Save button can never clear it.
+    #[test]
+    fn a_dirty_tag_that_can_never_be_saved_is_not_unsaved_work() {
+        let monolithic = kit_holding(
+            TagEntryLocation::Monolithic {
+                name: "test\\example".to_owned(),
+                group_tag: u32::from_be_bytes(*b"trak"),
+            },
+            blam_tags::Endian::Be,
+        );
+        assert!(
+            !kit_has_dirty_documents(&monolithic),
+            "a monolithic build's edits are session-scratch, not unsaved work"
+        );
+
+        // The same document from somewhere it can be written back to still
+        // stops a close, which is the whole point of the flag.
+        let loose = kit_holding(
+            TagEntryLocation::LooseFile(PathBuf::from("example.camera_track")),
+            blam_tags::Endian::Le,
+        );
+        assert!(kit_has_dirty_documents(&loose));
+    }
 
     /// A folder move rewrites tag keys underneath the open tabs. The tree is
     /// what has to be rewritten: `open_tabs` is re-derived from it every frame,
@@ -540,6 +622,19 @@ pub(super) fn tag_tree_id(id: KitId) -> egui::Id {
 }
 
 impl Kit {
+    /// This kit's browser entry for `key`, wherever it is listed: the visible
+    /// entries, the full set a filtered browser hides, or a favorite pulled in
+    /// from elsewhere.
+    pub(super) fn entry_for_key(&self, key: &str) -> Option<&TagEntry> {
+        let source = self.source.as_ref()?;
+        source
+            .entries
+            .iter()
+            .chain(source.all_entries.iter())
+            .chain(self.active_favorite_entries.iter())
+            .find(|entry| entry.key == key)
+    }
+
     /// Tag keys currently laid out, in tab order. Derived from the tree, which
     /// owns the layout; callers treat `open_tabs` as a read-only view.
     pub(super) fn tabs_from_tree(&self) -> Vec<String> {


### PR DESCRIPTION
A tag build was viewable and nothing else. Every field rendered as painted text, so its values could not be selected or copied — the report that prompted this asked only for copyable text ("typing this shit by hand is tedious"), and editability is what delivers it: a read-only row has no caret to place and no selection to drag.

## Editability and saveability are now two questions

They were one gate, and saveability was answering both.

- **`is_editable_tag`** — true for every location and every byte order. An edit is a write into the document's own bytes, and blam-tags encodes each field in the tag's own endian, so there is nothing incoherent about typing into a big-endian tag. Kept as an exhaustive `match` so a new `TagEntryLocation` has to state its answer rather than inherit one.
- **`unsaveable_reason`** — the single source of truth for refusals. A monolithic build has no writer; the MCC writer emits a little-endian header, so a big-endian tag has no round-trip either.

It feeds both save paths, a "Cannot be saved" badge in the tag header, and the dirty-document accounting.

That last one is load-bearing. A dirty document that can never be saved is not unsaved *work*, and the close prompt's only outcomes are Save and Discard. Counting these would have put a quit behind a dialog whose Save button can never clear it — `CloseApp` re-checks for dirty documents after the prompt closes, so it would never terminate.

## Engine bump: `06b1d4e` → `22cdc0e`

Reading a Halo 4 monolithic build's render geometry panicked in `half_to_f32`: its subnormal branch counted the exponent down in a `u32`, so `e + 127` overflowed for any half needing two or more normalizing shifts. Release builds wrapped straight back to the intended value and never noticed — this only showed up under `debug-assertions`, where it killed the tag-load worker thread and left the tab on "Loading…" forever. The exponent is now `i32`, and the engine test covers all 1023 subnormals in both signs.

## Verification

Against a Halo 4 development build, **115,080 tags**:

| | |
|---|---|
| edited big-endian, value read back as typed, bytes absent in LE order | **107,110** |
| no `real` field to type into | 7,711 |
| unreadable (parse errors, uninvestigated) | 259 |
| panicked on read / failed | **0 / 0** |

The sweep is skip-if-absent behind `BABOON_MONOLITHIC` and reports that ledger — every tag counted before anything is filtered, every skip named — because a run that reached almost nothing must not read as a clean pass.

Byte order is checked against real data rather than a synthetic tag on purpose: element bytes are held in source wire order, so flipping `TagFile::endian` on a schema-built tag changes the wire marker and not one byte of block data. Such a test would agree with a broken encoder.

The value-row test drives real pointer input instead of asserting which branch was taken: it clicks across the row and checks whether anything takes a caret — yes when editable, never when not.

Full suite: 473 passed, 0 failed.

## Worth a reviewer's attention

A **big-endian loose tag becomes editable too**. That is the same rule rather than a second one — edits live in memory, and saving is where the refusal belongs — but it is a behaviour change beyond monolithic builds, and easy to scope back to `Monolithic` alone if that reads better.