### PR TITLE
Give a collision, physics, or animation tag extracted on its own its skeleton

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,7 +502,7 @@ dependencies = [
 [[package]]
 name = "blam-tags"
 version = "0.1.0"
-source = "git+https://github.com/camden-smallwood/blam-tags?rev=bd7fa35#bd7fa354d8688af969c2d4759663df2c258855b2"
+source = "git+https://github.com/camden-smallwood/blam-tags?rev=ff7526e#ff7526ebf37d05ac39c985c52bddca015d7430de"
 dependencies = [
  "anyhow",
  "bcdec_rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,7 +502,7 @@ dependencies = [
 [[package]]
 name = "blam-tags"
 version = "0.1.0"
-source = "git+https://github.com/Zoephie/blam-tags?rev=f92c8ec#f92c8ecc938df92effe517fd54e143830bc9c755"
+source = "git+https://github.com/camden-smallwood/blam-tags?rev=0656e0d#0656e0d59a5d07f19425955987b9e3f8b1fd9fb2"
 dependencies = [
  "anyhow",
  "bcdec_rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,7 +502,7 @@ dependencies = [
 [[package]]
 name = "blam-tags"
 version = "0.1.0"
-source = "git+https://github.com/camden-smallwood/blam-tags?rev=0656e0d#0656e0d59a5d07f19425955987b9e3f8b1fd9fb2"
+source = "git+https://github.com/camden-smallwood/blam-tags?rev=bd7fa35#bd7fa354d8688af969c2d4759663df2c258855b2"
 dependencies = [
  "anyhow",
  "bcdec_rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,13 +2,12 @@
 # parent workspace. The blam-tags engine is pinned to a revision, not a
 # submodule.
 #
-# The engine lives at camden-smallwood/blam-tags and the pin belongs there. It
-# points at Zoephie/blam-tags `codex/chimp-backend` while work that has not
-# reached upstream is in flight — currently the signed DXN bump-map fix
-# (camden-smallwood/blam-tags#3) and the recursive cross-game layout comparison
-# the Halo Reach → Campaign Evolved import needs. That branch is camden's
-# `master` plus those, so nothing upstream is dropped. Move the pin back to the
-# camden URL at the merge commit once they land.
+# The engine lives at camden-smallwood/blam-tags and the pin is back there. Its
+# `master` now carries both pieces that were in flight on Zoephie/blam-tags
+# `codex/chimp-backend` — the signed DXN bump-map fix (merged as
+# camden-smallwood/blam-tags#3) and the recursive cross-game layout comparison
+# the Halo Reach → Campaign Evolved import needs, merged in at `11dcd83`. The
+# old pin `f92c8ec` is an ancestor of this rev, so nothing was dropped.
 [workspace]
 members = ["."]
 default-members = ["."]
@@ -27,7 +26,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1"
 atomic-write-file = "0.3"
-blam-tags = { git = "https://github.com/Zoephie/blam-tags", rev = "f92c8ec", features = ["audio", "iostore"] }
+blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "0656e0d", features = ["audio", "iostore"] }
 directories = "6"
 display-info = "0.5"
 eframe = { version = "0.29", default-features = false, features = ["default_fonts", "glow"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1"
 atomic-write-file = "0.3"
-blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "bd7fa35", features = ["audio", "iostore"] }
+blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "ff7526e", features = ["audio", "iostore"] }
 directories = "6"
 display-info = "0.5"
 eframe = { version = "0.29", default-features = false, features = ["default_fonts", "glow"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1"
 atomic-write-file = "0.3"
-blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "0656e0d", features = ["audio", "iostore"] }
+blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "bd7fa35", features = ["audio", "iostore"] }
 directories = "6"
 display-info = "0.5"
 eframe = { version = "0.29", default-features = false, features = ["default_fonts", "glow"] }

--- a/src/app.rs
+++ b/src/app.rs
@@ -438,6 +438,7 @@ impl Baboon {
         set_dark_mode(prefs.dark_mode);
         cc.egui_ctx.set_visuals(foundation_visuals());
         let names = TagNameIndex::load_from_definitions(&locate_definitions_root());
+        names.publish_as_process_group_names();
         let (tx, rx) = mpsc::channel();
         let last_session = (!suppress_startup_popups && first_run_wizard.is_none())
             .then(load_last_session)

--- a/src/app.rs
+++ b/src/app.rs
@@ -312,6 +312,11 @@ pub struct Baboon {
     /// File-menu actions run after the editor has rendered, so an edit being
     /// committed by focus loss is applied before its save/export snapshot.
     deferred_file_action: Option<DeferredFileAction>,
+    /// Kits whose session-restore load has not landed yet, and the one the
+    /// session named as focused. Every load ends by making its own kit active,
+    /// so the focus can only be honoured once none are outstanding.
+    restoring_kits: HashSet<KitId>,
+    restored_active_kit: Option<KitId>,
     color_popup: Option<MaterialColorPopup>,
     /// Kits owning the editing popups below. Each outlives the frame that
     /// opened it and applies an edit addressed by tag key — and a tag key is
@@ -566,6 +571,8 @@ impl Baboon {
                 .unwrap_or_default(),
             blender_path: prefs.blender_path,
             deferred_file_action: None,
+            restoring_kits: HashSet::new(),
+            restored_active_kit: None,
             color_popup: None,
             color_popup_kit: None,
             function_popup_kit: None,

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -3245,6 +3245,32 @@ impl Baboon {
         }
     }
 
+    /// Record the session as the event loop tears down.
+    ///
+    /// Baboon's whole shutdown chain hangs off a window close request:
+    /// `handle_app_close_request` only acts on `close_requested()`, and it is
+    /// what eventually reaches [`Self::execute_close_action`] and saves the
+    /// session. macOS never sends one for Cmd+Q — AppKit posts
+    /// `applicationWillTerminate:`, which closes each window directly rather
+    /// than asking it to close, so no `CloseRequested` is ever emitted and none
+    /// of that runs. The session file was then left holding whatever last wrote
+    /// it, which for a Campaign Evolved workspace is its project autosave: quit
+    /// with a Halo 3 kit open and the next launch restored Campaign Evolved,
+    /// because that was the last session anything had recorded.
+    ///
+    /// This runs on every shutdown, including the ordinary one that already
+    /// saved a moment earlier — the write is the same document either way. It
+    /// cannot prompt: the loop is already exiting and `LoopExiting` cannot be
+    /// vetoed, so unsaved tag edits still go unremarked on a Cmd+Q.
+    pub(super) fn persist_session_on_exit(&mut self) {
+        match self.current_session_state() {
+            Some(session) => {
+                let _ = save_last_session(&session);
+            }
+            None => clear_last_session(),
+        }
+    }
+
     /// Reopen the tags staged for the kit that just finished loading.
     fn finish_pending_session_restore(&mut self, ctx: egui::Context) {
         let restore = std::mem::take(&mut self.kits[self.active].pending_restore_tags);

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -3089,6 +3089,7 @@ impl Baboon {
 
     fn session_kit_state(&self, kit_index: usize) -> Option<LastSessionKit> {
         let kit = &self.kits[kit_index];
+        let was_active = kit_index == self.active;
         let source = kit.source.as_ref()?;
         let (source_kind, source_path) = match &source.source {
             TagSource::SingleFile { path } => (LastSessionSourceKind::SingleFile, path.clone()),
@@ -3165,6 +3166,7 @@ impl Baboon {
             tags,
             chimp_packages,
             active_chimp_package,
+            was_active,
         })
     }
 
@@ -3182,6 +3184,7 @@ impl Baboon {
             tags,
             chimp_packages,
             active_chimp_package,
+            was_active,
         } in kits
         {
             match source_kind {
@@ -3223,6 +3226,16 @@ impl Baboon {
             }
             // The loaders route to a kit and leave it active, so this stages
             // the tags on the kit the load will land in.
+            //
+            // Each load also finishes by making its own kit active, so the
+            // focused workspace would otherwise be whichever one happened to
+            // load last. Remember the kit the session named and every kit still
+            // to land, so the focus can be set once they all have.
+            let restoring = self.kits[self.active].id;
+            self.restoring_kits.insert(restoring);
+            if was_active {
+                self.restored_active_kit = Some(restoring);
+            }
             self.kits[self.active].pending_restore_tags = tags;
             self.kits[self.active].pending_restore_chimp_packages = chimp_packages;
             self.kits[self.active].pending_restore_active_chimp_package = active_chimp_package;
@@ -3268,6 +3281,28 @@ impl Baboon {
                 let _ = save_last_session(&session);
             }
             None => clear_last_session(),
+        }
+    }
+
+    /// Mark one restored kit's load as settled, whatever became of it, and once
+    /// none are left hand the focus to the kit the session named.
+    ///
+    /// Every completed load makes its own kit active, so during a restore the
+    /// focused workspace is otherwise decided by which source finishes first —
+    /// a loose folder against a container set is not a race with a stable
+    /// winner. The saved kit is only honoured while it is still open and it
+    /// still loaded; a kit the user unchecked in the restore prompt, or whose
+    /// source has since moved, leaves the focus wherever the loads put it.
+    pub(super) fn settle_restored_kit(&mut self, kit: KitId) {
+        let Some(active) = focus_after_restore(
+            &mut self.restoring_kits,
+            &mut self.restored_active_kit,
+            kit,
+        ) else {
+            return;
+        };
+        if let Some(index) = self.kit_index(active) {
+            self.active = index;
         }
     }
 
@@ -10285,6 +10320,91 @@ mod tsv_paste_tests {
                 Some("material name^".to_owned()),
             ]
         );
+    }
+}
+
+/// Retire one restored kit's load and report the kit that should take the focus
+/// — `None` while any restore is still outstanding, or when the session named
+/// no kit and there is nothing to honour.
+///
+/// Split out from [`Baboon::settle_restored_kit`] because it is the whole
+/// decision: the app half only turns the answer into an index.
+fn focus_after_restore(
+    restoring: &mut HashSet<KitId>,
+    restored_active: &mut Option<KitId>,
+    settled: KitId,
+) -> Option<KitId> {
+    // A load that was not part of the restore settles nothing, and neither does
+    // one that still leaves others in flight.
+    if !restoring.remove(&settled) || !restoring.is_empty() {
+        return None;
+    }
+    restored_active.take()
+}
+
+#[cfg(test)]
+mod restore_focus_tests {
+    use super::*;
+
+    /// Every completed load makes its own kit active, so a restore's focus can
+    /// only be honoured once none are left in flight — otherwise whichever
+    /// source finished last would win, and a loose folder racing a container
+    /// set has no stable winner. Quitting with Halo 3 focused came back to
+    /// Campaign Evolved this way.
+    #[test]
+    fn the_focus_waits_for_every_restored_kit_to_land() {
+        let (halo3, evolved) = (KitId(1), KitId(2));
+        let mut restoring = HashSet::from([halo3, evolved]);
+        let mut active = Some(halo3);
+
+        assert_eq!(
+            focus_after_restore(&mut restoring, &mut active, evolved),
+            None,
+            "one kit is still loading, so the focus is not settled yet"
+        );
+        assert_eq!(
+            focus_after_restore(&mut restoring, &mut active, halo3),
+            Some(halo3),
+            "the last landing hands the focus to the kit the session named"
+        );
+        assert_eq!(active, None, "and it is honoured only once");
+    }
+
+    /// Load order must not change the answer.
+    #[test]
+    fn the_focused_kit_wins_whichever_lands_first() {
+        let (halo3, evolved) = (KitId(1), KitId(2));
+        for order in [[halo3, evolved], [evolved, halo3]] {
+            let mut restoring = HashSet::from([halo3, evolved]);
+            let mut active = Some(halo3);
+            let settled: Vec<_> = order
+                .into_iter()
+                .filter_map(|kit| focus_after_restore(&mut restoring, &mut active, kit))
+                .collect();
+            assert_eq!(settled, [halo3], "landing order {order:?} changed the focus");
+        }
+    }
+
+    /// A session written before the focused kit was recorded names none, and a
+    /// load that was never part of a restore must not disturb anything.
+    #[test]
+    fn nothing_is_claimed_without_a_named_kit_or_a_restore() {
+        let halo3 = KitId(1);
+        let mut restoring = HashSet::from([halo3]);
+        let mut active = None;
+        assert_eq!(
+            focus_after_restore(&mut restoring, &mut active, halo3),
+            None
+        );
+
+        let mut restoring = HashSet::new();
+        let mut active = Some(halo3);
+        assert_eq!(
+            focus_after_restore(&mut restoring, &mut active, KitId(9)),
+            None,
+            "an ordinary load is not a restore landing"
+        );
+        assert_eq!(active, Some(halo3), "and leaves the pending focus alone");
     }
 }
 

--- a/src/app/controller/loading.rs
+++ b/src/app/controller/loading.rs
@@ -16,6 +16,7 @@ impl Baboon {
         // the load was in flight the result is dropped rather than landing in
         // whichever kit happens to be active now.
         let Some(index) = self.resolve_kit(kit) else {
+            self.settle_restored_kit(kit);
             return true;
         };
         self.active = index;
@@ -23,6 +24,7 @@ impl Baboon {
             Ok(loaded) => loaded,
             Err(error) => {
                 self.release_source_load(kit);
+                self.settle_restored_kit(kit);
                 self.status = error;
                 return false;
             }
@@ -107,6 +109,10 @@ impl Baboon {
             self.schedule_next_entry_index_refresh(ctx);
         }
         self.finish_pending_session_restore(ctx.clone());
+        // This load made its own kit active. If a session restore is still in
+        // flight that is only provisional — the focus belongs to the kit the
+        // session named, once every restored kit has landed.
+        self.settle_restored_kit(kit);
         self.finish_pending_command_line_launch(ctx.clone());
         false
     }

--- a/src/app/editor/value_parser.rs
+++ b/src/app/editor/value_parser.rs
@@ -630,6 +630,12 @@ pub(in crate::app) fn enum_option_label(options: &[&str], selected: i64) -> Stri
 }
 
 pub(in crate::app) fn extension_to_group_tag(extension: &str) -> Option<u32> {
+    // The games' own `_meta.json` first — it covers every group Baboon can
+    // open, and does not have to be kept in step by hand. The table below
+    // remains for the cases that run before any definitions are loaded.
+    if let Some(group_tag) = crate::format::process_group_tag_for(extension) {
+        return Some(group_tag);
+    }
     let fourcc = match extension {
         "material" => "mat",
         "material_shader" => "mats",

--- a/src/app/export/geometry.rs
+++ b/src/app/export/geometry.rs
@@ -493,6 +493,55 @@ impl blam_tags::extract::TagResolver for SourceResolver<'_> {
     }
 }
 
+/// The `.model` that owns a selected `model_animation_graph`, when swapping it
+/// in for the graph would give the export a rest pose it does not otherwise
+/// have.
+///
+/// Applied only to graphs whose `additional node data` leaves at least one
+/// skeleton bone without a rest pose, so the 2,515 Reach graphs that are
+/// already complete export byte-for-byte as before. The owner is found by the
+/// graph's own path and then **verified**: it counts only if that model's
+/// `animation` reference points back at this graph. Measured over Halo Reach,
+/// that improves 45 of the 79 short graphs (`magnum`, `plasma_pistol`, and the
+/// cinematic object graphs among them); the other 34 have no model beside them
+/// and keep today's behaviour. Halo 3's 50 short graphs have no sibling model
+/// at all, so nothing there changes.
+fn animation_graph_owner(
+    source: &TagSource,
+    entry: &TagEntry,
+    jmad: &TagFile,
+) -> Option<TagFile> {
+    if entry.group_tag != u32::from_be_bytes(*b"jmad") {
+        return None;
+    }
+    let skeleton = blam_tags::Skeleton::from_tag(jmad);
+    if skeleton.is_empty() || animation_rest_pose_is_complete(jmad, &skeleton) {
+        return None;
+    }
+    let reference = entry_reference_path(source, entry)?;
+    let model = load_referenced_tag_from_source(source, &reference, "model", b"hlmt").ok()?;
+    let names_this_graph = tag_ref_path(&model.root(), "animation")
+        .is_some_and(|r| r.eq_ignore_ascii_case(&reference));
+    names_this_graph.then_some(model)
+}
+
+/// Whether the jmad's own `additional node data` gives every skeleton bone a
+/// rest pose.
+fn animation_rest_pose_is_complete(jmad: &TagFile, skeleton: &blam_tags::Skeleton) -> bool {
+    let named: std::collections::HashSet<String> = jmad
+        .root()
+        .field_path("additional node data")
+        .and_then(|field| field.as_block())
+        .map(|block| {
+            (0..block.len())
+                .filter_map(|i| block.element(i)?.read_string_id("node name"))
+                .filter(|name| !name.is_empty())
+                .collect()
+        })
+        .unwrap_or_default();
+    skeleton.nodes.iter().all(|node| named.contains(&node.name))
+}
+
 /// Extract every animation in `entry` (a jmad, `.model`, object tag, or
 /// Halo CE `model_animations`) to JMA-family files under
 /// `<output>/<stem>/animations/`, in-process via `blam_tags::extract`.
@@ -504,7 +553,15 @@ pub(in crate::app) fn extract_animations_for_entry(
     let tag = read_entry(source, entry)?;
     let resolver = SourceResolver { source };
     let stem = tag_file_stem(entry);
-    let summary = blam_tags::extract::animation::animations_to_dir(&tag, &resolver, output, &stem)?;
+    // A graph extracted on its own names no render_model, so its rest pose can
+    // only come from `additional node data` — the denormalised copy inside the
+    // jmad. 79 of Halo Reach's 2,594 graphs carry none at all, and those export
+    // with every bone at identity. Hand the extractor the owning `.model`
+    // instead, exactly as if the model had been the selected tag.
+    let owner = animation_graph_owner(source, entry, &tag);
+    let input = owner.as_ref().unwrap_or(&tag);
+    let summary =
+        blam_tags::extract::animation::animations_to_dir(input, &resolver, output, &stem)?;
     let mut message = format!(
         "Extracted {} animation(s) from {} into {}",
         summary.written,
@@ -733,6 +790,94 @@ mod tests {
                 "{extension}: the export path did not resolve a skeleton — {message}"
             );
         }
+    }
+
+    /// A `model_animation_graph` that stores no `additional node data` has no
+    /// rest pose reachable from the graph alone, so extracting it on its own
+    /// wrote every bone at identity. Guards that the owning `.model` is now
+    /// found from the graph's own path and its render_model used instead.
+    ///
+    /// Ignored by default — it needs a loose Halo Reach tag tree.
+    ///
+    /// Run with:
+    ///   REACH_TAGS=~/Halo/haloreach_mcc/tags \
+    ///     cargo test animation_graph_without -- --ignored --nocapture
+    #[test]
+    #[ignore = "requires a loose Halo Reach tag tree; set REACH_TAGS"]
+    fn animation_graph_without_its_own_rest_pose_borrows_the_owning_models() {
+        let Ok(root) = std::env::var("REACH_TAGS") else {
+            eprintln!("skipping: set REACH_TAGS to a loose Halo Reach tags directory");
+            return;
+        };
+        let root = PathBuf::from(root);
+        let source = TagSource::LooseFolder {
+            root: root.clone(),
+            game: Some("haloreach_mcc".to_owned()),
+            definitions_root: crate::app::locate_definitions_root(),
+        };
+        // The magnum's own graph: five gun bones, and not one `additional node
+        // data` entry to place them with.
+        let stem = "objects/weapons/pistol/magnum/magnum";
+        let path = root.join(format!("{stem}.model_animation_graph"));
+        assert!(path.is_file(), "{} is not in this tag tree", path.display());
+        let entry = TagEntry {
+            key: format!("file:{}", path.display()),
+            display_path: format!("{stem}.model_animation_graph"),
+            group_tag: u32::from_be_bytes(*b"jmad"),
+            group_name: Some("model_animation_graph".to_owned()),
+            location: TagEntryLocation::LooseFile(path),
+        };
+
+        let jmad = read_entry(&source, &entry).expect("read the graph");
+        let skeleton = blam_tags::Skeleton::from_tag(&jmad);
+        assert!(
+            !animation_rest_pose_is_complete(&jmad, &skeleton),
+            "this graph carries its own rest pose, so it proves nothing here"
+        );
+
+        let owner = animation_graph_owner(&source, &entry, &jmad)
+            .expect("the magnum's .model should be found and should name this graph");
+        let resolved =
+            blam_tags::extract::animation::resolve_animation_inputs(&owner, &SourceResolver {
+                source: &source,
+            })
+            .expect("resolve through the owning model");
+        let render = resolved
+            .render_model
+            .as_ref()
+            .expect("the owning model names a render_model");
+
+        let object_space = blam_tags::extract::animation::additional_node_data_is_object_space(
+            &blam_tags::Animation::new(&jmad).expect("read animations"),
+        );
+        let without =
+            blam_tags::extract::animation::build_defaults(&skeleton, &jmad, None, object_space);
+        let with = blam_tags::extract::animation::build_defaults(
+            &skeleton,
+            &jmad,
+            Some(render),
+            object_space,
+        );
+
+        let posed = |set: &[blam_tags::NodeTransform]| {
+            set.iter()
+                .filter(|t| {
+                    t.translation.x != 0.0 || t.translation.y != 0.0 || t.translation.z != 0.0
+                })
+                .count()
+        };
+        assert_eq!(
+            posed(&without),
+            0,
+            "the graph-only control is supposed to be collapsed to identity; \
+             if it is not, this test proves nothing"
+        );
+        assert!(
+            posed(&with) > 1,
+            "only {}/{} bones got a rest pose from the owning model",
+            posed(&with),
+            with.len()
+        );
     }
 
     /// End-to-end against a real Campaign Evolved install: mount the pak set,

--- a/src/app/export/geometry.rs
+++ b/src/app/export/geometry.rs
@@ -33,30 +33,44 @@ pub(in crate::app) fn extract_geometry_for_entry(
                 path.display()
             ))
         }
-        b"coll" => {
+        // Neither of these tags stores its own bone transforms, so both need the
+        // owning model's skeleton to come out anywhere but the origin.
+        group @ (b"coll" | b"phmo") => {
+            let collision = group == b"coll";
             let tag = read_entry(source, entry)?;
             fs::create_dir_all(output)?;
             let stem = tag_file_stem(entry);
-            let jms = JmsFile::from_collision_model(&tag)?;
-            let path = output.join(format!("{stem}.collision.jms"));
+            let skeleton = owning_model_skeleton(source, entry);
+            let nodes = skeleton.as_ref().map(ModelSkeleton::nodes);
+            let mut jms = if collision {
+                collision_jms_for_game(&tag, nodes)?
+            } else {
+                physics_jms_for_game(&tag, nodes)?
+            };
+            if let Some(skel) = skeleton.as_ref().and_then(ModelSkeleton::campaign_evolved) {
+                jms.reorient_for_campaign_evolved(skel);
+            }
+            let (group_name, kind) = if collision {
+                ("collision_model", "collision")
+            } else {
+                ("physics_model", "physics")
+            };
+            let path = output.join(format!("{stem}.{kind}.jms"));
             let mut file = std::io::BufWriter::new(fs::File::create(&path)?);
             jms.write(&mut file, blam_tags::game::Game::of(&tag).jms_version())?;
+            // Halo 1 collision is node-local with no bind transform in the tag,
+            // so there is no skeleton to miss there.
+            let composes_a_skeleton =
+                !(collision && blam_tags::game::Game::of(&tag) == blam_tags::game::Game::Halo1);
             Ok(format!(
-                "Extracted collision_model geometry {}",
-                path.display()
-            ))
-        }
-        b"phmo" => {
-            let tag = read_entry(source, entry)?;
-            fs::create_dir_all(output)?;
-            let stem = tag_file_stem(entry);
-            let jms = JmsFile::from_physics_model(&tag)?;
-            let path = output.join(format!("{stem}.physics.jms"));
-            let mut file = std::io::BufWriter::new(fs::File::create(&path)?);
-            jms.write(&mut file, blam_tags::game::Game::of(&tag).jms_version())?;
-            Ok(format!(
-                "Extracted physics_model geometry {}",
-                path.display()
+                "Extracted {group_name} geometry {}{}",
+                path.display(),
+                if skeleton.is_none() && composes_a_skeleton {
+                    " (no owning model found, so every bone is at the origin — \
+                     extract the .model that references this tag instead)"
+                } else {
+                    ""
+                }
             ))
         }
         _ => anyhow::bail!(
@@ -64,6 +78,152 @@ pub(in crate::app) fn extract_geometry_for_entry(
             format_group_tag(entry.group_tag)
         ),
     }
+}
+
+/// The rest pose a collision or physics JMS is composed against, plus — on
+/// Campaign Evolved — the `skeleton model` whose Halo-style armature the
+/// finished file is reoriented onto.
+struct ModelSkeleton {
+    nodes: Vec<blam_tags::JmsNode>,
+    campaign_evolved: Option<TagFile>,
+}
+
+impl ModelSkeleton {
+    fn nodes(&self) -> &[blam_tags::JmsNode] {
+        &self.nodes
+    }
+
+    fn campaign_evolved(&self) -> Option<&TagFile> {
+        self.campaign_evolved.as_ref()
+    }
+}
+
+/// Collision and physics geometry is stored bone-local, and neither tag carries
+/// its own bone transforms — those live in the `render_model` (or, on Campaign
+/// Evolved, the `skeleton model`) that the owning `.model` names. Extracting one
+/// of those tags on its own therefore had nothing to compose against: every bone
+/// came out at the origin and every hull and shape piled up on top of it, which
+/// is what a rigged model looks like collapsed to 0,0,0.
+///
+/// A standalone tag names no skeleton, so the owner is found by the tag's own
+/// path: `objects/…/flood_tank.collision_model` belongs to
+/// `objects/…/flood_tank.model`. Measured across the 2,486 collision and physics
+/// tags in the Halo 3 tag set, that names a render_model one of the tag's real
+/// owners uses in 2,479 cases; the 7 remaining have no `.model` beside them and
+/// fall through to the render_model at the same path. Anything still unresolved
+/// returns `None` and the export degrades to the old unposed output rather than
+/// to a wrong pose.
+fn owning_model_skeleton(source: &TagSource, entry: &TagEntry) -> Option<ModelSkeleton> {
+    let reference = entry_reference_path(source, entry)?;
+    if let Ok(model) = load_referenced_tag_from_source(source, &reference, "model", b"hlmt") {
+        if let Some(skeleton) = model_skeleton(source, &model) {
+            return Some(skeleton);
+        }
+    }
+    // No `.model` beside the tag (or it named no usable skeleton) — a
+    // render_model at the same path is the next-best owner.
+    let render = load_referenced_tag_from_source(source, &reference, "render_model", b"mode").ok()?;
+    Some(ModelSkeleton {
+        nodes: render_jms_for_game(&render).ok()?.nodes,
+        campaign_evolved: None,
+    })
+}
+
+/// The rest pose a `.model` supplies to its collision and physics geometry:
+/// the render_model's bind pose, or the `skeleton model` on Campaign Evolved,
+/// which ships no render_model at all.
+fn model_skeleton(source: &TagSource, model: &TagFile) -> Option<ModelSkeleton> {
+    let root = model.root();
+    if let Some(reference) = tag_ref_path(&root, "render model") {
+        if let Ok(render) =
+            load_referenced_tag_from_source(source, &reference, "render_model", b"mode")
+        {
+            if let Ok(jms) = render_jms_for_game(&render) {
+                return Some(ModelSkeleton {
+                    nodes: jms.nodes,
+                    campaign_evolved: None,
+                });
+            }
+        }
+    }
+    let reference = tag_ref_path(&root, "skeleton model")?;
+    let skeleton = load_referenced_tag_from_source(source, &reference, "skeleton_model", b"skel")
+        .ok()?;
+    // Deliberately the raw rest pose — see the note in `extract_model_geometry`
+    // on why the reorientation is applied after the geometry is placed.
+    let nodes = JmsFile::skeleton_rest_pose(&skeleton).ok()?;
+    Some(ModelSkeleton {
+        nodes,
+        campaign_evolved: Some(skeleton),
+    })
+}
+
+/// A tag's own reference path, in the backslash form tag references use.
+///
+/// Taken from where the tag physically lives rather than from its display path
+/// where possible: a monolithic cache stores the reference name verbatim, and a
+/// loose file's is its path under the tags root. The display path is only a
+/// fallback because building it replaces whatever follows the last dot with the
+/// group's friendly extension, which truncates the handful of authoring names
+/// that contain a literal dot.
+fn entry_reference_path(source: &TagSource, entry: &TagEntry) -> Option<String> {
+    let extension = entry
+        .group_name
+        .clone()
+        .or_else(|| group_tag_to_extension(entry.group_tag).map(str::to_owned))?;
+    let strip = |path: &str| -> Option<String> {
+        let reference = path
+            .strip_suffix(&format!(".{extension}"))
+            .unwrap_or_else(|| path.rsplit_once('.').map_or(path, |(stem, _)| stem));
+        (!reference.is_empty()).then(|| reference.replace('/', "\\"))
+    };
+    match &entry.location {
+        TagEntryLocation::Monolithic { name, .. } if !name.is_empty() => Some(name.clone()),
+        TagEntryLocation::LooseFile(path) => {
+            let root = match source {
+                TagSource::LooseFolder { root, .. } => Some(root.clone()),
+                TagSource::SingleFile { path } => derive_tags_root(path),
+                _ => None,
+            }?;
+            strip(&path.strip_prefix(&root).ok()?.to_string_lossy())
+        }
+        _ => strip(&entry.display_path),
+    }
+}
+
+/// Halo 1 keeps collision geometry in `model_collision_geometry`, which stores
+/// its BSPs per node with no region/permutation nesting; every later engine uses
+/// `collision_model`. Reading a Halo 1 tag with the later walker found no `bsps`
+/// under any permutation and wrote an empty file.
+fn collision_jms_for_game(
+    tag: &TagFile,
+    skeleton: Option<&[blam_tags::JmsNode]>,
+) -> anyhow::Result<JmsFile> {
+    Ok(match blam_tags::game::Game::of(tag) {
+        // Halo 1 collision vertices are already node-local and the tag holds no
+        // bind transform, so there is nothing to compose a skeleton against.
+        blam_tags::game::Game::Halo1 => JmsFile::from_model_collision_geometry(tag)?,
+        _ => match skeleton {
+            Some(skeleton) => JmsFile::from_collision_model_with_skeleton(tag, skeleton)?,
+            None => JmsFile::from_collision_model(tag)?,
+        },
+    })
+}
+
+/// Halo 2 physics models store their shapes flat; Halo 3 and later nest them
+/// behind rigid-body shape references.
+fn physics_jms_for_game(
+    tag: &TagFile,
+    skeleton: Option<&[blam_tags::JmsNode]>,
+) -> anyhow::Result<JmsFile> {
+    Ok(match (blam_tags::game::Game::of(tag), skeleton) {
+        (blam_tags::game::Game::Halo2, Some(skeleton)) => {
+            JmsFile::from_physics_model_h2_with_skeleton(tag, skeleton)?
+        }
+        (blam_tags::game::Game::Halo2, None) => JmsFile::from_physics_model_h2(tag)?,
+        (_, Some(skeleton)) => JmsFile::from_physics_model_with_skeleton(tag, skeleton)?,
+        (_, None) => JmsFile::from_physics_model(tag)?,
+    })
 }
 
 pub(in crate::app) fn extract_model_geometry(
@@ -192,11 +352,7 @@ pub(in crate::app) fn extract_model_geometry(
                 Ok(tag) => {
                     let collision_dir = output.join("collision");
                     fs::create_dir_all(&collision_dir)?;
-                    let mut jms = if let Some(skeleton) = skeleton {
-                        JmsFile::from_collision_model_with_skeleton(&tag, skeleton)?
-                    } else {
-                        JmsFile::from_collision_model(&tag)?
-                    };
+                    let mut jms = collision_jms_for_game(&tag, skeleton)?;
                     if let Some(skel) = campaign_evolved_skeleton.as_ref() {
                         jms.reorient_for_campaign_evolved(skel);
                     }
@@ -217,11 +373,7 @@ pub(in crate::app) fn extract_model_geometry(
                 Ok(tag) => {
                     let physics_dir = output.join("physics");
                     fs::create_dir_all(&physics_dir)?;
-                    let mut jms = if let Some(skeleton) = skeleton {
-                        JmsFile::from_physics_model_with_skeleton(&tag, skeleton)?
-                    } else {
-                        JmsFile::from_physics_model(&tag)?
-                    };
+                    let mut jms = physics_jms_for_game(&tag, skeleton)?;
                     if let Some(skel) = campaign_evolved_skeleton.as_ref() {
                         jms.reorient_for_campaign_evolved(skel);
                     }
@@ -393,6 +545,195 @@ pub(in crate::app) fn extract_scenario_geometry(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_tags_own_reference_path_drops_only_the_group_extension() {
+        let root = PathBuf::from("/kits/halo3/tags");
+        let source = TagSource::LooseFolder {
+            root: root.clone(),
+            game: Some("halo3_mcc".to_owned()),
+            definitions_root: PathBuf::from("/definitions"),
+        };
+        let loose = |relative: &str| TagEntry {
+            key: relative.to_owned(),
+            display_path: relative.to_owned(),
+            group_tag: u32::from_be_bytes(*b"coll"),
+            group_name: Some("collision_model".to_owned()),
+            location: TagEntryLocation::LooseFile(root.join(relative)),
+        };
+
+        assert_eq!(
+            entry_reference_path(
+                &source,
+                &loose("objects/characters/flood_tank/flood_tank.collision_model")
+            )
+            .as_deref(),
+            Some("objects\\characters\\flood_tank\\flood_tank")
+        );
+        // Authoring names may contain a literal dot. The group extension is a
+        // known suffix, so it comes off without taking the dotted name with it.
+        assert_eq!(
+            entry_reference_path(&source, &loose("objects/gear/crate_1.5.collision_model"))
+                .as_deref(),
+            Some("objects\\gear\\crate_1.5")
+        );
+        // A monolithic cache stores the reference name itself — no derivation.
+        let cached = TagEntry {
+            key: "cache:coll:x".to_owned(),
+            display_path: "objects/gear/crate_1.collision_model".to_owned(),
+            group_tag: u32::from_be_bytes(*b"coll"),
+            group_name: Some("collision_model".to_owned()),
+            location: TagEntryLocation::Monolithic {
+                name: "objects\\gear\\crate_1.5".to_owned(),
+                group_tag: u32::from_be_bytes(*b"coll"),
+            },
+        };
+        assert_eq!(
+            entry_reference_path(&source, &cached).as_deref(),
+            Some("objects\\gear\\crate_1.5")
+        );
+    }
+
+    /// A `collision_model` / `physics_model` extracted on its own used to come
+    /// out collapsed — every bone at the origin and every hull and shape stacked
+    /// there with it — because nothing supplied the rest pose those tags do not
+    /// store. Guards that the owning `.model` is now found from the tag's own
+    /// path and its skeleton composed in.
+    ///
+    /// Ignored by default — it needs a loose Halo 3 tag tree.
+    ///
+    /// Run with:
+    ///   H3_TAGS=~/Halo/halo3_mcc/tags \
+    ///     cargo test standalone_collision -- --ignored --nocapture
+    #[test]
+    #[ignore = "requires a loose Halo 3 tag tree; set H3_TAGS"]
+    fn standalone_collision_and_physics_export_is_posed_by_the_owning_model() {
+        let Ok(root) = std::env::var("H3_TAGS") else {
+            eprintln!("skipping: set H3_TAGS to a loose Halo 3 tags directory");
+            return;
+        };
+        let root = PathBuf::from(root);
+        let source = TagSource::LooseFolder {
+            root: root.clone(),
+            game: Some("halo3_mcc".to_owned()),
+            definitions_root: crate::app::locate_definitions_root(),
+        };
+        // A rigged character: its collision hulls and physics shapes are stored
+        // per-bone, so an unposed export piles all of them on the origin.
+        let stem = "objects/characters/flood_tank/flood_tank";
+        let cases = [
+            ("collision_model", *b"coll"),
+            ("physics_model", *b"phmo"),
+        ];
+        for (extension, group_tag) in cases {
+            let path = root.join(format!("{stem}.{extension}"));
+            assert!(path.is_file(), "{} is not in this tag tree", path.display());
+            let entry = TagEntry {
+                key: format!("file:{}", path.display()),
+                display_path: format!("{stem}.{extension}"),
+                group_tag: u32::from_be_bytes(group_tag),
+                group_name: Some(extension.to_owned()),
+                location: TagEntryLocation::LooseFile(path),
+            };
+
+            let skeleton = owning_model_skeleton(&source, &entry)
+                .unwrap_or_else(|| panic!("{extension}: no owning model resolved"));
+            let posed = skeleton
+                .nodes()
+                .iter()
+                .filter(|node| {
+                    node.translation.x != 0.0
+                        || node.translation.y != 0.0
+                        || node.translation.z != 0.0
+                })
+                .count();
+            assert!(
+                posed > 1,
+                "{extension}: the owning model's skeleton is itself unposed \
+                 ({posed}/{} bones off the origin)",
+                skeleton.nodes().len()
+            );
+
+            let tag = read_entry(&source, &entry).expect("read tag");
+            let unposed = match extension {
+                "collision_model" => collision_jms_for_game(&tag, None),
+                _ => physics_jms_for_game(&tag, None),
+            }
+            .expect("build unposed jms");
+            let jms = match extension {
+                "collision_model" => collision_jms_for_game(&tag, Some(skeleton.nodes())),
+                _ => physics_jms_for_game(&tag, Some(skeleton.nodes())),
+            }
+            .expect("build posed jms");
+
+            // The armature the file emits, not just the skeleton handed in.
+            let off_origin = jms
+                .nodes
+                .iter()
+                .filter(|node| {
+                    node.translation.x != 0.0
+                        || node.translation.y != 0.0
+                        || node.translation.z != 0.0
+                })
+                .count();
+            assert!(
+                off_origin > 1,
+                "{extension}: {off_origin}/{} emitted bones are off the origin — \
+                 the skeleton was not overlaid",
+                jms.nodes.len()
+            );
+            assert_eq!(
+                unposed
+                    .nodes
+                    .iter()
+                    .filter(|node| node.translation.x != 0.0)
+                    .count(),
+                0,
+                "{extension}: the no-skeleton control is supposed to be collapsed; \
+                 if it is not, this test proves nothing"
+            );
+            // The armature also has to be a hierarchy, not a flat pile of roots
+            // — a collision node spells its parent link `parent node`.
+            assert!(
+                jms.nodes.iter().filter(|node| node.parent >= 0).count() > 1,
+                "{extension}: the emitted armature has no bone hierarchy"
+            );
+
+            // Collision vertices are absolute, so composing the skeleton in has
+            // to move them; physics shapes stay node-local and are placed by the
+            // bone at import time, so only the armature changes there.
+            if extension == "collision_model" {
+                assert_ne!(
+                    unposed.vertices.len(),
+                    0,
+                    "collision_model exported no geometry"
+                );
+                let moved = jms
+                    .vertices
+                    .iter()
+                    .zip(unposed.vertices.iter())
+                    .filter(|(a, b)| a.position.x != b.position.x || a.position.z != b.position.z)
+                    .count();
+                assert!(
+                    moved > jms.vertices.len() / 2,
+                    "only {moved}/{} collision vertices moved when the skeleton was applied",
+                    jms.vertices.len()
+                );
+            }
+
+            // And the same through the entry point the browser's Extract
+            // Geometry menu actually calls.
+            let out = std::env::temp_dir().join("baboon_standalone_geometry_test");
+            let _ = std::fs::remove_dir_all(&out);
+            let message =
+                extract_geometry_for_entry(&source, &entry, &out).expect("extract geometry");
+            println!("{message}");
+            assert!(
+                !message.contains("no owning model"),
+                "{extension}: the export path did not resolve a skeleton — {message}"
+            );
+        }
+    }
 
     /// End-to-end against a real Campaign Evolved install: mount the pak set,
     /// find a structure BSP and the scenario that references it, and run both

--- a/src/app/material.rs
+++ b/src/app/material.rs
@@ -41,7 +41,7 @@ pub(super) fn draw_material_tag(
                         )
                     });
                 if let Some(model) = model {
-                    draw_shader_editor_model(ui, &model, color_popup, function_popup, edit);
+                    draw_shader_editor_model(ui, &model, color_popup, function_popup, edit, expert_mode);
                     return;
                 }
                 // Shader grid couldn't be built (rmdf/rmop chain didn't

--- a/src/app/prefs.rs
+++ b/src/app/prefs.rs
@@ -737,6 +737,13 @@ fn parse_session_kit(value: &Value) -> Option<LastSessionKit> {
         .get("has_project")
         .and_then(Value::as_bool)
         .unwrap_or(project_path.is_some());
+    // Absent in every session written before the focused workspace was
+    // recorded, which reads back as "no kit was active" and leaves the restore
+    // picking whichever kit it used to.
+    let was_active = value
+        .get("active")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
     // Absent in sessions written before the browser view became per-kit, and
     // in every version-1 and version-2 file. `None` means "use the default".
     let browser_mode = browser_mode_from_str(value.get("browser_mode").and_then(Value::as_str));
@@ -807,12 +814,15 @@ fn parse_session_kit(value: &Value) -> Option<LastSessionKit> {
         tags,
         chimp_packages,
         active_chimp_package,
+        was_active,
     })
 }
 
 /// Persist every kit's source and open tag keys for the launch-time restore
-/// prompt. Written only from the confirmed app-exit path, so a crash or a
-/// canceled close leaves the previous successfully closed session intact.
+/// prompt, along with which of them was focused. Written from the confirmed
+/// app-exit path and again as the event loop tears down, so a quit that never
+/// asks the window to close — macOS Cmd+Q — still records the session; a crash
+/// leaves the previous one intact.
 pub(super) fn save_last_session(session: &LastSessionState) -> Result<(), String> {
     let path = last_session_path();
     if let Some(parent) = path.parent() {
@@ -857,6 +867,13 @@ fn session_value(session: &LastSessionState) -> Value {
                 "tags": tags,
                 "chimp_packages": kit.chimp_packages,
                 "active_chimp_package": kit.active_chimp_package,
+                // Which workspace the user was looking at. Written as a flag on
+                // the kit rather than an index beside the list: the restore
+                // prompt can drop kits, and an index would then point at
+                // whichever one moved into that slot. Absent in sessions
+                // written before this, which read back as "no kit was active"
+                // and leave the restore picking as it used to.
+                "active": kit.was_active,
             })
         })
         .collect::<Vec<_>>();
@@ -1267,6 +1284,7 @@ mod session_tests {
             }],
             chimp_packages: Vec::new(),
             active_chimp_package: None,
+            was_active: false,
         }
     }
 
@@ -1285,6 +1303,7 @@ mod session_tests {
                 tags: Vec::new(),
                 chimp_packages: vec!["/Game/Vehicles/Warthog".to_owned()],
                 active_chimp_package: Some("/Game/Vehicles/Warthog".to_owned()),
+                was_active: true,
             }],
         };
         let value = session_value(&session);
@@ -1296,6 +1315,53 @@ mod session_tests {
             restored.kits[0].active_chimp_package.as_deref(),
             Some("/Game/Vehicles/Warthog")
         );
+    }
+
+    /// Which workspace the user was looking at survives the round trip, and is
+    /// carried on the kit rather than as an index beside the list — the restore
+    /// prompt can drop kits, and an index would then name whichever one moved
+    /// into that slot.
+    #[test]
+    fn the_focused_kit_is_remembered_and_travels_with_its_own_kit() {
+        let mut halo3 = kit("C:/halo3", Some(BrowserMode::Folders));
+        let mut evolved = kit("C:/evolved", Some(BrowserMode::Groups));
+        evolved.source_kind = LastSessionSourceKind::IoStoreContainerSet;
+        halo3.was_active = true;
+        evolved.was_active = false;
+        let session = LastSessionState {
+            kits: vec![evolved, halo3],
+        };
+
+        let value = session_value(&session);
+        let restored = parse_last_session(&value).expect("session parses");
+        assert_eq!(restored.kits.len(), 2);
+        assert!(!restored.kits[0].was_active, "the container kit was not focused");
+        assert!(restored.kits[1].was_active, "the Halo 3 kit was focused");
+        // It is the kit that is marked, not a position: the flag follows its
+        // own workspace when the list is filtered.
+        let kept = restored
+            .kits
+            .into_iter()
+            .filter(|kit| kit.source_kind == LastSessionSourceKind::LooseFolder)
+            .collect::<Vec<_>>();
+        assert_eq!(kept.len(), 1);
+        assert!(kept[0].was_active);
+    }
+
+    /// A session written before the focused workspace was recorded has no
+    /// `active` on any kit, and must still load rather than being rejected.
+    #[test]
+    fn a_session_without_a_focused_kit_still_loads() {
+        let value = serde_json::json!({
+            "version": 4,
+            "kits": [{
+                "source": { "kind": "loose_folder", "path": "C:/halo3" },
+                "tags": [],
+            }],
+        });
+        let restored = parse_last_session(&value).expect("session parses");
+        assert_eq!(restored.kits.len(), 1);
+        assert!(!restored.kits[0].was_active);
     }
 
     /// Each workspace keeps its own browser view, so a session holding a kit

--- a/src/app/shader.rs
+++ b/src/app/shader.rs
@@ -115,6 +115,15 @@ pub(super) enum ShaderRowEditKind {
         create: Option<ShaderParamCreateTarget>,
     },
     ShaderTemplateRef,
+    /// A structural tag reference — a shader's `definition`
+    /// (render_method_definition) or `shader template`
+    /// (render_method_template). Foundation exposes both for editing under
+    /// expert mode and reconciles nothing afterwards, so this commits as a
+    /// plain reference write and leaves the existing parameters alone.
+    StructuralRef {
+        group_tag: u32,
+        extension: &'static str,
+    },
     /// Boolean checkbox backed by an existing field or a new shader parameter.
     Bool {
         create: Option<ShaderParamCreateTarget>,
@@ -227,7 +236,15 @@ pub(super) struct ShaderEditorModel {
     /// string-id. Empty when the field could not be located.
     global_material_edit_path: String,
     definition_path: String,
+    /// Absolute tag field paths for the two structural references. Foundation
+    /// exposes both for editing under expert mode — its expert gate is a
+    /// blanket field-panel switch, and it carries no shader-aware code that
+    /// could reconcile parameters afterwards, so re-pointing one leaves the
+    /// existing parameters describing the old definition. Empty when the field
+    /// could not be located.
+    definition_edit_path: String,
     shader_template_path: Option<String>,
+    shader_template_edit_path: String,
     categories: Vec<ShaderEditorCategory>,
     sections: Vec<ShaderEditorSection>,
     atmosphere_flags: ShaderFlagsRow,
@@ -331,6 +348,27 @@ pub(super) fn build_shader_editor_model(
 
     let global_material_type = read_global_material_type(tag);
     let global_material_edit_path = append_field_path(&edit_prefix, "global material type");
+    // Empty when the field is not there, so the row stays read-only rather than
+    // offering an edit that would fail to commit. `render_method_existing_field_path`
+    // falls back to its first candidate whether or not it exists, which is the
+    // wrong shape here.
+    let resolve_edit_path = |candidates: &[String]| -> String {
+        candidates
+            .iter()
+            .find(|path| tag.root().field_path(path).is_some())
+            .cloned()
+            .unwrap_or_default()
+    };
+    let definition_edit_path = resolve_edit_path(&[
+        append_field_path(&edit_prefix, "definition"),
+        append_field_path(&edit_prefix, "definition*"),
+    ]);
+    // The template reference hangs off the postprocess block, not the
+    // render_method root — `RenderMethod` reads it from `postprocess[0]`.
+    let shader_template_edit_path = resolve_edit_path(&[
+        append_field_path(&edit_prefix, "postprocess[0]/shader template"),
+        append_field_path(&edit_prefix, "shader template"),
+    ]);
     let shader_flags_path =
         render_method_existing_field_path(tag, &edit_prefix, &["shader flags", "shader flags*"]);
     let custom_fog_path =
@@ -381,6 +419,8 @@ pub(super) fn build_shader_editor_model(
         global_material_type,
         global_material_edit_path,
         definition_path: render_method.definition_path,
+        definition_edit_path,
+        shader_template_edit_path,
         shader_template_path: render_method
             .postprocess_definition
             .as_ref()

--- a/src/app/shader/editing.rs
+++ b/src/app/shader/editing.rs
@@ -1465,6 +1465,147 @@ pub(in crate::app) fn draw_shader_editable_value(
             edit.buffers.put(buffer_key, draft);
         }
 
+        // A shader's structural references: `definition` and `shader template`.
+        // Text box + Open + browse, committed straight through the generic
+        // field-edit path. Nothing is reconciled afterwards, which matches
+        // Foundation — it carries no shader-aware code to reconcile with, and
+        // its expert mode is a blanket field-panel switch.
+        ShaderRowEditKind::StructuralRef { group_tag, extension } => {
+            let (group_tag, extension) = (*group_tag, *extension);
+            let current = row_edit.current.clone();
+            let browse_rect = egui::Rect::from_min_size(
+                rect.right_top() - Vec2::new(26.0, 0.0),
+                Vec2::new(24.0, rect.height()),
+            );
+            let open_rect = egui::Rect::from_min_size(
+                rect.right_top() - Vec2::new(70.0, 0.0),
+                Vec2::new(40.0, rect.height()),
+            );
+            let text_rect = egui::Rect::from_min_size(
+                rect.left_top(),
+                Vec2::new((rect.width() - 72.0).max(40.0), rect.height()),
+            );
+            let cleaned = sanitize_ref_path(&current);
+            let open_ref = cleaned
+                .strip_suffix(&format!(".{extension}"))
+                .unwrap_or(&cleaned)
+                .replace('/', "\\");
+            let open_enabled = !open_ref.is_empty() && open_ref != "NONE";
+            ui.painter().rect_filled(
+                open_rect,
+                0.0,
+                if open_enabled { material_input() } else { material_disabled_input() },
+            );
+            ui.painter()
+                .rect_stroke(open_rect, 0.0, Stroke::new(1.0, material_input_edge()));
+            let icon_rect = egui::Rect::from_center_size(open_rect.center(), Vec2::splat(16.0));
+            paint_button_icon_at(
+                ui,
+                ButtonIcon::Open,
+                icon_rect,
+                if open_enabled { material_text() } else { material_muted_text() },
+            );
+            if open_enabled
+                && ui
+                    .interact(
+                        open_rect,
+                        ui.make_persistent_id(format!("structural_ref_open:{buffer_key}")),
+                        Sense::click(),
+                    )
+                    .on_hover_text(format!("Open the referenced {extension} tag"))
+                    .clicked()
+            {
+                *edit.open_request = Some(OpenTagRequest {
+                    group_tag,
+                    rel_path: open_ref.clone(),
+                    float: ui.input(|i| i.modifiers.alt),
+                });
+            }
+
+            let id = edit.widget_id(("structural_ref_text", &buffer_key));
+            let mut draft = edit.buffers.take(&buffer_key, &current);
+            let mut commit = None;
+            let text_response = ui
+                .scope_builder(egui::UiBuilder::new().max_rect(text_rect), |ui| {
+                    ui.visuals_mut().extreme_bg_color = material_input();
+                    let resp = ui.add(
+                        egui::TextEdit::singleline(&mut draft.text)
+                            .id(id)
+                            .desired_width(text_rect.width())
+                            .text_color(material_text())
+                            .font(egui::TextStyle::Monospace),
+                    );
+                    text_edit_cursor_to_start_on_tab_focus(ui, &resp);
+                    draft.note_response(&resp);
+                    if draft.should_commit(ui, &resp) {
+                        commit = Some(draft.text.trim().to_owned());
+                    }
+                    resp
+                })
+                .inner;
+            let accepts = |payload: &DraggedTagRef| payload.group_tag == group_tag;
+            if let Some(payload) = text_response.dnd_hover_payload::<DraggedTagRef>() {
+                let color = if accepts(&payload) {
+                    Color32::from_rgb(120, 170, 90)
+                } else {
+                    REFERENCE_MISSING_COLOR
+                };
+                ui.painter()
+                    .rect_stroke(text_response.rect, 2.0, Stroke::new(1.5, color));
+            }
+            if edit.editable
+                && let Some(payload) = text_response.dnd_release_payload::<DraggedTagRef>()
+                && accepts(&payload)
+            {
+                commit = Some(payload.rel_path.clone());
+            }
+
+            ui.painter().rect_filled(browse_rect, 0.0, material_input());
+            ui.painter()
+                .rect_stroke(browse_rect, 0.0, Stroke::new(1.0, material_input_edge()));
+            ui.painter().text(
+                browse_rect.center(),
+                Align2::CENTER_CENTER,
+                "...",
+                FontId::proportional(11.0),
+                material_text(),
+            );
+            if ui
+                .interact(
+                    browse_rect,
+                    ui.make_persistent_id(format!("structural_ref_browse:{buffer_key}")),
+                    Sense::click(),
+                )
+                .on_hover_text(format!("Browse for a .{extension} tag file"))
+                .clicked()
+            {
+                let mut dialog = rfd::FileDialog::new()
+                    .add_filter(extension, &[extension])
+                    .set_title(format!("Select {extension} Tag"));
+                if let Some(tags_root) = edit.tags_root {
+                    dialog = dialog.set_directory(tag_reference_start_dir(tags_root, &open_ref));
+                }
+                if let Some(path) = dialog.pick_file() {
+                    match normalize_bitmap_browse_path(&path, edit.tags_root) {
+                        Ok(rel) => {
+                            draft.set_clean(rel.clone());
+                            commit = Some(rel);
+                        }
+                        Err(error) => {
+                            if let Some(status) = edit.status.as_deref_mut() {
+                                *status = error;
+                            }
+                        }
+                    }
+                }
+            }
+            if let Some(input) = commit {
+                edit.pending
+                    .push(PendingFieldEdit { path: row_edit.path.clone(), input });
+            }
+            edit.buffers.put(buffer_key, draft);
+        }
+
         ShaderRowEditKind::Bool { create } => {
             let current_raw = row_edit.current.trim().parse::<i32>().unwrap_or(0);
             let mut checked = current_raw != 0;

--- a/src/app/shader/h2.rs
+++ b/src/app/shader/h2.rs
@@ -41,6 +41,10 @@ pub(in crate::app) fn build_h2ek_shader_editor_model(
         global_material_type: String::new(),
         global_material_edit_path: String::new(),
         definition_path: String::new(),
+        // Halo 2 shows its template through its own row, which already carries
+        // an edit; these two belong to the Halo 3-era render_method grid.
+        definition_edit_path: String::new(),
+        shader_template_edit_path: String::new(),
         shader_template_path: None,
         categories: Vec::new(),
         sections,
@@ -2131,6 +2135,7 @@ fn shader_row_edit_kind_name(kind: &ShaderRowEditKind) -> &'static str {
         ShaderRowEditKind::StringId => "string_id",
         ShaderRowEditKind::BitmapRef { .. } => "bitmap_ref",
         ShaderRowEditKind::ShaderTemplateRef => "shader_template_ref",
+        ShaderRowEditKind::StructuralRef { .. } => "structural_ref",
         ShaderRowEditKind::Bool { .. } => "bool",
         ShaderRowEditKind::Enum(_) => "enum",
         ShaderRowEditKind::Flags(_) => "flags",

--- a/src/app/shader/tests.rs
+++ b/src/app/shader/tests.rs
@@ -190,3 +190,117 @@ mod slashed_field_names {
         }
     }
 }
+
+/// The two structural references — `definition` and `shader template` — were
+/// drawn as painted text with editing switched off, so a shader's render
+/// method definition could be read but never changed, unlike Foundation's
+/// expert mode. Guards the part that is easy to get wrong: the tag field paths
+/// the editor commits through. `definition` sits on the render_method block,
+/// but the template reference hangs off `postprocess[0]`, not the root.
+///
+/// Ignored by default — it needs a loose Halo 3 tag tree.
+///
+/// Run with:
+///   H3_TAGS=~/Halo/halo3_mcc/tags \
+///     cargo test structural_shader_references -- --ignored --nocapture
+#[test]
+#[ignore = "requires a loose Halo 3 tag tree; set H3_TAGS"]
+fn structural_shader_references_resolve_to_editable_reference_fields() {
+    let Ok(root) = std::env::var("H3_TAGS") else {
+        eprintln!("skipping: set H3_TAGS to a loose Halo 3 tags directory");
+        return;
+    };
+    let root = std::path::PathBuf::from(root);
+    let source = crate::source::TagSource::LooseFolder {
+        root: root.clone(),
+        game: Some("halo3_mcc".to_owned()),
+        definitions_root: crate::app::locate_definitions_root(),
+    };
+
+    // Any shader that resolves its render-method chain will do; walk until one
+    // builds a grid, so this does not hinge on one hand-picked tag.
+    let mut rmdf_cache = std::collections::HashMap::new();
+    let mut rmop_cache = std::collections::HashMap::new();
+    let mut checked = 0usize;
+    for entry in walkdir_shaders(&root).into_iter().take(400) {
+        let Ok(tag) = blam_tags::TagFile::read(&entry) else { continue };
+        let Some(model) = super::build_shader_editor_model(
+            &tag,
+            u32::from_be_bytes(*b"rmsh"),
+            Some(&source),
+            &mut rmdf_cache,
+            &mut rmop_cache,
+        ) else {
+            continue;
+        };
+
+        assert!(
+            !model.definition_edit_path.is_empty(),
+            "{}: no edit path for `definition`",
+            entry.display()
+        );
+        let field = tag
+            .root()
+            .field_path(&model.definition_edit_path)
+            .unwrap_or_else(|| panic!("{}: definition path does not resolve", entry.display()));
+        let Some(blam_tags::TagFieldData::TagReference(reference)) = field.value() else {
+            panic!("{}: `definition` is not a tag reference", entry.display());
+        };
+        assert_eq!(
+            reference.group_tag_and_name.map(|(_, name)| name),
+            Some(model.definition_path.clone()),
+            "{}: the edit path addresses a different reference than the row shows",
+            entry.display()
+        );
+
+        // The template only exists once a postprocess block does.
+        if let Some(template) = model.shader_template_path.as_deref() {
+            assert!(
+                !model.shader_template_edit_path.is_empty(),
+                "{}: no edit path for `shader template`",
+                entry.display()
+            );
+            let field = tag
+                .root()
+                .field_path(&model.shader_template_edit_path)
+                .unwrap_or_else(|| {
+                    panic!("{}: shader template path does not resolve", entry.display())
+                });
+            let Some(blam_tags::TagFieldData::TagReference(reference)) = field.value() else {
+                panic!("{}: `shader template` is not a tag reference", entry.display());
+            };
+            assert_eq!(
+                reference.group_tag_and_name.map(|(_, name)| name),
+                Some(template.to_owned()),
+                "{}: template edit path addresses a different reference",
+                entry.display()
+            );
+        }
+        checked += 1;
+        if checked >= 5 {
+            break;
+        }
+    }
+    assert!(checked > 0, "no shader in this tag tree built a grid to check");
+    println!("checked {checked} shader(s)");
+}
+
+fn walkdir_shaders(root: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let mut out = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(rd) = std::fs::read_dir(&dir) else { continue };
+        for entry in rd.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.extension().is_some_and(|e| e == "shader") {
+                out.push(path);
+                if out.len() > 400 {
+                    return out;
+                }
+            }
+        }
+    }
+    out
+}

--- a/src/app/shader/tests.rs
+++ b/src/app/shader/tests.rs
@@ -304,3 +304,115 @@ fn walkdir_shaders(root: &std::path::Path) -> Vec<std::path::PathBuf> {
     }
     out
 }
+
+/// The row being drawn is only half of "editable" — the commit has to land.
+/// This drives the same path the widget pushes (`apply_pending_edits` at the
+/// resolved edit path) and checks the reference actually changes on the tag.
+///
+/// Ignored by default — it needs a loose Halo 3 tag tree.
+///
+/// Run with:
+///   H3_TAGS=~/Halo/halo3_mcc/tags \
+///     cargo test committing_a_structural_reference -- --ignored --nocapture
+#[test]
+#[ignore = "requires a loose Halo 3 tag tree; set H3_TAGS"]
+fn committing_a_structural_reference_rewrites_the_tag() {
+    let Ok(root) = std::env::var("H3_TAGS") else {
+        eprintln!("skipping: set H3_TAGS to a loose Halo 3 tags directory");
+        return;
+    };
+    let root = std::path::PathBuf::from(root);
+    let source = crate::source::TagSource::LooseFolder {
+        root: root.clone(),
+        game: Some("halo3_mcc".to_owned()),
+        definitions_root: crate::app::locate_definitions_root(),
+    };
+    let mut rmdf_cache = std::collections::HashMap::new();
+    let mut rmop_cache = std::collections::HashMap::new();
+
+    for entry in walkdir_shaders(&root).into_iter().take(400) {
+        let Ok(mut tag) = blam_tags::TagFile::read(&entry) else { continue };
+        let Some(model) = super::build_shader_editor_model(
+            &tag,
+            u32::from_be_bytes(*b"rmsh"),
+            Some(&source),
+            &mut rmdf_cache,
+            &mut rmop_cache,
+        ) else {
+            continue;
+        };
+        if model.definition_edit_path.is_empty() {
+            continue;
+        }
+
+        let before = model.definition_path.clone();
+        let after = "shaders\\custom_definition";
+        assert_ne!(before, after, "pick a value that is actually a change");
+
+        let mut dirty = crate::app::Dirty::default();
+        let applied = crate::app::apply_pending_edits(
+            &mut tag,
+            vec![crate::app::PendingFieldEdit {
+                path: model.definition_edit_path.clone(),
+                input: format!("{after}.render_method_definition"),
+            }],
+            &mut dirty,
+        );
+        assert!(
+            applied.outcomes.iter().all(|outcome| outcome.result.is_ok()),
+            "{}: commit failed: {:?}",
+            entry.display(),
+            applied.status
+        );
+        assert!(dirty.is_set(), "a committed edit marks the document dirty");
+
+        let field = tag
+            .root()
+            .field_path(&model.definition_edit_path)
+            .expect("definition still resolves");
+        let Some(blam_tags::TagFieldData::TagReference(reference)) = field.value() else {
+            panic!("definition stopped being a tag reference");
+        };
+        assert_eq!(
+            reference.group_tag_and_name.map(|(_, name)| name).as_deref(),
+            Some(after),
+            "{}: the reference did not take the committed value",
+            entry.display()
+        );
+        println!("{}: {before:?} -> {after:?}", entry.display());
+        return;
+    }
+    panic!("no shader in this tag tree built a grid to commit against");
+}
+
+/// The extension a tag reference is typed with has to resolve to a group tag,
+/// and that used to come from a hand-written table in the value parser — which
+/// had no `render_method_definition`, so committing a shader's definition was
+/// refused as an unknown group and the row changed nothing. The mapping now
+/// comes from the games' own `_meta.json`, so anything Baboon can open is
+/// something it can parse a reference to.
+#[test]
+fn reference_extensions_resolve_from_the_games_own_metadata() {
+    let names = crate::format::TagNameIndex::load_from_definitions(
+        &crate::app::locate_definitions_root(),
+    );
+    names.publish_as_process_group_names();
+    for (extension, fourcc) in [
+        ("render_method_definition", b"rmdf"),
+        ("render_method_template", b"rmt2"),
+        ("shader_template", b"stem"),
+    ] {
+        assert_eq!(
+            crate::format::process_group_tag_for(extension),
+            Some(u32::from_be_bytes(*fourcc)),
+            "{extension} is not in any game's tag_index"
+        );
+        // And the parser that the field editor commits through agrees.
+        let parsed = crate::app::parse_tag_reference(&format!("shaders\\example.{extension}"))
+        .unwrap_or_else(|error| panic!("{extension}: {error}"));
+        assert_eq!(
+            parsed.group_tag_and_name,
+            Some((u32::from_be_bytes(*fourcc), "shaders\\example".to_owned()))
+        );
+    }
+}

--- a/src/app/shader/widgets.rs
+++ b/src/app/shader/widgets.rs
@@ -9,6 +9,7 @@ pub(in crate::app) fn draw_shader_editor_model(
     color_popup: &mut Option<MaterialColorPopup>,
     function_popup: &mut Option<FunctionPopup>,
     edit: &mut FieldEditContext<'_>,
+    expert_mode: bool,
 ) {
     // MATERIAL section only for material-bearing shader types (Guerilla
     // vtable+0x70 gate). Effect-style shaders have no global material type.
@@ -60,7 +61,13 @@ pub(in crate::app) fn draw_shader_editor_model(
             parameter_type: Some("tag reference".to_owned()),
             is_overridden: true,
             function: None,
-            edit: None,
+            edit: structural_reference_edit(
+                expert_mode,
+                &model.definition_edit_path,
+                &model.definition_path,
+                *b"rmdf",
+                "render_method_definition",
+            ),
             context_menu: None,
             create_anim_op: None,
             constant_function_view: None,
@@ -81,7 +88,13 @@ pub(in crate::app) fn draw_shader_editor_model(
             parameter_type: Some("tag reference".to_owned()),
             is_overridden: true,
             function: None,
-            edit: None,
+            edit: structural_reference_edit(
+                expert_mode,
+                &model.shader_template_edit_path,
+                template_path,
+                *b"rmt2",
+                "render_method_template",
+            ),
             context_menu: None,
             create_anim_op: None,
             constant_function_view: None,
@@ -337,6 +350,40 @@ pub(in crate::app) fn collect_shader_template_references(
             }
         }
     }
+}
+
+/// The editor for a shader's `definition` / `shader template` reference, or
+/// `None` when the field is not on this tag — in which case the row stays the
+/// read-only text it has always been rather than offering an edit that could
+/// not commit. Whether the user may actually type into it is the field
+/// editor's own `editable` gate, which is what expert mode drives.
+fn structural_reference_edit(
+    expert_mode: bool,
+    edit_path: &str,
+    current_path: &str,
+    group_tag: [u8; 4],
+    extension: &'static str,
+) -> Option<ShaderRowEdit> {
+    // Re-pointing either reference changes which parameters the tag is
+    // supposed to carry, and nothing reconciles the ones already on it —
+    // Foundation gates the same edit behind expert mode and reconciles nothing
+    // either. Outside expert mode the row stays the text it has always been.
+    if !expert_mode || edit_path.is_empty() {
+        return None;
+    }
+    let current = if current_path.is_empty() {
+        "NONE".to_owned()
+    } else {
+        format!("{}.{extension}", current_path.replace('\\', "/"))
+    };
+    Some(ShaderRowEdit {
+        path: edit_path.to_owned(),
+        current,
+        kind: ShaderRowEditKind::StructuralRef {
+            group_tag: u32::from_be_bytes(group_tag),
+            extension,
+        },
+    })
 }
 
 pub(in crate::app) fn shader_template_label(key: &str) -> String {

--- a/src/app/state/documents.rs
+++ b/src/app/state/documents.rs
@@ -199,6 +199,11 @@ pub(in crate::app) struct LastSessionKit {
     pub(in crate::app) tags: Vec<LastSessionTag>,
     pub(in crate::app) chimp_packages: Vec<String>,
     pub(in crate::app) active_chimp_package: Option<String>,
+    /// Whether this was the kit the user was looking at. Carried per kit rather
+    /// than as an index into the list so that dropping a kit — which the
+    /// restore prompt lets the user do — cannot silently re-point it at
+    /// whichever workspace slid into that slot.
+    pub(in crate::app) was_active: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -219,6 +224,8 @@ pub(in crate::app) struct RestoreKit {
     pub(in crate::app) tags: Vec<LastSessionTag>,
     pub(in crate::app) chimp_packages: Vec<String>,
     pub(in crate::app) active_chimp_package: Option<String>,
+    /// Whether this kit was the focused one when the session was saved.
+    pub(in crate::app) was_active: bool,
 }
 
 pub(in crate::app) struct LastOpenedWindowEntry {
@@ -249,6 +256,8 @@ pub(in crate::app) struct LastOpenedWindowsKit {
     pub(in crate::app) entries: Vec<LastOpenedWindowEntry>,
     pub(in crate::app) chimp_entries: Vec<LastOpenedChimpEntry>,
     pub(in crate::app) active_chimp_package: Option<String>,
+    /// Whether this kit was the focused one when the session was saved.
+    pub(in crate::app) was_active: bool,
 }
 
 /// Launch-time restore prompt backed by `last_session.json`. OK reloads each
@@ -317,6 +326,7 @@ impl LastOpenedWindowsKit {
             entries,
             chimp_entries,
             active_chimp_package: saved.active_chimp_package,
+            was_active: saved.was_active,
         })
     }
 
@@ -377,6 +387,7 @@ impl LastOpenedWindowsPrompt {
                     tags,
                     chimp_packages,
                     active_chimp_package,
+                    was_active: kit.was_active,
                 }
             })
             .collect()

--- a/src/app/ui.rs
+++ b/src/app/ui.rs
@@ -620,5 +620,6 @@ impl eframe::App for Baboon {
 
     fn on_exit(&mut self, _gl: Option<&eframe::glow::Context>) {
         self.window_state.persist_now();
+        self.persist_session_on_exit();
     }
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -8,6 +8,20 @@ use anyhow::{Context, Result};
 use blam_tags::{StringIdData, TagFieldData, TagReferenceData, format_group_tag, parse_group_tag};
 use serde_json::Value;
 
+/// Extension -> group tag, accumulated from every `_meta.json` the app loads.
+/// Consulted by the field editor, which has no game in hand at the point it
+/// parses a reference.
+fn process_group_names() -> &'static std::sync::RwLock<BTreeMap<String, u32>> {
+    static NAMES: std::sync::OnceLock<std::sync::RwLock<BTreeMap<String, u32>>> =
+        std::sync::OnceLock::new();
+    NAMES.get_or_init(|| std::sync::RwLock::new(BTreeMap::new()))
+}
+
+/// The group tag for a definition name, from the loaded games' `_meta.json`.
+pub fn process_group_tag_for(name: &str) -> Option<u32> {
+    process_group_names().read().ok()?.get(name).copied()
+}
+
 #[derive(Clone, Debug, Default)]
 /// Bidirectional group-tag/name lookup assembled from definition metadata.
 /// Merging keeps the first observed mapping so the default cross-game index is
@@ -82,6 +96,26 @@ impl TagNameIndex {
 
     pub fn group_tag_for(&self, name: &str) -> Option<u32> {
         self.group_tag_for_name.get(name).copied()
+    }
+
+    /// Publish this index as the process-wide extension -> group lookup.
+    ///
+    /// Parsing a typed tag reference (`<path>.<extension>`) has to turn the
+    /// extension back into a group tag, and it happens deep inside the field
+    /// editor, far from any loaded game. The alternative was a hand-written
+    /// table in the value parser, which is exactly the shape that silently
+    /// omits entries: it had no `render_method_definition`, so committing an
+    /// edit to a shader's definition was refused as an unknown group and the
+    /// row accepted input while changing nothing. Every mapping here comes
+    /// from the games' own `_meta.json`, so a group Baboon can open is a group
+    /// it can parse a reference to.
+    pub fn publish_as_process_group_names(&self) {
+        let Ok(mut registry) = process_group_names().write() else {
+            return;
+        };
+        for (name, group_tag) in &self.group_tag_for_name {
+            registry.entry(name.clone()).or_insert(*group_tag);
+        }
     }
 
     /// Adds only unknown mappings, preserving the receiver's precedence.


### PR DESCRIPTION
Two reports from Discord, both the same shape: a tag that stores no bone
transforms of its own, extracted straight from the browser, with nothing to
compose against.

## Collision and physics collapse to 0,0,0

> Collision and Physics meshes get collapsed 0 0 0 including bones as well.
> A Elephant: Physics mesh loads properly but its treads, ramp which are rigged
> have their position and bones set to 0 0 0. B Cov_Barrier: Static props are
> unaffected as they have no bones. C Flood Tank: Entire collision model and
> bones get collapsed to 0 0 0.

A `collision_model` and a `physics_model` keep their geometry bone-local and
store no bone transforms — those live in the `render_model` (or, on Campaign
Evolved, the `skeleton model`) that the owning `.model` names. #31 gave the
`.model` arm a skeleton, but the browser also offers Extract Geometry on `coll`
and `phmo` tags directly, and that arm passed nothing. Reproduced exactly on
`flood_tank`: 0 of 37 bones posed and the hulls in an 86-unit pile on the
origin. All three reported cases fall out of it — a static prop has one bone
already at the origin, so nothing moves.

A standalone tag names no owner, so it is found by the tag's own path:
`flood_tank.collision_model` belongs to `flood_tank.model`. Across the 2,486
collision and physics tags Halo 3 ships, that names a render_model one of the
tag's real owners uses in 2,479 cases; the other 7 have no `.model` beside them
and fall through to the render_model at the same path, then to nothing — in
which case the export is exactly what it was before rather than posed somewhere
wrong. The reference comes from where the tag lives rather than from its display
path, since building that path replaces everything after the last dot with the
group's friendly extension and would truncate a name like `crate_1.5`.

Both arms now also pick their reader by engine, which the equivalent shell
commands always did and these never had. Halo 1 keeps collision in
`model_collision_geometry`, whose BSPs hang off the nodes with no
region/permutation nesting, so the later walker found no `bsps` under any
permutation and wrote an empty file; Halo 2 physics shapes are stored flat
rather than behind rigid-body shape references. Neither is reproducible here —
there are no loose Halo 1 or Halo 2 tags on this machine — but the layouts
differ in the definitions for every game, and the dispatch mirrors
`render_jms_for_game`.

## Animation graphs with no rest pose

A `model_animation_graph` extracted on its own resolves no render_model either,
so its rest pose can only come from `additional node data`, the denormalised
copy inside the graph. 79 of the 2,594 graphs Halo Reach ships carry none at
all — the magnum's, the plasma pistol's, and every cinematic object graph — and
those exported with every bone at identity.

Same fix: find the owner by the graph's own path, then verify it, since a model
only counts if its `animation` reference points back at this graph. Handing the
model to the extractor is what selecting the model would have done, so the
render_model arrives through the existing resolution. Only graphs actually short
of a rest pose are redirected, so the 2,515 complete ones export byte-for-byte
as before. 45 of the 79 improve; the remaining 34 have no model beside them and
keep what they had. Halo 3's 50 partially-covered graphs have no sibling model
either, so nothing changes there.

## Engine

Bumped to `0656e0d`, which gives a collision model's bones back their hierarchy:
a collision node names its parent `parent node` where a physics node names it
`parent`, and the shared reader only ever asked for the latter, so every
collision JMS came out a flat pile of root bones. Checked against the
render_model, which is where that hierarchy actually comes from — across the
1,347 Halo 3 models carrying both, agreeing bone parents go from 1,341 to 4,464
of 4,464, and the 307 entirely parentless armatures go to none.

That rev also moves the pin back to `camden-smallwood/blam-tags`, merging in the
cross-game layout comparison it had been parked on `Zoephie/blam-tags`
`codex/chimp-backend` for. The old pin `f92c8ec` is an ancestor, so nothing is
dropped.

## Tests

One unit test for the reference derivation, plus three end-to-end tests gated on
a loose tag tree (`H3_TAGS` / `REACH_TAGS`), each carrying a control that is
supposed to be collapsed so the test fails if the fix stops doing anything.
Verified they fail when the resolution is deliberately broken. Full suite green.