### PR TITLE
Fix missing polygons and flipped UVs in Campaign Evolved JMS extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,7 +502,7 @@ dependencies = [
 [[package]]
 name = "blam-tags"
 version = "0.1.0"
-source = "git+https://github.com/camden-smallwood/blam-tags?rev=ff7526e#ff7526ebf37d05ac39c985c52bddca015d7430de"
+source = "git+https://github.com/camden-smallwood/blam-tags?rev=736e9a7#736e9a7d44574ab509f1c7e7e56ad366acd80a1d"
 dependencies = [
  "anyhow",
  "bcdec_rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,8 @@
 # `codex/chimp-backend` — the signed DXN bump-map fix (merged as
 # camden-smallwood/blam-tags#3) and the recursive cross-game layout comparison
 # the Halo Reach → Campaign Evolved import needs, merged in at `11dcd83`. The
-# old pin `f92c8ec` is an ancestor of this rev, so nothing was dropped.
+# old pin `f92c8ec` is an ancestor of this rev, so nothing was dropped — as is
+# `ff7526e`, the pin this bump replaces.
 [workspace]
 members = ["."]
 default-members = ["."]
@@ -26,7 +27,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1"
 atomic-write-file = "0.3"
-blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "ff7526e", features = ["audio", "iostore"] }
+blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "736e9a7", features = ["audio", "iostore"] }
 directories = "6"
 display-info = "0.5"
 eframe = { version = "0.29", default-features = false, features = ["default_fonts", "glow"] }


### PR DESCRIPTION
Two defects behind the Discord report that a CE model extracted to JMS comes out with polygons missing and with texture V flipped on some parts but not others. Both are in the engine; this is the rev bump (`ff7526e` -> `736e9a7`, [camden-smallwood/blam-tags](https://github.com/camden-smallwood/blam-tags)). The old pin is an ancestor of the new one.

Measured throughout against the real install (`spartans/spartans`, 61 skeletal parts + 480 bone-attached static armour pieces).

## Missing polygons — Nanite read its index stream past the end of the buffer

`ReadUnalignedDword` takes a **signed** bit offset, and Nanite's strip decoder genuinely passes a negative one: it reads at `(NumPrevRefVertices - 1) * 5`, which is `-5` for the first ref vertex a cluster codes. The engine leans on that — the CPU encoder pads its index buffer by a byte (`check(BitOffset > -8)`) and the GPU path lets the `int` arithmetic shift walk back one — because the bits it lands on are the cluster's own first 5-bit delta, which the caller really does use.

Ours was unsigned, so `-5 >> 3` shifted logically into an enormous address instead of stepping back a byte. The read fell off the end, returned zeros, and the triangle's third index collapsed onto its second — a degenerate where a real triangle belonged.

Raw decode, hole repair disabled, across the spartan's 243 Nanite meshes (1,654,704 triangles):

| | collapsed triangles |
|---|---|
| before | 9,669 |
| after | 0 |

`repair_nanite_triangular_holes` was patching only the subset that left an exactly-three-vertex boundary loop — one missing triangle. Anything two or more triangles wide it could not reach, which is what surfaced as holes. The composite JMS now emits every triangle in the index buffer (4,886,865 -> 4,887,950, zero dropped).

Worth flagging separately: **that repair heuristic is now dead on this corpus.** The decoder gives it nothing to fix, and it still costs an edge-hash pass over millions of triangles per mesh. Left in place — removing it is a call for a separate PR.

## Flipped UVs — the skeletal and static converters disagreed

`SkeletalMesh` and `StaticMesh` both decode raw Unreal UVs (their `decode_uv` is the same code), but the skeletal converters were written as though the skeletal decoder had already flipped V — a comment in `actorx.rs` even said so. It never did. The four converters ended up disagreeing in a mirrored way:

| | skeletal | static |
|---|---|---|
| -> JMS | raw V | `1-V` |
| -> PSK/PSKX | `1-V` | raw V |

A CE character is one JMS built from both, so the two conventions met in a single file. Chimp never showed it because it writes one mesh per file.

Composite JMS V ranges on the spartan:

| | skeletal parts | static parts |
|---|---|---|
| before | `-0.997 .. 1.000` | `0.001 .. 1.999` |
| after | `0.000 .. 1.997` | `0.001 .. 1.999` |

Unreal and the Halo engines both run V downward from a top-left origin, and JMS is the one format that doesn't — the classic `read_vertex` / `read_h2_vertex` / `read_ce_vertex` paths all flip. So the static converters were right on both counts, and all four now settle there: JMS flips, ActorX passes through.

**Note this also changes Chimp's standalone skeletal PSK/PSKX output**, which was double-flipping. That follows from the same premise but is a behaviour change nobody reported a problem with; happy to split that half back out if you'd rather.

## Tests

New engine regression tests pin both: the negative-offset read against the engine's own arithmetic, and the two converter pairs against each other so they can't drift apart again. Full suites green — 399 in blam-tags, 682 in Baboon.

Not verified from here: I can't import a JMS into Blender on this machine, so this confirms the defects are gone, not that every artifact in the report's screenshots is. Some triangles remain zero-area *by position* on the densest meshes (the chest is worst); those look like ordinary Nanite position quantization, which UE also renders as zero-area, but I didn't prove it.