### PR TITLE
Extract and preview a particle model's source geometry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,7 +502,7 @@ dependencies = [
 [[package]]
 name = "blam-tags"
 version = "0.1.0"
-source = "git+https://github.com/camden-smallwood/blam-tags?rev=736e9a7#736e9a7d44574ab509f1c7e7e56ad366acd80a1d"
+source = "git+https://github.com/camden-smallwood/blam-tags?rev=9546231#954623170e146721edfd7f45182085fcea7cac3b"
 dependencies = [
  "anyhow",
  "bcdec_rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1"
 atomic-write-file = "0.3"
-blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "736e9a7", features = ["audio", "iostore"] }
+blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "9546231", features = ["audio", "iostore"] }
 directories = "6"
 display-info = "0.5"
 eframe = { version = "0.29", default-features = false, features = ["default_fonts", "glow"] }

--- a/src/app/browser/filter.rs
+++ b/src/app/browser/filter.rs
@@ -303,6 +303,16 @@ mod tests {
                 String::from_utf8_lossy(group)
             );
         }
+        // A particle_model exports its source JMI plus one JMS per object.
+        // `pmdf` is Halo 3 / Reach / Halo 4; `PRTM` is Halo 2's unrelated
+        // tag of the same name, which routes through the same menu item.
+        for group in [b"pmdf", b"PRTM"] {
+            assert!(
+                supports_tag_extract_menu(u32::from_be_bytes(*group)),
+                "{} should enable the Extract menu",
+                String::from_utf8_lossy(group)
+            );
+        }
         // A plain weapon has no extractor at all — it must leave it disabled.
         assert!(!supports_tag_extract_menu(u32::from_be_bytes(*b"weap")));
     }

--- a/src/app/browser/tree.rs
+++ b/src/app/browser/tree.rs
@@ -1099,6 +1099,16 @@ pub(in crate::app) fn draw_entry(
                             action = Some(BrowserAction::ExtractGeometry(entry.key.clone()));
                             ui.close_menu();
                         }
+                        if supports_particle_geometry_extraction(entry.group_tag)
+                            && context_menu_button(
+                                ui,
+                                "Extract particle geometry (JMI + one JMS per object)",
+                            )
+                            .clicked()
+                        {
+                            action = Some(BrowserAction::ExtractGeometry(entry.key.clone()));
+                            ui.close_menu();
+                        }
                         if supports_animation_extraction(entry.group_tag)
                             && context_menu_button(ui, "Extract animations").clicked()
                         {
@@ -1534,6 +1544,7 @@ pub(in crate::app) fn supports_tag_extract_menu(group_tag: u32) -> bool {
     supports_tag_geometry_extraction(group_tag)
         || supports_bsp_geometry_extraction(group_tag)
         || supports_scenario_geometry_extraction(group_tag)
+        || supports_particle_geometry_extraction(group_tag)
         || supports_animation_extraction(group_tag)
         || supports_tag_import_info_extraction(group_tag)
         || is_bitmap_group(group_tag)
@@ -1559,6 +1570,13 @@ fn supports_bsp_geometry_extraction(group_tag: u32) -> bool {
 /// A scenario exports every BSP it references, one file each.
 fn supports_scenario_geometry_extraction(group_tag: u32) -> bool {
     group_tag.to_be_bytes().as_slice() == b"scnr"
+}
+
+/// A particle_model exports to a `.jmi` manifest plus one JMS per object
+/// it was imported from — not a single file — so it gets its own wording
+/// rather than joining [`supports_tag_geometry_extraction`].
+fn supports_particle_geometry_extraction(group_tag: u32) -> bool {
+    blam_tags::is_particle_model_group(group_tag)
 }
 
 fn supports_tag_import_info_extraction(group_tag: u32) -> bool {

--- a/src/app/editor.rs
+++ b/src/app/editor.rs
@@ -50,7 +50,7 @@ pub(super) fn draw_tag(
     let is_object_family = is_object_family_group(entry.group_tag);
     let is_shaderish =
         is_material_tag(entry) || is_material_shader_tag(entry) || is_shader_tag(entry);
-    let is_model = is_model_group(entry.group_tag, names);
+    let is_model = is_previewable_geometry_group(entry.group_tag, names);
 
     draw_tag_metadata(ui, tag, entry, names);
     if !is_object_family {

--- a/src/app/editor/model.rs
+++ b/src/app/editor/model.rs
@@ -135,6 +135,22 @@ pub(in crate::app) fn is_model_group(group_tag: u32, names: &TagNameIndex) -> bo
         || names.name_for(group_tag) == Some("gbxmodel")
 }
 
+/// Tags that get the Fields / Render Model tab pair and a geometry
+/// viewport — everything [`is_model_group`] covers, plus geometry-bearing
+/// tags that are not "models" in the object sense.
+///
+/// Kept separate from [`is_model_group`] on purpose: that predicate also
+/// decides whether a *tag_reference* is an object's model link
+/// (`find_model_reference`), and a `particle`'s `Model` → `pmdf` field
+/// would be misread as one, putting a bogus model summary on every
+/// particle tag.
+pub(in crate::app) fn is_previewable_geometry_group(
+    group_tag: u32,
+    names: &TagNameIndex,
+) -> bool {
+    is_model_group(group_tag, names) || blam_tags::is_particle_model_group(group_tag)
+}
+
 pub(in crate::app) fn format_reference_path(
     names: &TagNameIndex,
     group_tag: u32,

--- a/src/app/export/geometry.rs
+++ b/src/app/export/geometry.rs
@@ -73,6 +73,34 @@ pub(in crate::app) fn extract_geometry_for_entry(
                 }
             ))
         }
+        // A particle_model is the merged geometry of every object in the
+        // JMI it was imported from, so it comes back out as that manifest
+        // plus one JMS per object — the layout `import particle model`
+        // reads. `pmdf` is Halo 3 / Reach / Halo 4; `PRTM` is Halo 2's
+        // unrelated tag of the same name, which additionally stores the
+        // original object names.
+        b"pmdf" | b"PRTM" => {
+            let tag = read_entry(source, entry)?;
+            let stem = tag_file_stem(entry);
+            let summary =
+                blam_tags::extract::particle_model::particle_model_to_dir(&tag, output, &stem)?;
+            let objects = summary.emitted.iter().filter(|e| e.object.is_some()).count();
+            let manifest = summary
+                .emitted
+                .first()
+                .map(|e| e.path.display().to_string())
+                .unwrap_or_default();
+            Ok(format!(
+                "Extracted particle geometry {manifest} ({objects} object{}){}",
+                if objects == 1 { "" } else { "s" },
+                if summary.names_are_authentic {
+                    ""
+                } else {
+                    " — this engine stores no object names, so they are \
+                     numbered from the tag name"
+                },
+            ))
+        }
         _ => anyhow::bail!(
             "geometry extraction is not available for {}",
             format_group_tag(entry.group_tag)
@@ -971,3 +999,7 @@ mod tests {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "../tests/particle_model_extract_menu.rs"]
+mod particle_model_extract_menu;

--- a/src/app/find.rs
+++ b/src/app/find.rs
@@ -448,7 +448,7 @@ impl Baboon {
             return;
         }
         if let Some(entry) = self.entry_for_key(&hit.tag_key) {
-            if is_model_group(entry.group_tag, self.names()) {
+            if is_previewable_geometry_group(entry.group_tag, self.names()) {
                 self.kits[self.active].model_previews
                     .entry(hit.tag_key.clone())
                     .or_default()

--- a/src/app/model_preview/loading.rs
+++ b/src/app/model_preview/loading.rs
@@ -61,6 +61,25 @@ pub(super) fn load_model_preview(
     source: Option<&TagSource>,
     high_detail: bool,
 ) -> Result<ModelPreviewData, String> {
+    // `particle_model` carries its geometry inline with no wrapper, but
+    // it is not a render_model: no regions, no permutations, no
+    // materials, no nodes. Its objects are the entries of the JMI the
+    // artist imported, so each becomes a preview region and gets its own
+    // toggle in the region list.
+    if blam_tags::is_particle_model_group(model_tag.header.group_tag) {
+        let stem = preview_tag_stem(entry);
+        let preview = build_particle_model_preview(model_tag, &stem)?;
+        if preview.batches.is_empty() {
+            return Err("This particle_model has no previewable geometry.".to_owned());
+        }
+        return Ok(model_preview_data(
+            entry.key.clone(),
+            entry.display_path.clone(),
+            preview,
+            Vec::new(),
+        ));
+    }
+
     // Halo CE `gbxmodel` (mod2) and a bare `render_model` (mode) ARE the
     // render geometry — there is no `.model` (hlmt) wrapper carrying a
     // "render model" reference, so preview the tag itself.
@@ -139,6 +158,102 @@ pub(super) fn load_model_preview(
 /// `sections`, Halo CE the gbxmodel `geometries`), so batches carry the render
 /// model's own region/permutation names and stay in sync with the variant
 /// selection. JMS is export-only — never used for rendering.
+/// Tag basename, used to name gen3 particle objects (`pmdf` stores no
+/// object names — see `blam_tags::particle_model`). Falls back to the
+/// entry key when the display path has no usable leaf.
+fn preview_tag_stem(entry: &TagEntry) -> String {
+    entry
+        .display_path
+        .rsplit(['/', '\\'])
+        .next()
+        .map(|leaf| leaf.split('.').next().unwrap_or(leaf))
+        .filter(|stem| !stem.is_empty())
+        .unwrap_or("particle_model")
+        .to_owned()
+}
+
+/// Build preview geometry from a `particle_model` (`pmdf` or Halo 2
+/// `PRTM`).
+///
+/// blam-tags does the decode — splitting the merged strip at the
+/// `m_gpu_data/m_variants` boundaries (gen3) or the `models[]` ranges
+/// (Halo 2), decompressing positions through the compression bounds, and
+/// compacting each object to its own vertex set. Each object lands as a
+/// one-permutation region so the existing region list doubles as an
+/// object toggle, which is the closest thing the tag has to structure.
+pub(super) fn build_particle_model_preview(
+    tag: &TagFile,
+    stem: &str,
+) -> Result<RenderModelPreview, String> {
+    let meshes = blam_tags::particle_model_meshes(tag, stem).map_err(|e| e.to_string())?;
+
+    let mut preview = RenderModelPreview {
+        bounds_min: [f32::INFINITY; 3],
+        bounds_max: [f32::NEG_INFINITY; 3],
+        ..Default::default()
+    };
+
+    for mesh in &meshes {
+        let Ok(vertex_base) = u32::try_from(preview.vertices.len()) else {
+            continue;
+        };
+        if mesh
+            .vertices
+            .len()
+            .checked_add(preview.vertices.len())
+            .is_none_or(|count| count > u32::MAX as usize)
+        {
+            continue;
+        }
+
+        preview.vertices.reserve(mesh.vertices.len());
+        for vertex in &mesh.vertices {
+            let position = [vertex.position.x, vertex.position.y, vertex.position.z];
+            expand_preview_bounds_local(&mut preview.bounds_min, &mut preview.bounds_max, position);
+            preview.vertices.push(RenderModelPreviewVertex {
+                position,
+                normal: [vertex.normal.i, vertex.normal.j, vertex.normal.k],
+            });
+        }
+
+        let Ok(index_start) = u32::try_from(preview.indices.len()) else {
+            continue;
+        };
+        preview
+            .indices
+            .extend(mesh.indices.iter().map(|index| vertex_base + index));
+        let Ok(index_end) = u32::try_from(preview.indices.len()) else {
+            continue;
+        };
+        let index_count = index_end - index_start;
+        if index_count == 0 {
+            continue;
+        }
+
+        preview.regions.push(RenderModelPreviewRegion {
+            name: mesh.name.clone(),
+            permutations: vec![PARTICLE_OBJECT_PERMUTATION.to_owned()],
+        });
+        preview.batches.push(RenderModelPreviewBatch {
+            region_name: mesh.name.clone(),
+            permutation_name: PARTICLE_OBJECT_PERMUTATION.to_owned(),
+            material_index: 0,
+            index_start,
+            index_count,
+        });
+    }
+
+    if preview.vertices.is_empty() {
+        preview.bounds_min = [0.0; 3];
+        preview.bounds_max = [0.0; 3];
+    }
+    Ok(preview)
+}
+
+/// A particle object has no permutations; the region list still needs a
+/// selectable entry per region, so every object gets this single one.
+const PARTICLE_OBJECT_PERMUTATION: &str = "default";
+
 pub(super) fn build_render_preview(render_tag: &TagFile) -> Result<RenderModelPreview, String> {
     let render_model = RenderModel::from_tag(render_tag).map_err(|error| error.to_string())?;
     let render_meshes =
@@ -1894,3 +2009,7 @@ mod ce_repro_tests {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "../tests/particle_model_preview.rs"]
+mod particle_model_preview;

--- a/src/app/model_preview/mod.rs
+++ b/src/app/model_preview/mod.rs
@@ -84,7 +84,7 @@ pub(super) fn draw_model_preview_panel(
     model_preview_size: &mut f32,
     edit: &mut FieldEditContext<'_>,
 ) {
-    let is_model = is_model_group(entry.group_tag, names);
+    let is_model = is_previewable_geometry_group(entry.group_tag, names);
     if !is_model {
         return;
     }

--- a/src/app/tests/particle_model_extract_menu.rs
+++ b/src/app/tests/particle_model_extract_menu.rs
@@ -1,0 +1,159 @@
+//! Right-click → Extract → particle geometry actually extracts.
+//!
+//! This wiring has two halves that are edited in different files and can
+//! drift apart silently: the browser's `supports_*` gate decides whether
+//! the menu item is drawn, and `extract_geometry_for_entry`'s match arm
+//! decides whether the action does anything. Either one alone looks
+//! finished — a gate with no arm shows a menu entry that errors, an arm
+//! with no gate is unreachable.
+//!
+//! The gate half lives with the other groups in
+//! `browser::filter`'s `tag_extract_menu_covers_every_group_with_an_asset_extractor`.
+//! What is asserted here is the action half, each test opening by
+//! re-checking its own gate so the pair stays visible in one place.
+//!
+//! Skips silently when the corresponding tag set is absent.
+
+use std::path::{Path, PathBuf};
+
+use crate::app::browser::supports_tag_extract_menu;
+use crate::app::export::extract_geometry_for_entry;
+use crate::source::{TagEntry, TagEntryLocation, TagSource};
+
+/// Root of an extracted MCC tag set, via `BLAM_TEST_<KIT>_TAGS` or the
+/// conventional local layout.
+fn kit_tags(kit: &str) -> Option<PathBuf> {
+    let var = format!("BLAM_TEST_{}_TAGS", kit.to_uppercase());
+    if let Ok(p) = std::env::var(&var) {
+        let p = PathBuf::from(p);
+        return p.is_dir().then_some(p);
+    }
+    let home = std::env::var("HOME").ok()?;
+    let p = PathBuf::from(home)
+        .join("Halo")
+        .join(format!("{kit}_mcc"))
+        .join("tags");
+    p.is_dir().then_some(p)
+}
+
+fn loose_source(root: &Path, game: &str) -> TagSource {
+    TagSource::LooseFolder {
+        root: root.to_path_buf(),
+        game: Some(game.to_owned()),
+        definitions_root: crate::app::locate_definitions_root(),
+    }
+}
+
+fn entry_for(root: &Path, rel: &str, group: &[u8; 4]) -> TagEntry {
+    let path = root.join(rel);
+    TagEntry {
+        key: format!("file:{}", path.display()),
+        display_path: rel.to_owned(),
+        group_tag: u32::from_be_bytes(*group),
+        group_name: Some("particle_model".to_owned()),
+        location: TagEntryLocation::LooseFile(path),
+    }
+}
+
+/// The gen3 action writes the manifest plus one JMS per object, at the
+/// paths the manifest names.
+#[test]
+fn extracting_a_gen3_particle_model_writes_a_resolvable_jmi() {
+    assert!(
+        supports_tag_extract_menu(u32::from_be_bytes(*b"pmdf")),
+        "the menu item that reaches this action is not drawn",
+    );
+    let Some(root) = kit_tags("haloreach") else {
+        return;
+    };
+    let rel = "fx/particles/models/debris/generic_shards/generic_shards.particle_model";
+    if !root.join(rel).is_file() {
+        return;
+    }
+    let out = std::env::temp_dir().join("baboon_pm_extract_gen3");
+    let _ = std::fs::remove_dir_all(&out);
+    std::fs::create_dir_all(&out).expect("create output dir");
+
+    let summary = extract_geometry_for_entry(
+        &loose_source(&root, "haloreach_mcc"),
+        &entry_for(&root, rel, b"pmdf"),
+        &out,
+    )
+    .expect("extract particle geometry");
+    assert!(summary.contains("8 objects"), "unexpected summary: {summary}");
+
+    // The manifest must sit where `import particle model` expects, and
+    // every line it names must resolve to a real JMS beside it. A
+    // dangling line is a silent import failure, not a warning.
+    let jmi = out.join("generic_shards").join("generic_shards.jmi");
+    assert!(jmi.is_file(), "no manifest at {}", jmi.display());
+    let text = std::fs::read_to_string(&jmi).expect("read manifest");
+    assert!(text.contains("\r\n"), "manifest must use CRLF");
+    let objects: Vec<&str> = text
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && !l.starts_with(';'))
+        .skip(2)
+        .collect();
+    assert_eq!(objects.len(), 8, "manifest lists {} objects", objects.len());
+    for name in objects {
+        let jms = jmi
+            .parent()
+            .unwrap()
+            .join(name)
+            .join("render")
+            .join(format!("{name}.JMS"));
+        assert!(jms.is_file(), "manifest names `{name}` but {} is missing", jms.display());
+        let body = std::fs::read_to_string(&jms).expect("read JMS");
+        assert!(body.contains(";### VERTICES ###"), "`{name}` JMS has no vertices section");
+    }
+
+    // Lowercase, because tool.exe's manifest-vs-directory check is a
+    // case-sensitive `strncmp(ext, ".jmi", 5)`.
+    assert_eq!(jmi.extension().and_then(|e| e.to_str()), Some("jmi"));
+
+    let _ = std::fs::remove_dir_all(&out);
+}
+
+/// Halo 2 goes through the same action but a different decode, and its
+/// summary must not claim the names were invented — `PRTM` stores them.
+#[test]
+fn extracting_a_halo2_particle_model_keeps_its_object_names() {
+    assert!(
+        supports_tag_extract_menu(u32::from_be_bytes(*b"PRTM")),
+        "the menu item that reaches this action is not drawn",
+    );
+    let Some(root) = kit_tags("halo2") else {
+        return;
+    };
+    let rel = "effects/particle_models/urban_debris/urban_debris.particle_model";
+    if !root.join(rel).is_file() {
+        return;
+    }
+    let out = std::env::temp_dir().join("baboon_pm_extract_h2");
+    let _ = std::fs::remove_dir_all(&out);
+    std::fs::create_dir_all(&out).expect("create output dir");
+
+    let summary = extract_geometry_for_entry(
+        &loose_source(&root, "halo2_mcc"),
+        &entry_for(&root, rel, b"PRTM"),
+        &out,
+    )
+    .expect("extract particle geometry");
+    assert!(summary.contains("10 objects"), "unexpected summary: {summary}");
+    assert!(
+        !summary.contains("numbered from the tag name"),
+        "Halo 2 stores its object names — the summary must not say otherwise: {summary}",
+    );
+
+    assert!(
+        out.join("urban_debris")
+            .join("can_1")
+            .join("render")
+            .join("can_1.JMS")
+            .is_file(),
+        "shipped object name `can_1` did not reach the output tree",
+    );
+
+    let _ = std::fs::remove_dir_all(&out);
+}

--- a/src/app/tests/particle_model_preview.rs
+++ b/src/app/tests/particle_model_preview.rs
@@ -1,0 +1,356 @@
+//! `particle_model` tags get a working Render Model tab.
+//!
+//! blam-tags owns the decode (splitting the merged triangle strip at the
+//! `m_gpu_data/m_variants` boundaries, decompressing through the
+//! compression bounds) and is tested there. What this asserts is
+//! Baboon's half:
+//!
+//! - the tab pair and viewport actually appear for `pmdf` / `PRTM`,
+//! - **without** widening [`is_model_group`], whose other job is deciding
+//!   whether a `tag_reference` is an object's model link — a `particle`
+//!   tag's `Model` → `pmdf` field would be misread as one,
+//! - each JMI object becomes its own preview region, so the region list
+//!   doubles as an object toggle,
+//! - the geometry the viewport uploads is right way round — batches
+//!   index inside the vertex buffer and face normals agree with the
+//!   stored vertex normals.
+//!
+//! Skips silently when the corresponding tag set is absent.
+
+use std::path::PathBuf;
+
+use blam_tags::TagFile;
+
+use crate::app::editor::{is_model_group, is_previewable_geometry_group};
+use crate::app::model_preview::loading::build_particle_model_preview;
+use crate::app::model_preview::RenderModelPreview;
+
+/// Root of an extracted MCC tag set, via `BLAM_TEST_<KIT>_TAGS` or the
+/// conventional local layout.
+fn kit_tags(kit: &str) -> Option<PathBuf> {
+    let var = format!("BLAM_TEST_{}_TAGS", kit.to_uppercase());
+    if let Ok(p) = std::env::var(&var) {
+        let p = PathBuf::from(p);
+        return p.is_dir().then_some(p);
+    }
+    let home = std::env::var("HOME").ok()?;
+    let p = PathBuf::from(home)
+        .join("Halo")
+        .join(format!("{kit}_mcc"))
+        .join("tags");
+    p.is_dir().then_some(p)
+}
+
+fn names() -> crate::format::TagNameIndex {
+    let defs = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("definitions");
+    crate::format::TagNameIndex::load_from_definitions(&defs)
+}
+
+/// Read a tag, routing Halo 2's classic format through its JSON
+/// definition (classic tags carry no embedded `blay`).
+fn read(path: &std::path::Path, game: &str) -> TagFile {
+    let bytes = std::fs::read(path).expect("read tag bytes");
+    if blam_tags::classic::ClassicHeader::parse(&bytes).is_some() {
+        let def = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("definitions")
+            .join(game)
+            .join("particle_model.json");
+        let layout = blam_tags::layout::TagLayout::from_json(&def).expect("load classic layout");
+        return blam_tags::classic::read_classic_tag_file(&bytes, layout).expect("decode classic");
+    }
+    TagFile::read(path).expect("read tag")
+}
+
+/// Mean dot(face normal, averaged vertex normal) over the preview's
+/// triangles. A correct upload lands near +1; flipped winding lands near
+/// -1, and a mis-split strip near 0.
+fn face_normal_agreement(preview: &RenderModelPreview) -> Option<f32> {
+    let mut total = 0.0f64;
+    let mut n = 0usize;
+    for tri in preview.indices.chunks_exact(3) {
+        let v: Vec<_> = tri
+            .iter()
+            .filter_map(|&i| preview.vertices.get(i as usize))
+            .collect();
+        if v.len() != 3 {
+            continue;
+        }
+        let (pa, pb, pc) = (v[0].position, v[1].position, v[2].position);
+        let u = [pb[0] - pa[0], pb[1] - pa[1], pb[2] - pa[2]];
+        let w = [pc[0] - pa[0], pc[1] - pa[1], pc[2] - pa[2]];
+        let f = [
+            u[1] * w[2] - u[2] * w[1],
+            u[2] * w[0] - u[0] * w[2],
+            u[0] * w[1] - u[1] * w[0],
+        ];
+        let fl = (f[0] * f[0] + f[1] * f[1] + f[2] * f[2]).sqrt();
+        if fl < 1e-12 {
+            continue;
+        }
+        let vn = [
+            (v[0].normal[0] + v[1].normal[0] + v[2].normal[0]) / 3.0,
+            (v[0].normal[1] + v[1].normal[1] + v[2].normal[1]) / 3.0,
+            (v[0].normal[2] + v[1].normal[2] + v[2].normal[2]) / 3.0,
+        ];
+        let vl = (vn[0] * vn[0] + vn[1] * vn[1] + vn[2] * vn[2]).sqrt();
+        if vl < 1e-12 {
+            continue;
+        }
+        total += (0..3).map(|k| (f[k] / fl) * (vn[k] / vl)).sum::<f32>() as f64;
+        n += 1;
+    }
+    (n > 0).then(|| (total / n as f64) as f32)
+}
+
+/// The panel gate opens for particle models — and `is_model_group` stays
+/// closed, so `find_model_reference` does not start treating a
+/// `particle`'s `Model` field as an object's model link.
+#[test]
+fn particle_model_is_previewable_without_becoming_a_model() {
+    let names = names();
+    for group in [b"pmdf", b"PRTM"] {
+        let tag = u32::from_be_bytes(*group);
+        let label = String::from_utf8_lossy(group).into_owned();
+        assert!(
+            is_previewable_geometry_group(tag, &names),
+            "`{label}` must open the Render Model tab",
+        );
+        assert!(
+            !is_model_group(tag, &names),
+            "`{label}` must NOT count as a model group — that predicate also \
+             decides whether a tag_reference is an object's model link",
+        );
+    }
+    // The predicate must still admit everything it used to.
+    for group in [b"hlmt", b"mod2"] {
+        let tag = u32::from_be_bytes(*group);
+        assert!(is_previewable_geometry_group(tag, &names));
+    }
+}
+
+/// A multi-object gen3 tag: one region per JMI object, batches wired to
+/// those regions, and geometry the right way round.
+#[test]
+fn gen3_objects_become_regions_with_valid_geometry() {
+    let Some(tags) = kit_tags("haloreach") else {
+        return;
+    };
+    let path =
+        tags.join("fx/particles/models/debris/generic_shards/generic_shards.particle_model");
+    if !path.is_file() {
+        return;
+    }
+    let tag = read(&path, "haloreach_mcc");
+    let preview = build_particle_model_preview(&tag, "generic_shards").expect("build preview");
+
+    assert_eq!(preview.regions.len(), 8, "generic_shards ships 8 objects");
+    assert_eq!(
+        preview.batches.len(),
+        preview.regions.len(),
+        "every object needs a draw batch or it renders invisible",
+    );
+    for (region, batch) in preview.regions.iter().zip(&preview.batches) {
+        assert_eq!(region.name, batch.region_name, "batch must target its region");
+        assert!(
+            region.permutations.contains(&batch.permutation_name),
+            "batch permutation `{}` is not selectable in region `{}`",
+            batch.permutation_name,
+            region.name,
+        );
+        assert!(batch.index_count > 0, "region `{}` has an empty batch", region.name);
+    }
+
+    // Every batch must address inside the shared buffers, or the
+    // renderer reads past the end.
+    for batch in &preview.batches {
+        let end = (batch.index_start + batch.index_count) as usize;
+        assert!(end <= preview.indices.len(), "batch range past the index buffer");
+        for &i in &preview.indices[batch.index_start as usize..end] {
+            assert!((i as usize) < preview.vertices.len(), "index past the vertex buffer");
+        }
+    }
+
+    assert!(
+        preview.bounds_min.iter().all(|v| v.is_finite())
+            && preview.bounds_max.iter().all(|v| v.is_finite()),
+        "bounds must be finite or the camera cannot frame the model",
+    );
+
+    let score = face_normal_agreement(&preview).expect("measurable");
+    assert!(
+        score > 0.6,
+        "preview geometry scored {score:.3} — a mis-split strip scores ~0 and \
+         flipped winding ~-1",
+    );
+}
+
+/// Halo 2's `PRTM` is a different tag and a different decode, and it
+/// names its own objects — the region list should show those names.
+#[test]
+fn halo2_regions_carry_the_shipped_object_names() {
+    let Some(tags) = kit_tags("halo2") else {
+        return;
+    };
+    let path = tags.join("effects/particle_models/urban_debris/urban_debris.particle_model");
+    if !path.is_file() {
+        return;
+    }
+    let tag = read(&path, "halo2_mcc");
+    let preview = build_particle_model_preview(&tag, "urban_debris").expect("build preview");
+
+    let region_names: Vec<&str> = preview.regions.iter().map(|r| r.name.as_str()).collect();
+    assert_eq!(
+        region_names,
+        vec![
+            "can_1", "can_2", "can_3", "can_4", "can_5", "paper_1", "paper_2", "paper_3",
+            "butt_1", "butt_2",
+        ],
+        "Halo 2 stores `models[].model name` — the region list must show them",
+    );
+
+    let score = face_normal_agreement(&preview).expect("measurable");
+    assert!(score > 0.6, "preview geometry scored {score:.3}");
+}
+
+/// A single-object tag still produces one selectable region rather than
+/// an empty list, so the viewport is not blank.
+#[test]
+fn single_object_tag_still_yields_one_region() {
+    let Some(tags) = kit_tags("haloreach") else {
+        return;
+    };
+    let path = tags.join("fx/particles/models/weapons/brute_spike/brute_spike.particle_model");
+    if !path.is_file() {
+        return;
+    }
+    let tag = read(&path, "haloreach_mcc");
+    let preview = build_particle_model_preview(&tag, "brute_spike").expect("build preview");
+
+    assert_eq!(preview.regions.len(), 1);
+    assert_eq!(preview.regions[0].name, "brute_spike");
+    assert!(!preview.indices.is_empty(), "single-object preview must have geometry");
+}
+
+/// Drive the real UI entry point, not the builder underneath it.
+///
+/// `load_model_preview` is what the panel calls, and it derives the
+/// object-naming stem from `entry.display_path` rather than being handed
+/// one. Asserting through it is what catches a stem derivation that
+/// silently yields `""` (every object would become `_1`, `_2`, …) or
+/// keeps the `.particle_model` extension.
+#[test]
+fn load_model_preview_derives_object_names_from_the_entry() {
+    let Some(tags) = kit_tags("haloreach") else {
+        return;
+    };
+    let path = tags.join("fx/particles/models/debris/falling_leaves/falling_leaves.particle_model");
+    if !path.is_file() {
+        return;
+    }
+    let tag = read(&path, "haloreach_mcc");
+    let names = names();
+    let entry = crate::source::TagEntry {
+        key: format!("file:{}", path.display()),
+        display_path: "fx/particles/models/debris/falling_leaves/falling_leaves.particle_model"
+            .to_owned(),
+        group_tag: tag.header.group_tag,
+        group_name: Some("particle_model".to_owned()),
+        location: crate::source::TagEntryLocation::LooseFile(path.clone()),
+    };
+
+    let data = crate::app::model_preview::loading::load_model_preview(
+        &tag, &entry, &names, None, false,
+    )
+    .expect("preview loads without a loose-folder source — geometry is inline");
+
+    assert!(!data.preview.regions.is_empty(), "no objects were exposed");
+    for region in &data.preview.regions {
+        assert!(
+            region.name.starts_with("falling_leaves"),
+            "object `{}` was not named from the tag stem — the stem derivation \
+             is dropping or mangling `entry.display_path`",
+            region.name,
+        );
+        assert!(
+            !region.name.contains(".particle_model"),
+            "object `{}` kept the tag extension",
+            region.name,
+        );
+    }
+    // A particle_model has no model variants. The Variant combo still
+    // renders (showing only `<None>`), same as a bare `render_model`
+    // preview — but nothing must invent entries for it, or the combo
+    // would offer selections that change nothing.
+    assert!(data.variants.is_empty(), "a particle_model has no variants");
+}
+
+/// Every shipped particle_model in every present kit must produce a
+/// preview with geometry — no panic, no empty viewport.
+///
+/// The panel wraps the load in `catch_unwind` and shows the message, so
+/// a regression here degrades to a red label rather than a crash; this
+/// keeps it from degrading silently.
+#[test]
+fn every_shipped_particle_model_previews() {
+    let kits = [
+        ("halo2", "halo2_mcc"),
+        ("halo3", "halo3_mcc"),
+        ("haloreach", "haloreach_mcc"),
+        ("halo4", "halo4_mcc"),
+    ];
+    let names = names();
+    let mut checked = 0usize;
+    let mut objects = 0usize;
+    let mut failures: Vec<String> = Vec::new();
+
+    for (kit, game) in kits {
+        let Some(root) = kit_tags(kit) else { continue };
+        let mut stack = vec![root.clone()];
+        while let Some(dir) = stack.pop() {
+            let Ok(entries) = std::fs::read_dir(&dir) else { continue };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    stack.push(path);
+                    continue;
+                }
+                if path.extension().and_then(|e| e.to_str()) != Some("particle_model") {
+                    continue;
+                }
+                let tag = read(&path, game);
+                let rel = path.strip_prefix(&root).unwrap_or(&path);
+                let display = rel.to_string_lossy().replace('\\', "/");
+                let tag_entry = crate::source::TagEntry {
+                    key: format!("file:{}", path.display()),
+                    display_path: display.clone(),
+                    group_tag: tag.header.group_tag,
+                    group_name: Some("particle_model".to_owned()),
+                    location: crate::source::TagEntryLocation::LooseFile(path.clone()),
+                };
+                checked += 1;
+                match crate::app::model_preview::loading::load_model_preview(
+                    &tag, &tag_entry, &names, None, false,
+                ) {
+                    Ok(data) => {
+                        if data.preview.indices.is_empty() || data.preview.regions.is_empty() {
+                            failures.push(format!("{display}: empty preview"));
+                        }
+                        objects += data.preview.regions.len();
+                    }
+                    Err(e) => failures.push(format!("{display}: {e}")),
+                }
+            }
+        }
+    }
+
+    if checked == 0 {
+        return; // no kits present
+    }
+    assert!(
+        failures.is_empty(),
+        "{} of {checked} particle_models failed to preview:\n  {}",
+        failures.len(),
+        failures.join("\n  "),
+    );
+    eprintln!("[particle_model preview] {checked} tags, {objects} objects");
+}

--- a/src/app/ui/tag_pane.rs
+++ b/src/app/ui/tag_pane.rs
@@ -175,7 +175,7 @@ impl Baboon {
             );
         } else {
             let mut local_model_preview;
-            let model_preview = if is_model_group(entry.group_tag, names) {
+            let model_preview = if is_previewable_geometry_group(entry.group_tag, names) {
                 kit.model_previews.entry(key.clone()).or_default()
             } else {
                 local_model_preview = ModelPreviewState::default();


### PR DESCRIPTION
A `.particle_model` had no preview and no extractor. It now gets both: the
Render Model tab, and an Extract-menu item that writes back the `.jmi` +
JMS source tree tool.exe imported it from.

blam-tags `736e9a7` -> `9546231` (one engine commit) carries the decode.

## What a particle_model is

Per its own schema explanation, "only a shell for containing imported
particle geometry data". `tool.exe`'s `import particle model` merges every
object listed in a **JMI** into one mesh, so both features come down to
splitting that mesh back apart.

A JMI is not a geometry format — it is a CRLF text manifest naming N sibling
object directories whose geometry lives in `<object>/render/<object>.jms`.
Byte layout taken from tool.exe's own writer (`sub_140081030`), the version
floor from its reader (`sub_1401AD920`).

No shipped particle_model has an import-info stream to extract: all 306
across the four kits carry only `tag!`/`want`, and Halo 2's classic tags
have no chunk table at all. The source has to be reconstructed.

## Two things the tag does not say outright

- **The gen3 index buffer is a triangle strip even when the schema says
  otherwise.** 224 of the 266 gen3 tags declare `index buffer type =
  DEFAULT` rather than `triangle strip`, but ~60% have index counts not
  divisible by 3, which rules out a list. (The enum *is* trustworthy on
  `render_model`, where H4 genuinely uses lists — so the two can't share
  the decision.)
- **The strip must be cut at the `m_gpu_data/m_variants` boundaries.**
  There is no `0xFFFF` restart between objects; the variant ranges *are*
  the restarts. Decoding the whole buffer as one strip fabricates triangles
  bridging unrelated objects.

Measured by mean dot(face normal, averaged vertex normal) — correct lands
near +1, a wrong primitive or an uncut strip near 0. On Reach's 7-object
`glass_fragments`:

| decode | score |
|---|---|
| per-variant | **+0.994** |
| whole-buffer strip | +0.015 |
| triangle list | +0.108 |

The variant layout is confirmed against tool.exe's importer and the
symbolled Reach build's `c_particle_model_definition::s_gpu_data::get_variants`,
and holds on all 266 gen3 tags: header count matches entry count and the
ranges tile the index buffer contiguously.

**Halo 2's `PRTM` is a different tag** — a full particle-system definition
that happens to carry geometry — and a richer source: uncompressed
vertices, a triangle *list*, and `models[].model name`, so it recovers the
original object names gen3 discards.

## Verification

Whole shipped corpus, all four kits:

- **Extraction**: 306 tags, 527 objects, 83,002 triangles, zero failures.
  Per-kit face-normal agreement H2 0.957 / H3 0.947 / Reach 0.960 / H4 0.974.
- **Preview**: the same 306 tags through `load_model_preview`, no empty
  viewports, same 527 objects.

Every claim above is pinned by a test that fails without it. I broke each
one deliberately and confirmed the failure: ignoring the variant ranges,
decoding as a list, flipping winding, emptying the stem derivation, using
the one-line `is_model_group` widening, and removing the extract match arm
while leaving the menu item.

## Two design notes

**`is_model_group` is not widened.** It also decides whether a
`tag_reference` is an object's model link, so a `particle` tag's `Model` ->
`pmdf` field would be misread as one and put a model summary on every
particle tag. The panel gate is a separate `is_previewable_geometry_group`.

**The manifest extension is lowercase `.jmi` deliberately.** tool.exe picks
"manifest" over "directory of JMS files" with a case-sensitive
`strncmp(ext, ".jmi", 5)`, so a `.JMI` file is silently treated as a
directory and derives the wrong tag name.

## What is synthesized, and what I did not verify

Gen3 stores no object names (numbered from the tag name), no materials
(`parts` is empty in all 266), and no nodes — a root `frame` and a
placeholder material slot are emitted so the JMS parses. I checked whether
walking the referencing `particle` tag could recover the shader: it cannot
usefully. 41 particle_models have **zero** referencing particles, and among
those with several the referrers disagree on the shader template in 42
cases and on bitmaps in 141 — and the material does not round-trip anyway,
since the tag has no materials block. An honest `default` beats a
plausible-looking name that is right half the time.

Not verified: **that tool.exe re-imports the output** — there is no Windows
machine here, so the format is derived from the writer/reader disassembly
rather than proven by a round trip. Whether a Bungie-era JMI differs from
what the newer `fbx-to-jmi` writer emits is also unknown; 8213 is that
writer's constant and the reader accepts anything above 8207. And the
viewport was not driven interactively — the preview assertions are on the
vertex/index/batch data handed to the renderer, not on pixels.
