### PR TITLE
Draw the LOD a Halo 2 permutation names, not the biggest section in the tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,7 +502,7 @@ dependencies = [
 [[package]]
 name = "blam-tags"
 version = "0.1.0"
-source = "git+https://github.com/Zoephie/blam-tags?rev=cca17a5#cca17a562e4f398aac1c7ef7cef83ffa472c4a35"
+source = "git+https://github.com/camden-smallwood/blam-tags?rev=f8f07ef#f8f07ef73846128c0b5f3c22c2cde00777821cb0"
 dependencies = [
  "anyhow",
  "bcdec_rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,7 +502,7 @@ dependencies = [
 [[package]]
 name = "blam-tags"
 version = "0.1.0"
-source = "git+https://github.com/camden-smallwood/blam-tags?rev=e8576da#e8576da7c5d587919a01caf3d97cc505e14cf673"
+source = "git+https://github.com/camden-smallwood/blam-tags?rev=f6a5d11#f6a5d118ca1c80a3a0867929ab783d7cd1207e24"
 dependencies = [
  "anyhow",
  "bcdec_rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,49 +2,13 @@
 # parent workspace. The blam-tags engine is pinned to a revision, not a
 # submodule.
 #
-# The engine lives at camden-smallwood/blam-tags and the pin belongs there. It
-# points at `fix-h2-lod-section-selection`, which is Zoephie/blam-tags
-# `chimp-header-editing` at `233cbd2` plus one commit, so nothing the previous
-# pin carried is dropped — `233cbd2` is what main pinned, tag-build explanation
-# fields and unnamed customs included. That branch is in turn camden's `master`
-# at `25aa5dc` plus the commits below — #4, which brought cross-game conversion
-# itself, is merged and part of that `master`.
-#
-# The one commit on top is the Halo 2 LOD fix: a permutation now draws the
-# section its own `L1..L6 section index` slots name rather than whichever
-# section is largest, because the vertex-count rule read `total vertex count`
-# off the section element, where it does not live. See the commit for the
-# corpus numbers.
-#
-# Two are fx fixes in flight upstream (camden-smallwood/blam-tags#5): a Reach
-# particle's render method arriving with too few option slots for Halo 4 to
-# open, and contrail_system carrying across as the tracer_system it became. They
-# sit on `halo4-particle-and-tracer`, which this branch was cut from.
-#
-# Two are what Chimp's Header view needs: `FNameMap::rename` with the
-# `visit_names_mut` traversals that keep decoded names from going stale behind
-# it, and a refusal in `add_package_override_to_writer` for an override whose
-# rebuilt package is no longer the one it replaces — that second one is an
-# independent bug fix and worth offering upstream on its own.
-#
-# Three are conversion, and are worth offering upstream on their own too: naming a
-# converted tag after the class it *became* rather than the one it was, which is
-# why a folder import refused a contrail_system into Halo 4 that imported fine
-# one tag at a time; and seeding a conversion from the layout revision the
-# target's definition declares, so two people with different copies of the same
-# editing kit stop getting different tags out of the same import; and seeding a
-# ported fx tag's material with the inputs its render method came with, so the
-# texture reaches the half of a Halo 4 particle that actually draws, which also
-# stopped a converted decal_system crashing Halo 4 the moment it was triggered.
-#
-# The rest are in-place rename: the general package primitive, the tag wrapper
-# over it, and two defects the round-trip found — a container header reading its
-# localized-source set from the wrong list, so any package renamed once could
-# not be moved again, and member enumeration collecting a package's own
-# tombstones. Both are independent bug fixes.
-#
-# The pin is on the camden URL because the Halo 2 fix lives there; the Zoephie
-# commits under it still want landing on camden's `master`.
+# The engine lives at camden-smallwood/blam-tags and the pin points at its
+# `master`. Everything Baboon had been carrying on feature branches — Zoephie's
+# Chimp header-editing and in-place rename work, the cross-game conversion
+# fixes, the tag-build shape fixes the kits' tools require, and the Halo 2 LOD
+# fix — is merged there as of `f6a5d11`, so the pin no longer needs a branch
+# that only exists to hold commits master is missing. Move it by merging into
+# `master` and bumping the rev; there is nothing else to reconcile.
 [workspace]
 members = ["."]
 default-members = ["."]
@@ -63,7 +27,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1"
 atomic-write-file = "0.3"
-blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "e8576da", features = ["audio", "iostore"] }
+blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "f6a5d11", features = ["audio", "iostore"] }
 directories = "6"
 display-info = "0.5"
 eframe = { version = "0.29", default-features = false, features = ["default_fonts", "glow"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,17 @@
 # submodule.
 #
 # The engine lives at camden-smallwood/blam-tags and the pin belongs there. It
-# points at Zoephie/blam-tags `chimp-header-editing`, which is camden's `master`
-# at `25aa5dc` plus the commits below, so nothing upstream is dropped — #4, which
-# brought cross-game conversion itself, is merged and part of that `master`.
+# points at `fix-h2-lod-section-selection`, which is Zoephie/blam-tags
+# `chimp-header-editing` at `cca17a5` plus one commit, so nothing the previous
+# pin carried is dropped. That branch is in turn camden's `master` at `25aa5dc`
+# plus the commits below — #4, which brought cross-game conversion itself, is
+# merged and part of that `master`.
+#
+# The one commit on top is the Halo 2 LOD fix: a permutation now draws the
+# section its own `L1..L6 section index` slots name rather than whichever
+# section is largest, because the vertex-count rule read `total vertex count`
+# off the section element, where it does not live. See the commit for the
+# corpus numbers.
 #
 # Two are fx fixes in flight upstream (camden-smallwood/blam-tags#5): a Reach
 # particle's render method arriving with too few option slots for Halo 4 to
@@ -34,7 +42,8 @@
 # not be moved again, and member enumeration collecting a package's own
 # tombstones. Both are independent bug fixes.
 #
-# Move the pin back to the camden URL once those land.
+# The pin is on the camden URL because the Halo 2 fix lives there; the Zoephie
+# commits under it still want landing on camden's `master`.
 [workspace]
 members = ["."]
 default-members = ["."]
@@ -53,7 +62,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1"
 atomic-write-file = "0.3"
-blam-tags = { git = "https://github.com/Zoephie/blam-tags", rev = "cca17a5", features = ["audio", "iostore"] }
+blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "f8f07ef", features = ["audio", "iostore"] }
 directories = "6"
 display-info = "0.5"
 eframe = { version = "0.29", default-features = false, features = ["default_fonts", "glow"] }


### PR DESCRIPTION
Reported on Discord (PichuFrenzy): more Halo 2 `.model` tags render only part of
their geometry. Following on from #49, which fixed the `LAMB` field offsets
underneath this.

`h_turret_mp` rendered a tripod with no gun. It was drawing its `destroyed`
permutation — one material instead of two, the barrel absent — for `base` as
well, because both permutations resolved to the same section.

## What was wrong

`read_regions` picked a permutation's section by vertex count:

```rust
b.element(s).and_then(|e| e.read_int_any("total vertex count"))
```

`total vertex count` is not a field of the section element. It sits one level
down, in the inline `section info`. Measured over the kit: readable at the
section root in **0 of 3,289** sections, and via `section info/total vertex
count` in **3,289/3,289**, matching the decoded mesh every time.

So every weight was `0`. `max_by_key` keeps the *last* maximum, and for a
single-region model the candidates were every section in the tag — so **every
permutation resolved to the last section**, which is both the identical-variants
symptom and, usually, the wrong level of detail.

## Which end of L1..L6 is the high-detail one

The owning `model` (hlmt) states the ladder as `reduce to L1` … `reduce to L5` —
the distances at which the object drops to that level. Swept the kit: **strictly
descending in all 224 models that state more than one distinct distance,
ascending in 0** (mongoose 36.1, 32.1, 20.0, 18.0, 0.0). `reduce to L1` is the
farthest, so L1 is what you see far away and **L6 what you see up close**, which
is what a preview should draw. That is also what the JMS extractor already
walked.

The vertex-count rule was a workaround for the offset bug #49 fixed, not for
anything in the data. Its comment cited `rocket_launcher`'s "stale" L1/L2 of
24932/25714 — `rocket_launcher` is a `LAMB` tag and those were fields read 28
bytes early. Its ladder reads cleanly now (L1 56v, L2-3 702v, L4-6 1458v), and
**0 of 3,289 sections are named by no permutation**, so there is nothing to
recover by guessing at sizes.

## Gate — 1,095 render_models, 2,042 permutations

| | old | new |
|---|---|---|
| regions whose permutations all collapse to ONE section | **33** | **0** |
| resolution unchanged | — | 1,999 |
| changed | — | 43 (22 larger, 18 smaller, 3 same size) |
| unresolved (-1) | 0 | 0 |
| preview vertices across the kit | 948,914 | 954,013 |

The 18 "smaller" are the collapse being undone — those permutations had been
showing another permutation's geometry.

Reported models: `c_turret_ap` 85 → 3,007 vertices, `h_turret_mp` 714 → 1,222
with `base` (865, tripod + gun shaders) and `destroyed` (357, tripod only) now
distinct, `rocket_launcher` → 1,458.

Markers needed no work — #49 already fixed them. Kit sweep: 2,407 groups, 0
unnamed; 4,019 markers, 0 on an out-of-range node, 0 non-finite.

## Engine

`cca17a5` → `f8f07ef`, one commit sitting directly on `cca17a5`, so nothing the
previous pin carried is dropped. The URL moves to `camden-smallwood/blam-tags`,
where that branch is Zoephie's `chimp-header-editing` plus this fix.

Rebased onto `zoephie/main` `7efb470` after the pin moved `ff3080f` → `cca17a5`
mid-review; the engine commit was rebased onto the new tip to match. Only
`Cargo.toml`/`Cargo.lock` conflicted, and only on the pin line.

Gated test `halo2_permutation_draws_the_section_its_own_lod_slots_name`
(`H2_TAGS` + `H2_DEFS`), verified to fail on the old rule (`left: 5, right: 4`).
322 engine lib tests pass.

## What I did not verify

The corpus numbers are measured, but nothing here was confirmed in-game — the
claim is that the preview now draws the section the tag names, not that every
one of the 43 changed permutations looks right on screen. One ignored engine
test, `convert::chain_sweep::write_converted_samples_into_kits`, fails on this
machine wanting the conversion kits installed; it is unrelated and fails the
same way on the base.
