### PR TITLE
Export a copied tag with the wrapper it was copied from

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,7 +502,7 @@ dependencies = [
 [[package]]
 name = "blam-tags"
 version = "0.1.0"
-source = "git+https://github.com/camden-smallwood/blam-tags?rev=f6a5d11#f6a5d118ca1c80a3a0867929ab783d7cd1207e24"
+source = "git+https://github.com/camden-smallwood/blam-tags?rev=312171d#312171ddac2d36fe3da9bd5abfc3c21cebbbbdc0"
 dependencies = [
  "anyhow",
  "bcdec_rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@
 # `master`. Everything Baboon had been carrying on feature branches — Zoephie's
 # Chimp header-editing and in-place rename work, the cross-game conversion
 # fixes, the tag-build shape fixes the kits' tools require, and the Halo 2 LOD
-# fix — is merged there as of `f6a5d11`, so the pin no longer needs a branch
+# fix — is merged there as of `312171d`, so the pin no longer needs a branch
 # that only exists to hold commits master is missing. Move it by merging into
 # `master` and bumping the rev; there is nothing else to reconcile.
 [workspace]
@@ -27,7 +27,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1"
 atomic-write-file = "0.3"
-blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "f6a5d11", features = ["audio", "iostore"] }
+blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "312171d", features = ["audio", "iostore"] }
 directories = "6"
 display-info = "0.5"
 eframe = { version = "0.29", default-features = false, features = ["default_fonts", "glow"] }

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -580,6 +580,29 @@ pub(in crate::app) fn classify_overlay(
     }
 }
 
+/// Which wrapper the exporter hands the writer for a tag it writes whole.
+///
+/// The two ways a tag reaches that path want opposite treatment, and the
+/// difference is already in the location. A copy Baboon made sits in a
+/// container under `Container`, and the `.uasset` resolved for it is the tag it
+/// was copied from — so its bindings are this tag's bindings. A tag authored
+/// through New Tag sits under `NewContainer` with a *donor* recorded, some
+/// unrelated tag that supplies structure only.
+///
+/// Getting this backwards is not a loud failure: an authored tag that kept its
+/// donor's bindings presents as the donor, and a copy that lost its own
+/// presents as nothing at all.
+pub(in crate::app) fn wrapper_origin_for(
+    location: &TagEntryLocation,
+) -> Option<blam_tags::iostore::writer::WrapperOrigin> {
+    use blam_tags::iostore::writer::WrapperOrigin;
+    match location {
+        TagEntryLocation::Container { .. } => Some(WrapperOrigin::Copy),
+        TagEntryLocation::NewContainer { .. } => Some(WrapperOrigin::Template),
+        _ => None,
+    }
+}
+
 impl Baboon {
     /// Resolve (and cache) the Wwise media a Campaign Evolved `sound` tag binds
     /// to. Returns `None` for every other game and source kind.
@@ -5206,7 +5229,15 @@ impl Baboon {
             String,
             std::sync::Arc<Vec<u8>>,
         )> = Vec::new();
-        let mut new_pkgs: Vec<(Vec<u8>, std::sync::Arc<Vec<u8>>, String)> = Vec::new();
+        // The origin rides along because the two ways a tag gets here want
+        // opposite treatment of the wrapper: a copy keeps the bindings of what
+        // it was copied from, an authored tag must not inherit its donor's.
+        let mut new_pkgs: Vec<(
+            Vec<u8>,
+            std::sync::Arc<Vec<u8>>,
+            String,
+            blam_tags::iostore::writer::WrapperOrigin,
+        )> = Vec::new();
         let mut skipped = 0usize;
         for overlay in snapshot.overlays.values() {
             if !included.contains(&overlay.identity) {
@@ -5248,7 +5279,16 @@ impl Baboon {
                         skipped += 1;
                         continue;
                     };
-                    new_pkgs.push((template, overlay.bytes.clone(), package));
+                    // A copy Baboon made: the template resolved just above is
+                    // the very tag it was copied from, so its wrapper is this
+                    // tag's wrapper. Stripping it would drop the Blueprint the
+                    // copy presents as, and for a model would refuse the export
+                    // outright over the region table it still names.
+                    let Some(origin) = wrapper_origin_for(&entry.location) else {
+                        skipped += 1;
+                        continue;
+                    };
+                    new_pkgs.push((template, overlay.bytes.clone(), package, origin));
                 }
                 TagEntryLocation::Container {
                     container,
@@ -5284,7 +5324,13 @@ impl Baboon {
                         skipped += 1;
                         continue;
                     };
-                    new_pkgs.push((template, overlay.bytes.clone(), package.clone()));
+                    // Authored from a recorded donor, which is some other tag:
+                    // its bindings say nothing true about this one.
+                    let Some(origin) = wrapper_origin_for(&entry.location) else {
+                        skipped += 1;
+                        continue;
+                    };
+                    new_pkgs.push((template, overlay.bytes.clone(), package.clone(), origin));
                 }
                 _ => skipped += 1,
             }
@@ -5327,14 +5373,16 @@ impl Baboon {
         let new_refs: Vec<blam_tags::iostore::writer::NewPackage> = new_pkgs
             .iter()
             .map(
-                |(template, bytes, package)| blam_tags::iostore::writer::NewPackage {
+                |(template, bytes, package, origin)| blam_tags::iostore::writer::NewPackage {
                     template_uasset: template.as_slice(),
                     tag_bytes: bytes.as_slice(),
                     new_package_path: package.as_str(),
                     redirect_from: None,
-                    // A new tag's wrapper is built from the template with the
-                    // donor's own bindings stripped; nothing here chooses one.
+                    // Only ever set deliberately, and nothing here chooses one:
+                    // an authored tag gets none, and a copy keeps whatever its
+                    // original had rather than being handed a new one.
                     asset_reference: None,
+                    origin: *origin,
                 },
             )
             .collect();

--- a/src/app/tests/classic_h2.rs
+++ b/src/app/tests/classic_h2.rs
@@ -24,9 +24,16 @@ fn h2_particle_mapping_field_edit_targets_exact_field() {
             .find(|f| f.name() == "color" && f.as_struct().is_some())
             .expect("color struct");
         let color = color_field.as_struct().unwrap();
+        // `color` used to hold two fields named `Mapping` -- the struct, and a
+        // `custom` placeholder ahead of it -- and this reached the struct
+        // through that ambiguity. The ambiguity was Baboon's own: a
+        // kit-authored layout names no `custom`, and once the builder stopped
+        // naming them the duplicate went away. The placeholder is still there,
+        // unnamed. Disambiguation against a duplicate a tag really has is
+        // gated by `h2_contrail_derived_path_targets_the_second_duplicate`.
         assert!(
-            color.field("Mapping").and_then(|f| f.as_struct()).is_none(),
-            "first 'Mapping' should be the non-struct custom placeholder"
+            color.fields_all().any(|f| f.name().is_empty()),
+            "the custom placeholder should still be there, just unnamed"
         );
         let mapping_field = color
             .fields_all()
@@ -52,6 +59,57 @@ fn h2_particle_mapping_field_edit_targets_exact_field() {
         matches!(value, Some(TagFieldData::CharInteger(4))),
         "Function Type not set via positional path: {value:?}"
     );
+}
+
+/// The path the editor derives for a field must reach *that* field, when the
+/// tag really does name two the same.
+///
+/// This is the case positional paths exist for. It runs against a duplicate an
+/// H2 contrail actually ships -- `bitmap` twice at the root -- rather than one
+/// Baboon created for itself by naming a `custom`, which is what the particle
+/// fixture above used to rely on. 709 of the kit's 28,195 tags carry a real
+/// duplicate.
+#[test]
+fn h2_contrail_derived_path_targets_the_second_duplicate() {
+    let tag_path = "/Users/camden/Halo/halo2_mcc/tags/effects/objects/weapons/rifle/sniper_rifle/sniper.contrail";
+    let def = test_definition_path("halo2_mcc/contrail.json");
+    if !std::path::Path::new(tag_path).exists() || !std::path::Path::new(&def).exists() {
+        eprintln!("skipping: H2 contrail/definition not present");
+        return;
+    }
+    let bytes = std::fs::read(tag_path).unwrap();
+    let layout = blam_tags::layout::TagLayout::from_json(&def).unwrap();
+    let tag = blam_tags::classic::read_classic_tag_file(&bytes, layout).unwrap();
+    let root = tag.root();
+
+    let duplicates: Vec<_> = root.fields_all().filter(|f| f.name() == "bitmap").collect();
+    assert_eq!(
+        duplicates.len(),
+        2,
+        "this contrail should declare `bitmap` twice"
+    );
+
+    // Derive each path the way the editor does, then resolve it back. The
+    // second is the one a bare name can never reach.
+    for field in &duplicates {
+        let path = append_field_path_for("", field);
+        let resolved = root
+            .field_path(&path)
+            .unwrap_or_else(|| panic!("derived path {path} no longer resolves"));
+        assert_eq!(
+            resolved.ordinal(),
+            field.ordinal(),
+            "derived path {path} resolved to a different field"
+        );
+    }
+
+    // And the two really are distinct, so the loop above is not passing by
+    // resolving the same field twice.
+    let derived: Vec<String> = duplicates
+        .iter()
+        .map(|f| append_field_path_for("", f))
+        .collect();
+    assert_ne!(derived[0], derived[1], "both duplicates derived one path");
 }
 
 fn load_h2_tag(tag_path: &str, def_rel: &str) -> Option<blam_tags::TagFile> {

--- a/src/app/tests/mod_overrides.rs
+++ b/src/app/tests/mod_overrides.rs
@@ -598,3 +598,55 @@ fn an_overlay_identical_to_the_shipped_tag_is_not_a_change() {
         ModExportChange::Unresolved
     );
 }
+
+/// A copy and an authored tag are handed different wrappers, and the location
+/// is what decides.
+///
+/// Both reach the exporter as `CampaignProjectTagKind::New` and are written
+/// whole, so the kind cannot tell them apart — the location can. A copy Baboon
+/// made lives in a container, and the `.uasset` resolved for it is the tag it
+/// was copied from; a tag from New Tag lives in a `NewContainer` with a donor
+/// recorded against it.
+///
+/// This is gated because getting it backwards fails quietly in both directions.
+/// A copy stripped of its wrapper exports fine and presents as nothing in game —
+/// which is what shipped, and what users hit as an export that could never
+/// succeed once the tag was a `model`, since a model's wrapper names a region
+/// string table that stripping orphans.
+#[test]
+fn a_copy_keeps_its_wrapper_and_an_authored_tag_does_not() {
+    use blam_tags::iostore::writer::WrapperOrigin;
+
+    // A copy: it sits in a container like any other tag.
+    assert_eq!(
+        wrapper_origin_for(&TagEntryLocation::Container {
+            container: 0,
+            rel_path: "Meteorite/Content/Tags/objects/x/y-model.ubulk".to_owned(),
+        }),
+        Some(WrapperOrigin::Copy),
+        "a copy must keep the bindings of the tag it was copied from"
+    );
+
+    // Authored through New Tag, both ways a wrapper is obtained: donated from
+    // an unrelated same-group tag, or derived from the group's own rules.
+    // Neither carries bindings that belong to the tag being created.
+    for template in [
+        NewContainerTemplate::Donor {
+            container: 0,
+            rel_path: "Meteorite/Content/Tags/objects/other/donor-model.ubulk".to_owned(),
+        },
+        NewContainerTemplate::Derived {
+            group: "model".to_owned(),
+        },
+    ] {
+        assert_eq!(
+            wrapper_origin_for(&TagEntryLocation::NewContainer {
+                template,
+                package: "/Game/Tags/objects/x/y-model".to_owned(),
+                group_tag: u32::from_be_bytes(*b"mode"),
+            }),
+            Some(WrapperOrigin::Template),
+            "an authored tag must not inherit its donor's bindings"
+        );
+    }
+}


### PR DESCRIPTION
A user on the development branch reported that any tag duplicated since the last
few updates could never be exported: *"will never allow the mod to export, no
matter the tag or change made"*. The status bar named it — `a donated wrapper
kept an import reference after sanitizing. Nothing was exported.`

Reproduced locally against the shipped corpus, with their exact tag.

## What was wrong

Both ways a tag reaches the whole-package export path want **opposite**
treatment of its `.uasset` wrapper, and the exporter treated them the same:

| | donor is | bindings |
|---|---|---|
| **New Tag** | an unrelated same-group tag, supplying structure | must be stripped |
| **Duplicate** | the tag being copied | *are* the copy's own |

Everything went out as a donation and got stripped. That is right for New Tag —
it is what `blam-tags@06b1d4e` was written for — and backwards for a copy.

**The loud half is `model`.** Stripping rebuilds the import map from the script
slots alone, on the stated premise that every package import served
`AssetReference` or `CookedAssetsReferencedByTag`. `BlamModelTagDataAsset` has a
third: `ModelRegionStringTable`. Sweeping all 12,329 shipped wrappers (12,161
decoded), it is the **only** object property that survives the strip — every
other one is `AssetReference` — and it is on **364 models**. Dropping its import
left it dangling, and the writer correctly refused.

**The quiet half is worse.** A copied biped exported *fine* with an empty
property block — donor `["AssetReference", "CookedAssetsReferencedByTag"]` →
copy `[]`. It silently lost the Blueprint it presents as. Anyone who duplicated
a tag since that engine change has likely shipped one.

## The fix

`NewPackage` gains `origin`. A copy carries its wrapper over whole — bindings
and import map alike — and only identity is retargeted; the group is checked
rather than assumed. A template still strips. Baboon routes on the location,
which already distinguishes the two.

Keeping the reference rather than copying the asset is what the shipped data
does: 364 models share 118 region tables, 214 of them one default, and six
Marine models share `DA_Marine_Regions`. It is also the documented UE practice —
mod content should reference base-game assets rather than duplicate them.

## Also: a failing test on main

`h2_particle_mapping_field_edit_targets_exact_field` has been red since
`blam-tags@233cbd2`. It reached a particle's `Mapping` struct through an earlier
field of the same name, and that name was **ours** — a kit-authored layout names
no `custom`, which is exactly what that commit fixed. So the ambiguity was
self-inflicted and removing it was correct; the fixture was what went stale.

Positional paths are *not* redundant: **709 of 28,195** H2 tags carry a real
duplicate (1,153 sites). The gate moves to one — an H2 contrail names `bitmap`
twice at its root — and asserts the path the editor *derives* for each resolves
back to that one.

## Verification

- Corpus gate on a real `model` donor, **with the control that disagrees**: the
  same donor written as a template still fails, so the copy passing means the
  origin was read and not that the guard stopped applying.
- Engine `509 passed / 0 failed` (was 507/1 — that 1 is the regression above).
- Baboon `733 passed / 0 failed` (was 731/1).
- Verified against the pushed engine rev with the local `[patch]` removed.

blam-tags `f6a5d11` → `312171d`.