### PR TITLE
Extract a single folder's tags from the browser right-click

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,16 @@ memory**, and exporting a mod is the way changes are committed:
   provides are counted as skipped. It is tens of thousands of decompressed reads
   and file writes, so it confirms first, reports progress in the status bar, and
   can be cancelled from there; Baboon stays usable while it runs.
+- **Extract tags to folder…** (right-click a folder in the browser) — the same
+  extraction aimed at one folder instead of the whole workspace, and **not**
+  Expert-gated: the scope is bounded and deliberately chosen. The count in the
+  menu is what actually gets written — tags authored this session have no shipped
+  payload to read, so they are excluded from it rather than promised and skipped.
+  Tags keep their **full** paths, so the result lands under `objects/characters/…`
+  inside the folder you pick and several folder extractions into one destination
+  merge into a single **Load Folder**-able kit. Offered in *Folders* mode only: a
+  *Groups* node is a group label rather than a folder, and the on-disk layout
+  follows the tags' own paths, so the result would not resemble the node clicked.
 
 Any in-place write to a container **drops that pak's perfect-hash lookup table**.
 The table maps a chunk id to a *slot* in the chunk-id array, so both the chunk

--- a/src/app/browser/tree.rs
+++ b/src/app/browser/tree.rs
@@ -719,6 +719,30 @@ pub(in crate::app) fn draw_tree_node(
             ui.close_menu();
         }
 
+        // Folders mode only. In Groups mode this node is a group label rather
+        // than a folder, and the extraction lays tags out by their own paths —
+        // so a group node would write a tree that has nothing to do with the
+        // node that was clicked.
+        if is_container && !groups_mode {
+            let container_keys = collect_container_tag_keys(node, entries);
+            if container_keys.is_empty() {
+                ui.label(RichText::new("No shipped tags in this folder").color(subtle_dark()));
+            } else if ui
+                .button(format!("Extract tags to folder... ({})", container_keys.len()))
+                .on_hover_text(
+                    "Write every tag this folder ships to a folder on disk, laid out like an \
+                     editing kit",
+                )
+                .clicked()
+            {
+                clicked = Some(BrowserAction::ExtractContainerFolderTags {
+                    label: folder_display_path(node),
+                    keys: container_keys,
+                });
+                ui.close_menu();
+            }
+        }
+
         let bitmap_keys = collect_bitmap_keys(node, entries);
         if bitmap_keys.is_empty() {
             ui.label(RichText::new("No bitmap tags in this folder").color(subtle_dark()));
@@ -938,6 +962,47 @@ pub(in crate::app) fn collect_tag_keys_into(
     }
     for child in &node.children {
         collect_tag_keys_into(child, entries, keys);
+    }
+}
+
+/// A folder node's path for display, in the forward-slash form the rest of the
+/// container UI uses. Falls back to the node's own label for a node with no
+/// relative path, so the root still names itself in a confirmation.
+fn folder_display_path(node: &TagTreeNode) -> String {
+    let rel = node.rel_path.to_string_lossy().replace('\\', "/");
+    if rel.is_empty() { node.label.clone() } else { rel }
+}
+
+/// Keys beneath `node` for tags the container actually ships.
+///
+/// Deliberately narrower than [`collect_tag_keys`]: the extraction reads each
+/// tag's shipped payload back out of the mounted `.ucas`, so an entry authored
+/// in this session has nothing to read and is silently skipped by the worker.
+/// Counting those would put a number in the menu that the run then fails to
+/// deliver, so they are excluded here and the label reports what will be written.
+pub(in crate::app) fn collect_container_tag_keys(
+    node: &TagTreeNode,
+    entries: &[TagEntry],
+) -> Vec<String> {
+    let mut keys = Vec::new();
+    collect_container_tag_keys_into(node, entries, &mut keys);
+    keys
+}
+
+fn collect_container_tag_keys_into(
+    node: &TagTreeNode,
+    entries: &[TagEntry],
+    keys: &mut Vec<String>,
+) {
+    for &entry_index in &node.entries {
+        if let Some(entry) = entries.get(entry_index) {
+            if matches!(entry.location, TagEntryLocation::Container { .. }) {
+                keys.push(entry.key.clone());
+            }
+        }
+    }
+    for child in &node.children {
+        collect_container_tag_keys_into(child, entries, keys);
     }
 }
 

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -518,6 +518,37 @@ fn ensure_export_directory(output: &Path) -> Result<(), String> {
         .map_err(|error| format!("Could not create {}: {error}", directory.display()))
 }
 
+/// The entries an extraction covers, resolved by one function so the count shown
+/// in the confirmation and the set handed to the worker cannot disagree.
+///
+/// `Container` is the only location with a shipped payload to read, so both
+/// scopes filter on it — a folder holding nothing but tags authored this session
+/// resolves to empty here rather than starting a run that writes no files.
+///
+/// Borrows rather than clones: the confirmation only needs to count, and cloning
+/// twelve thousand entries to call `.len()` on them is a waste the user pays for
+/// in the gap between picking a folder and seeing the dialog.
+fn container_dump_entries<'a>(
+    entries: &'a [TagEntry],
+    scope: &ContainerDumpScope,
+) -> Vec<&'a TagEntry> {
+    let wanted = match scope {
+        ContainerDumpScope::AllShipped => None,
+        ContainerDumpScope::Folder { keys, .. } => {
+            Some(keys.iter().map(String::as_str).collect::<HashSet<_>>())
+        }
+    };
+    entries
+        .iter()
+        .filter(|entry| matches!(entry.location, TagEntryLocation::Container { .. }))
+        .filter(|entry| {
+            wanted
+                .as_ref()
+                .is_none_or(|keys| keys.contains(entry.key.as_str()))
+        })
+        .collect()
+}
+
 /// Create the folder a mod is about to be written into.
 fn ensure_mod_output_dir(output: &Path) -> Result<(), String> {
     let Some(directory) = output.parent() else {
@@ -3539,6 +3570,9 @@ impl Baboon {
             BrowserAction::ExtractHlslIncludeFolder(keys) => {
                 self.begin_extract_hlsl_include_folder(keys, ctx)
             }
+            BrowserAction::ExtractContainerFolderTags { label, keys } => {
+                self.begin_extract_container_folder_tags(label, keys)
+            }
             BrowserAction::ExtractScenarioScripts(key) => {
                 self.begin_extract_scenario_scripts(key, ctx)
             }
@@ -3928,12 +3962,31 @@ impl Baboon {
     ///
     /// Expert-only, and re-checked here rather than trusting the menu: this is
     /// the one action in the application that writes tens of thousands of files
-    /// in one go, and it should not be reachable by a stale request.
+    /// in one go, and it should not be reachable by a stale request. The folder-
+    /// scoped twin below carries no such gate, because it is bounded and aimed.
     pub(super) fn begin_extract_all_container_tags(&mut self, _ctx: egui::Context) {
         if !self.expert_mode {
             self.status = "Extracting all tags requires Expert mode".to_owned();
             return;
         }
+        self.raise_container_dump_confirm(ContainerDumpScope::AllShipped, "Extract All Tags");
+    }
+
+    /// Asks where to put the shipped tags beneath one browser folder.
+    ///
+    /// The keys are the ones collected when the menu was drawn, so what runs is
+    /// what the count in the menu promised.
+    pub(super) fn begin_extract_container_folder_tags(&mut self, label: String, keys: Vec<String>) {
+        self.raise_container_dump_confirm(
+            ContainerDumpScope::Folder { label, keys },
+            "Extract Folder Tags",
+        );
+    }
+
+    /// The shared front half of both extractions: refuse to stack a second run,
+    /// require a container mount, count what the scope actually covers, pick a
+    /// destination, and keep that destination out of the game's own Paks folder.
+    fn raise_container_dump_confirm(&mut self, scope: ContainerDumpScope, dialog_title: &str) {
         if self.container_dump_job.is_some() {
             self.status = "An extraction is already running".to_owned();
             return;
@@ -3942,33 +3995,36 @@ impl Baboon {
             return;
         };
         let TagSource::IoStoreContainerSet { root, .. } = &source_data.source else {
-            self.status = "Extracting all tags needs a Campaign Evolved container".to_owned();
+            self.status = "Extracting tags needs a Campaign Evolved container".to_owned();
             return;
         };
         let root = root.clone();
         // A container mount enumerates every tag up front, so this is the whole
         // set — there is no background scan to wait on first.
-        let total = source_data
-            .entries
-            .iter()
-            .filter(|entry| matches!(entry.location, TagEntryLocation::Container { .. }))
-            .count();
+        let total = container_dump_entries(&source_data.entries, &scope).len();
         if total == 0 {
-            self.status = "This workspace has no container tags to extract".to_owned();
+            self.status = match &scope {
+                ContainerDumpScope::AllShipped => {
+                    "This workspace has no container tags to extract".to_owned()
+                }
+                ContainerDumpScope::Folder { label, .. } => {
+                    format!("{label} has no shipped tags to extract")
+                }
+            };
             return;
         }
         let Some(output) = rfd::FileDialog::new()
-            .set_title("Extract All Tags")
+            .set_title(dialog_title)
             .pick_folder()
         else {
             return;
         };
-        // Tens of thousands of files landing in the game's own Paks folder would
-        // be found by the next mount and are a nuisance to unpick by hand.
+        // Files landing in the game's own Paks folder would be found by the next
+        // mount and are a nuisance to unpick by hand.
         if output.starts_with(&root) {
             self.status = format!(
                 "Choose a folder outside {} — extracting into the game's own Paks folder would \
-                 leave tens of thousands of files beside its containers",
+                 leave the extracted tags beside its containers",
                 root.display()
             );
             return;
@@ -3977,11 +4033,18 @@ impl Baboon {
             kit: self.active_kit_id(),
             output,
             total,
+            scope,
         });
     }
 
     /// Runs the confirmed extraction on a worker thread.
-    pub(super) fn start_container_dump(&mut self, kit: KitId, output: PathBuf, ctx: egui::Context) {
+    pub(super) fn start_container_dump(
+        &mut self,
+        kit: KitId,
+        output: PathBuf,
+        scope: ContainerDumpScope,
+        ctx: egui::Context,
+    ) {
         if self.container_dump_job.is_some() {
             self.status = "An extraction is already running".to_owned();
             return;
@@ -3995,15 +4058,23 @@ impl Baboon {
         // Cloning the source is cheap: the mounted archives are behind `Arc`, so
         // this shares them rather than re-mapping the containers.
         let source = source_data.source.clone();
-        let entries: Vec<TagEntry> = source_data
-            .entries
-            .iter()
-            .filter(|entry| matches!(entry.location, TagEntryLocation::Container { .. }))
+        // Re-resolved rather than carried over from the confirmation: the user
+        // can edit the workspace while a modeless confirm is up, so this is the
+        // set as it stands at the moment the run actually starts.
+        let entries: Vec<TagEntry> = container_dump_entries(&source_data.entries, &scope)
+            .into_iter()
             .cloned()
             .collect();
         let total = entries.len();
         if total == 0 {
-            self.status = "This workspace has no container tags to extract".to_owned();
+            self.status = match &scope {
+                ContainerDumpScope::AllShipped => {
+                    "This workspace has no container tags to extract".to_owned()
+                }
+                ContainerDumpScope::Folder { label, .. } => {
+                    format!("{label} has no shipped tags to extract")
+                }
+            };
             return;
         }
         let stamp = KitStamp {
@@ -8244,6 +8315,10 @@ mod campaign_new_tag_tests;
 #[cfg(test)]
 #[path = "tests/campaign_import_gate.rs"]
 mod campaign_import_gate_tests;
+
+#[cfg(test)]
+#[path = "tests/container_folder_extract.rs"]
+mod container_folder_extract_tests;
 
 enum SaveChangesPromptAction {
     None,

--- a/src/app/state/browser.rs
+++ b/src/app/state/browser.rs
@@ -30,6 +30,11 @@ pub(in crate::app) enum BrowserAction {
     ExtractMaterialShaderSourceFolder(Vec<String>),
     ExtractHlslIncludeSource(String),
     ExtractHlslIncludeFolder(Vec<String>),
+    /// Write every shipped tag beneath one container folder to a chosen folder,
+    /// laid out like an editing kit. The narrow-scope twin of File → Extract All
+    /// Tags to Folder, and it shares that action's worker, progress and cancel.
+    /// `label` is the folder's display path, carried for the confirmation only.
+    ExtractContainerFolderTags { label: String, keys: Vec<String>, },
     /// Write a scenario's `source files` block out as a folder of `.hsc` files.
     ExtractScenarioScripts(String),
     /// Replace a scenario's `source files` block from a folder of `.hsc` files.

--- a/src/app/state/documents.rs
+++ b/src/app/state/documents.rs
@@ -698,16 +698,35 @@ pub(in crate::app) struct ContainerDuplicateConfirm {
     pub(in crate::app) destination_leaf: String,
 }
 
-/// Mandatory confirmation for extracting every shipped tag in a container set.
+/// Mandatory confirmation for extracting shipped tags out of a container set.
 ///
 /// Not destructive, but expensive enough to be worth a deliberate answer: it is
-/// tens of thousands of decompressed reads and file writes, and the user has to
-/// know that before it starts rather than three minutes into a frozen-looking
+/// thousands of decompressed reads and file writes, and the user has to know
+/// that before it starts rather than three minutes into a frozen-looking
 /// window. Carries its workspace like the other modeless confirms.
 pub(in crate::app) struct ContainerDumpConfirm {
     pub(in crate::app) kit: KitId,
     pub(in crate::app) output: PathBuf,
     pub(in crate::app) total: usize,
+    pub(in crate::app) scope: ContainerDumpScope,
+}
+
+/// Which shipped tags an extraction covers.
+///
+/// The scope is captured when the confirmation is raised rather than re-derived
+/// when it is accepted. A modeless confirm outlives the frame that opened it, and
+/// a folder's membership is a snapshot of the tree the user right-clicked: making
+/// the run re-walk the workspace on accept would let an import or a delete in
+/// between silently change what gets written.
+pub(in crate::app) enum ContainerDumpScope {
+    /// Every `Container` entry in the workspace — the File menu action.
+    AllShipped,
+    /// Just the tags beneath one browser folder, captured at right-click.
+    /// `label` is the folder's display path, for the confirmation wording.
+    Folder {
+        label: String,
+        keys: Vec<String>,
+    },
 }
 
 /// The outcome of a container write, kept on screen until dismissed.

--- a/src/app/tests/container_folder_extract.rs
+++ b/src/app/tests/container_folder_extract.rs
@@ -1,0 +1,213 @@
+//! Right-click → Extract tags to folder, on a Campaign Evolved container.
+//!
+//! The narrow-scope twin of File → Extract All Tags to Folder. It shares that
+//! action's worker, progress bar and cancel, so the only thing that is actually
+//! new is *which* entries reach the worker — which is what these gates cover.
+//!
+//! Both halves are tested against a case where the answers differ. A folder
+//! scope that quietly resolved to every tag in the workspace would still pass a
+//! test whose fixture only holds one folder, so every fixture here holds two.
+
+use super::*;
+
+/// A mounted container tag, as the browser would have indexed it.
+fn container_entry(path: &str) -> TagEntry {
+    TagEntry {
+        key: format!("ublock:pakchunk0:{path}"),
+        display_path: format!("{path}.bitmap"),
+        group_tag: u32::from_be_bytes(*b"bitm"),
+        group_name: Some("bitmap".to_owned()),
+        location: TagEntryLocation::Container {
+            container: 0,
+            rel_path: format!("Tags/{path}-bitmap.ubulk"),
+        },
+    }
+}
+
+/// A tag authored this session: in the tree, but with no shipped payload behind
+/// it to read back out of the container.
+fn new_container_entry(path: &str) -> TagEntry {
+    TagEntry {
+        key: format!("ublock:new:{path}"),
+        display_path: format!("{path}.bitmap"),
+        group_tag: u32::from_be_bytes(*b"bitm"),
+        group_name: Some("bitmap".to_owned()),
+        location: TagEntryLocation::NewContainer {
+            template: NewContainerTemplate::Derived {
+                group: "bitmap".to_owned(),
+            },
+            package: format!("/Game/Tags/{path}"),
+            group_tag: u32::from_be_bytes(*b"bitm"),
+        },
+    }
+}
+
+fn keys_of(entries: &[TagEntry]) -> Vec<String> {
+    entries.iter().map(|entry| entry.key.clone()).collect()
+}
+
+fn extracted_paths(entries: &[TagEntry], scope: &ContainerDumpScope) -> Vec<String> {
+    container_dump_entries(entries, scope)
+        .iter()
+        .map(|entry| entry.display_path.clone())
+        .collect()
+}
+
+fn folder(label: &str, keys: Vec<String>) -> ContainerDumpScope {
+    ContainerDumpScope::Folder {
+        label: label.to_owned(),
+        keys,
+    }
+}
+
+/// The point of the feature. The workspace holds two folders, so a scope that
+/// ignored its keys and fell through to "everything" would fail here rather
+/// than agreeing by accident.
+#[test]
+fn a_folder_scope_extracts_only_that_folder() {
+    let entries = vec![
+        container_entry("objects/characters/elite/elite"),
+        container_entry("objects/characters/elite/elite_helmet"),
+        container_entry("objects/vehicles/ghost/ghost"),
+    ];
+    let elite = keys_of(&entries[..2]);
+
+    assert_eq!(
+        extracted_paths(&entries, &folder("objects/characters/elite", elite)),
+        vec![
+            "objects/characters/elite/elite.bitmap",
+            "objects/characters/elite/elite_helmet.bitmap",
+        ],
+    );
+    // The same fixture, unscoped, reaches the third tag — so the assertion
+    // above is a restriction and not a description of the whole workspace.
+    assert_eq!(
+        extracted_paths(&entries, &ContainerDumpScope::AllShipped).len(),
+        3,
+    );
+}
+
+/// The count in the menu label and the set handed to the worker come from the
+/// same filter, so a folder holding an unsaved tag cannot promise a file that
+/// never gets written. `dump_shipped_container_tags` skips such an entry
+/// silently, which is exactly the kind of gap a count would paper over.
+#[test]
+fn a_tag_authored_this_session_is_not_extracted() {
+    let entries = vec![
+        container_entry("objects/characters/elite/elite"),
+        new_container_entry("objects/characters/elite/elite_custom"),
+    ];
+    let both = keys_of(&entries);
+
+    assert_eq!(
+        extracted_paths(&entries, &folder("objects/characters/elite", both)),
+        vec!["objects/characters/elite/elite.bitmap"],
+    );
+}
+
+/// A folder whose every tag was authored this session resolves to nothing, and
+/// the caller turns that into a status message instead of starting a run that
+/// writes no files.
+#[test]
+fn a_folder_of_only_unsaved_tags_resolves_to_nothing() {
+    let entries = vec![new_container_entry("objects/mine/thing")];
+    let keys = keys_of(&entries);
+
+    assert!(container_dump_entries(&entries, &folder("objects/mine", keys)).is_empty());
+}
+
+/// Keys are matched against the entries actually present, so a key for a tag
+/// that has since been deleted drops out rather than aborting the run. The
+/// captured scope outlives the frame that built it, and the workspace can move
+/// under it.
+#[test]
+fn a_key_with_no_surviving_entry_is_dropped() {
+    let entries = vec![container_entry("objects/characters/elite/elite")];
+    let mut keys = keys_of(&entries);
+    keys.push("ublock:pakchunk0:objects/characters/elite/deleted".to_owned());
+
+    assert_eq!(
+        extracted_paths(&entries, &folder("objects/characters/elite", keys)),
+        vec!["objects/characters/elite/elite.bitmap"],
+    );
+}
+
+/// A browser folder node holding `entry_indices`, with `children` beneath it.
+fn node(label: &str, entry_indices: &[usize], children: Vec<TagTreeNode>) -> TagTreeNode {
+    TagTreeNode {
+        label: label.to_owned(),
+        rel_path: std::path::PathBuf::from(label),
+        children,
+        children_loaded: true,
+        entries: entry_indices.to_vec(),
+        entries_loaded: true,
+        pending: false,
+    }
+}
+
+/// The other half of the honest count. `collect_container_tag_keys` is what the
+/// menu label counts; `container_dump_entries` is what the worker writes. If the
+/// collector let an authored tag through, the label would promise a file that
+/// the run then silently skips — the count would be wrong even though every
+/// controller-side gate above still passed.
+#[test]
+fn the_menu_count_excludes_a_tag_authored_this_session() {
+    let entries = vec![
+        container_entry("objects/characters/elite/elite"),
+        new_container_entry("objects/characters/elite/elite_custom"),
+    ];
+    let folder = node("objects/characters/elite", &[0, 1], Vec::new());
+
+    let collected = crate::app::browser::collect_container_tag_keys(&folder, &entries);
+    assert_eq!(collected, vec![entries[0].key.clone()]);
+    // The count the menu shows and the set the worker writes agree, which is the
+    // property the two functions exist to keep.
+    assert_eq!(
+        collected.len(),
+        container_dump_entries(&entries, &folder_scope_of(&collected)).len(),
+    );
+}
+
+/// Subfolders are included, so right-clicking `objects` covers everything under
+/// it rather than only the tags sitting directly in it.
+#[test]
+fn the_menu_count_descends_into_subfolders() {
+    let entries = vec![
+        container_entry("objects/loose"),
+        container_entry("objects/characters/elite/elite"),
+        container_entry("objects/characters/elite/elite_helmet"),
+    ];
+    let tree = node(
+        "objects",
+        &[0],
+        vec![node("objects/characters", &[], vec![node("objects/characters/elite", &[1, 2], Vec::new())])],
+    );
+
+    assert_eq!(
+        crate::app::browser::collect_container_tag_keys(&tree, &entries).len(),
+        3,
+    );
+}
+
+fn folder_scope_of(keys: &[String]) -> ContainerDumpScope {
+    folder("objects/characters/elite", keys.to_vec())
+}
+
+/// The all-shipped scope is unchanged by the folder work: it still covers every
+/// container entry and still excludes authored ones.
+#[test]
+fn the_all_shipped_scope_still_covers_every_container_tag() {
+    let entries = vec![
+        container_entry("objects/characters/elite/elite"),
+        container_entry("objects/vehicles/ghost/ghost"),
+        new_container_entry("objects/mine/thing"),
+    ];
+
+    assert_eq!(
+        extracted_paths(&entries, &ContainerDumpScope::AllShipped),
+        vec![
+            "objects/characters/elite/elite.bitmap",
+            "objects/vehicles/ghost/ghost.bitmap",
+        ],
+    );
+}

--- a/src/app/ui/dialogs.rs
+++ b/src/app/ui/dialogs.rs
@@ -1935,24 +1935,34 @@ impl Baboon {
         }
     }
 
-    /// "This will take a while" for the bulk container extraction.
+    /// "This will take a while" for a container extraction, whether it covers
+    /// the whole workspace or one right-clicked folder.
     ///
     /// Nothing here is destructive, so the wording is about cost rather than
     /// danger: how many files, roughly how long, and — the part that surprises
     /// people — that a mod mounted over the game is ignored, because this
-    /// extracts what the game *ships*, not what it currently loads.
+    /// extracts what the game *ships*, not what it currently loads. That last
+    /// point holds for a folder too, so it is said unconditionally.
     pub(super) fn draw_container_dump_confirm_window(&mut self, ctx: &egui::Context) {
-        let Some((kit, output, total)) = self
-            .container_dump_confirm
-            .as_ref()
-            .map(|confirm| (confirm.kit, confirm.output.clone(), confirm.total))
+        let Some((kit, output, total, folder)) =
+            self.container_dump_confirm.as_ref().map(|confirm| {
+                let folder = match &confirm.scope {
+                    ContainerDumpScope::AllShipped => None,
+                    ContainerDumpScope::Folder { label, .. } => Some(label.clone()),
+                };
+                (confirm.kit, confirm.output.clone(), confirm.total, folder)
+            })
         else {
             return;
         };
         let mut open = true;
         let mut do_extract = false;
         let mut cancel = false;
-        egui::Window::new("Extract every shipped tag?")
+        let title = match &folder {
+            Some(_) => "Extract this folder's tags?",
+            None => "Extract every shipped tag?",
+        };
+        egui::Window::new(title)
             .id(egui::Id::new("container_dump_confirm"))
             .open(&mut open)
             .collapsible(false)
@@ -1961,9 +1971,14 @@ impl Baboon {
             .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
             .show(ctx, |ui| {
                 ui.label(
-                    RichText::new(format!(
-                        "This writes all {total} tags from the mounted containers into:"
-                    ))
+                    RichText::new(match &folder {
+                        Some(label) => {
+                            format!("This writes the {total} shipped tag(s) in {label} into:")
+                        }
+                        None => {
+                            format!("This writes all {total} tags from the mounted containers into:")
+                        }
+                    })
                     .color(text_dark()),
                 );
                 ui.add_space(5.0);
@@ -1976,23 +1991,40 @@ impl Baboon {
                 // Measured on the shipping install: 12,292 tags, 5.4 GB, about a
                 // minute on an SSD. Stated as a range because a slow disk is
                 // several times that, and a promise of "a minute" that turns
-                // into ten is worse than no estimate at all.
+                // into ten is worse than no estimate at all. A folder is a
+                // fraction of that and gets no figure at all rather than one
+                // scaled from a total it has no fixed relation to.
                 ui.label(
-                    RichText::new(
-                        "Every container payload has to be read and decompressed. Expect a few \
-                         gigabytes of files and anywhere from a minute to considerably longer, \
-                         depending on the disk. Baboon stays usable while it runs, and you can \
-                         cancel it from the status bar.",
-                    )
+                    RichText::new(match &folder {
+                        Some(_) => {
+                            "Every container payload has to be read and decompressed, so this \
+                             takes longer than the tag count suggests. Baboon stays usable while \
+                             it runs, and you can cancel it from the status bar."
+                        }
+                        None => {
+                            "Every container payload has to be read and decompressed. Expect a \
+                             few gigabytes of files and anywhere from a minute to considerably \
+                             longer, depending on the disk. Baboon stays usable while it runs, \
+                             and you can cancel it from the status bar."
+                        }
+                    })
                     .color(egui::Color32::from_rgb(210, 120, 90)),
                 );
                 ui.add_space(5.0);
                 ui.label(
-                    RichText::new(
-                        "Tags are laid out like an editing kit \u{2014} levels/, objects/, \
-                         shaders/ \u{2014} so the result can be reopened with File \u{2192} Load \
-                         Folder.",
-                    )
+                    RichText::new(match &folder {
+                        // The folder's full path is recreated rather than
+                        // flattened, so several folder extractions into one
+                        // destination merge into a single loadable kit.
+                        Some(label) => format!(
+                            "Tags keep their full paths, so this lands under {label}/ inside the \
+                             folder you pick and can be reopened with File \u{2192} Load Folder.",
+                        ),
+                        None => "Tags are laid out like an editing kit \u{2014} levels/, objects/, \
+                                 shaders/ \u{2014} so the result can be reopened with File \
+                                 \u{2192} Load Folder."
+                            .to_owned(),
+                    })
                     .color(subtle_dark())
                     .small(),
                 );
@@ -2007,7 +2039,11 @@ impl Baboon {
                 );
                 ui.add_space(10.0);
                 ui.horizontal(|ui| {
-                    if ui.button("Extract All Tags").clicked() {
+                    let accept = match &folder {
+                        Some(_) => "Extract Tags",
+                        None => "Extract All Tags",
+                    };
+                    if ui.button(accept).clicked() {
                         do_extract = true;
                     }
                     if ui.button("Cancel").clicked() {
@@ -2018,12 +2054,16 @@ impl Baboon {
         if !open || cancel {
             self.container_dump_confirm = None;
         } else if do_extract {
-            self.container_dump_confirm = None;
+            // Taken rather than cleared: the scope captured at right-click is
+            // what the run covers, and it moves into the job here.
+            let scope = self.container_dump_confirm.take().map(|confirm| confirm.scope);
             // The extraction reads the active kit's source, so return to the
             // workspace this was raised from and drop it if that workspace has
             // since closed.
-            if self.focus_navigation_kit(kit) {
-                self.start_container_dump(kit, output, ctx.clone());
+            if let Some(scope) = scope {
+                if self.focus_navigation_kit(kit) {
+                    self.start_container_dump(kit, output, scope, ctx.clone());
+                }
             }
         }
     }


### PR DESCRIPTION
`File → Extract All Tags to Folder…` writes every tag the mounted containers ship, which is the only granularity there has ever been. Right-clicking a folder in the browser now offers the same extraction aimed at just that folder.

It reuses the existing worker rather than growing a second one, so it inherits the progress bar, the status-bar **Cancel**, the refusal to stack two runs, and the guard against extracting into the game's own `Paks` folder. The front half of both actions is now one `raise_container_dump_confirm`, so those guards cannot drift apart.

Scope is carried explicitly by a new `ContainerDumpScope`, captured when the confirmation is raised. A modeless confirm outlives the frame that opened it, so re-deriving the folder's membership on accept would let an import or a delete in between silently change what gets written.

### Deliberate choices

- **Not Expert-gated**, unlike the File menu action. That gate exists because extracting everything writes tens of thousands of files unprompted; a folder is bounded and deliberately aimed at. Its menu neighbours — extract bitmaps / material shaders / HLSL includes — are ungated for the same reason.
- **Tags keep their full paths**, so a folder extraction lands under `objects/characters/…` inside the chosen folder, and several of them into one destination merge into a single **Load Folder**-able kit.
- **Folders mode only.** A *Groups* node is a group label rather than a folder, and the on-disk layout follows the tags' own paths, so the result would not resemble the node that was clicked.
- **The count in the menu label is the count that gets written.** A tag authored this session has no shipped payload to read back out of the container and is skipped silently by the worker, so it is excluded from the count rather than promised and dropped.

### Where it lives

| File | Change |
|---|---|
| `state/browser.rs` | `BrowserAction::ExtractContainerFolderTags { label, keys }` |
| `state/documents.rs` | `ContainerDumpScope { AllShipped, Folder }`, carried on `ContainerDumpConfirm` |
| `browser/tree.rs` | The menu item, gated `is_container && !groups_mode`; `collect_container_tag_keys` |
| `controller.rs` | `container_dump_entries` — one function resolving both scopes |
| `ui/dialogs.rs` | Scope-aware title, body and accept-button wording |

`dump_shipped_container_tags` and `write_shipped_entry` are untouched: the former already took an arbitrary `entries` slice and filtered to `TagEntryLocation::Container` itself, and the latter already wrote at each tag's full `display_path`.

### Tests

7 new tests, covering the two halves that drift apart silently — what the menu counts (`collect_container_tag_keys`) and what the worker writes (`container_dump_entries`). Every fixture holds two folders, so a scope that quietly fell through to "everything" cannot pass by agreeing.

Each guard was proved by breaking it and watching a specific test go red:

| Sabotage | Test that failed |
|---|---|
| key filter always matches | `a_folder_scope_extracts_only_that_folder` (picked up the second folder's tag) |
| location filter always matches | 3 tests, incl. `a_tag_authored_this_session_is_not_extracted` |
| collector admits authored tags | `the_menu_count_excludes_a_tag_authored_this_session` |
| collector stops recursing | `the_menu_count_descends_into_subfolders` (1 vs 3) |

Suite **740 + 5 + 9, zero failures** (733 before). Warning count unchanged at **89**. No engine change — `Cargo.toml`/`Cargo.lock` untouched.

### Not verified

No click-through. `Baboon::new` needs an eframe `CreationContext` and reads real prefs, so there is still no headless harness for a menu action — the draw-time gate and the dialog wording are reviewed, not exercised. Nothing here ran against a real mounted Campaign Evolved install.