### PR TITLE
Keep a renamed container tag's own wrapper, and bump the engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -151,7 +151,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -502,7 +502,7 @@ dependencies = [
 [[package]]
 name = "blam-tags"
 version = "0.1.0"
-source = "git+https://github.com/camden-smallwood/blam-tags?rev=312171d#312171ddac2d36fe3da9bd5abfc3c21cebbbbdc0"
+source = "git+https://github.com/camden-smallwood/blam-tags?rev=a7417ac#a7417ac416cebfd72cd70bf40d0906e045d46656"
 dependencies = [
  "anyhow",
  "bcdec_rs",
@@ -957,7 +957,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1294,7 +1294,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2299,7 +2299,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3339,7 +3339,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3733,7 +3733,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4000,7 +4000,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4484,7 +4484,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1"
 atomic-write-file = "0.3"
-blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "312171d", features = ["audio", "iostore"] }
+blam-tags = { git = "https://github.com/camden-smallwood/blam-tags", rev = "a7417ac", features = ["audio", "iostore"] }
 directories = "6"
 display-info = "0.5"
 eframe = { version = "0.29", default-features = false, features = ["default_fonts", "glow"] }

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -4515,6 +4515,12 @@ impl Baboon {
             .clone();
         let rel_path = rel_path.clone();
         let group = entry.group_name.clone().unwrap_or_default();
+        // What the `.uasset` about to be reused is *to* this tag. It is read
+        // back out of this tag's own package below, so its bindings are this
+        // tag's bindings -- `wrapper_origin_for` is the one place that call is
+        // made, so a Save As cannot start disagreeing with an Export Mod.
+        let wrapper_origin =
+            wrapper_origin_for(&entry.location).ok_or("Not a Campaign Evolved container tag")?;
 
         // Tag content: current edited bytes if the tag is loaded, else the
         // original `.ubulk`.
@@ -4570,6 +4576,7 @@ impl Baboon {
                     } else {
                         None
                     },
+                    wrapper_origin,
                     &output,
                 )
                 .map_err(|e| format!("write container: {e}"))?;
@@ -4729,6 +4736,12 @@ impl Baboon {
                 }
             }
         };
+        // An authored tag's wrapper came from an unrelated donor, so the
+        // writer has to strip the donor's bindings rather than carry them.
+        let Some(wrapper_origin) = wrapper_origin_for(&entry.location) else {
+            self.status = "Not a new container tag".to_owned();
+            return;
+        };
         let leaf = package.rsplit('/').next().unwrap_or("tag");
         let Some(output) = pick_override_utoc(&format!("{leaf}_P.utoc")) else {
             return;
@@ -4738,7 +4751,12 @@ impl Baboon {
             return;
         }
         match blam_tags::iostore::writer::write_new_tag_container(
-            &template, &bytes, package, None, &output,
+            &template,
+            &bytes,
+            package,
+            None,
+            wrapper_origin,
+            &output,
         ) {
             Ok(()) => {
                 if let Some(doc) = self.kits[self.active].parsed_tags.get_mut(key) {


### PR DESCRIPTION
Engine bump to `a7417ac`, plus the one call-site change it forces.

## What needed changing here

`write_new_tag_container` now takes the wrapper's origin from its caller
instead of assuming every new package is seeded from an unrelated donor.
Baboon has both kinds and was passing the assumption on both.

Save As / Rename on a Campaign Evolved container tag reads the `.uasset` back
out of the tag's **own** package and hands it straight to the writer, so its
bindings are that tag's bindings. Treating it as a donor stripped them — the
same failure #53 fixed for Export Mod, still live on the single-tag path. A
renamed biped went out with an empty property block and lost the Blueprint it
presents as, with nothing said.

Both call sites now route through `wrapper_origin_for`, which is where the
`Container`-is-a-copy / `NewContainer`-is-a-donor decision already lived.
Getting it backwards is quiet in both directions, so it gets one home rather
than three literals.

## What the bump brings in for free

| Engine commit | Effect here |
| --- | --- |
| Fold a template's inherited base into the struct that carries it | A Reach particle converted to Halo 4 describes its render method instead of 100 bytes of anonymous padding — the tag Bonobo refused to open |
| Name a field's options only when the field names a list | `manual bsp flags` was reading `scenario_type_enum`'s fifteen options off its block index; the cross-game field comparison reported all fifteen as lost |
| Stamp a tag built from definitions with the header its kit expects | A freshly created tag no longer disagrees with its own embedded layout on save |

## Verification

`cargo check --all-targets` is clean, and that is the real gate for the code
change: the new argument is what makes it compile, so a stale engine could not
have passed.

**Not verified.** The suite was not run for this bump, and nothing was
exercised against a real mounted Campaign Evolved install — the
renamed-wrapper path is reviewed, not clicked through. On the engine side the
template fold carries four unit tests plus an ignored corpus test, but the
committed byte gate compares `prefab`, which has no `tmpl`, so no test in the
tree byte-compares a folded layout against a shipped particle.
