### PR TITLE
Add a poking profile for the 2026.08.11 tag module

### DIFF
--- a/src/app/runtime_poke.rs
+++ b/src/app/runtime_poke.rs
@@ -44,14 +44,56 @@ pub(in crate::app) struct RuntimeBuildProfile {
 
 /// Every build the runtime poker knows how to address, newest first.
 ///
-/// A build is only ever identified by the SHA-256 of the host executable and
-/// the tag module; the RVAs below were measured against those exact files and
-/// mean nothing for any other pair.
-const PROFILES: &[RuntimeBuildProfile] = &[NEXT_PROFILE, CU2_PROFILE, CU2_XBOXAPP_PROFILE];
+/// A build is selected by the SHA-256 of the tag module alone — that is the
+/// image every RVA below is an offset into. `host_sha256` records which
+/// executable the measurement was taken against and is not consulted, which is
+/// what lets one set of RVAs serve both the Steam and XboxApp packagings of the
+/// same tag module. The RVAs mean nothing for any other tag module.
+const PROFILES: &[RuntimeBuildProfile] = &[
+    STEAM_2026_08_11_PROFILE,
+    STEAM_2026_07_25_PROFILE,
+    CU2_PROFILE,
+    CU2_XBOXAPP_PROFILE,
+];
+
+/// Tag module built 2026-08-11.
+///
+/// Every RVA below is *the same value* as the 2026-07-25 profile, which is a
+/// claim that has to be earned rather than assumed. The two modules are the
+/// same size to the byte with every section at the same virtual address, and
+/// `.reloc` is identical, so no relocated pointer changed address. `.text` got
+/// one 16-byte insertion at 0x1C0AA0, displacing everything up to 0x5C75EC by
+/// +0x10 and leaving the rest in place. Measured against that:
+///
+/// * Each address here is reached by exactly as many RIP-relative instructions
+///   in the new module as in the old (1244, 3776, 11, 12, 7, 9, 12 and 2
+///   respectively), matching one-for-one under the +0x10 displacement. A global
+///   that had moved would have lost every reference to its old address.
+/// * All 53 `string_id` reference sites sit in functions that disassemble
+///   instruction-for-instruction identically once the code shift is normalised
+///   away, so the hardcoded bucket/entry/storage/builtin constants above still
+///   describe this build.
+/// * 32,639 of 33,052 `.pdata` functions are identical under that
+///   normalisation; every remaining difference is either in the two churn
+///   clusters at the shift boundaries or trailing jump-table data decoded as
+///   code, none of it structural.
+const STEAM_2026_08_11_PROFILE: RuntimeBuildProfile = RuntimeBuildProfile {
+    label: "Steam post-CU2 (tag module 2026.08.11)",
+    host_sha256: "EB1DACA659207F2B5C8A6FD922917195AE9C8AE19E771E396E08906282A4B152",
+    dll_sha256: "C8C144404ADF61A9DE821C996682A7E66ABADD7E530397D3BBDE31C123203BF7",
+    tag_table_pointer_rva: 0x0182_D1E8,
+    segment_table_rva: 0x02C2_CCC0,
+    string_id_storage_rva: 0x0135_7490,
+    string_id_storage_used_rva: 0x0135_7498,
+    string_id_strings_rva: 0x0135_74A0,
+    string_id_count_rva: 0x0135_74A8,
+    string_id_mapping_table_rva: 0x0135_74C0,
+    string_id_builtin_table_rva: 0x0082_F0A0,
+};
 
 /// Tag module built 2026-07-25 (the update that shipped after CU2). The game
 /// embeds no build number, so the label carries the tag module's PE date.
-const NEXT_PROFILE: RuntimeBuildProfile = RuntimeBuildProfile {
+const STEAM_2026_07_25_PROFILE: RuntimeBuildProfile = RuntimeBuildProfile {
     label: "Steam post-CU2 (tag module 2026.07.25)",
     host_sha256: "4D20DC56611B29CD710D591C86CF5DE55B914EB986838C42E719B82CCD367753",
     dll_sha256: "82B8A3A006BA3F981D6857DC7F4E4E929AE5282587F31F92F77A3FA78F4B2DAC",

--- a/src/app/runtime_poke/tests.rs
+++ b/src/app/runtime_poke/tests.rs
@@ -115,6 +115,37 @@ fn last_poke_for_test(patch: PokePatch, original: Vec<u8>) -> LastPoke {
     }
 }
 
+/// The profile table is searched by tag-module hash and the first match wins,
+/// so a duplicate hash would silently shadow a profile, and a hash written in
+/// the wrong case or length would never match at all — either way the profile
+/// is dead code that looks alive.
+#[test]
+fn profile_table_hashes_are_unique_and_comparable() {
+    let mut seen = Vec::new();
+    for profile in PROFILES {
+        assert_eq!(
+            profile.dll_sha256.len(),
+            64,
+            "{} has a malformed tag-module hash",
+            profile.label
+        );
+        assert!(
+            profile
+                .dll_sha256
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'A'..=b'F').contains(&byte)),
+            "{} must spell its tag-module hash in uppercase hex to match `format!(\"{{:X}}\")`",
+            profile.label
+        );
+        assert!(
+            !seen.contains(&profile.dll_sha256),
+            "{} repeats a tag-module hash already claimed by an earlier profile",
+            profile.label
+        );
+        seen.push(profile.dll_sha256);
+    }
+}
+
 #[test]
 fn checked_rva_math_rejects_overflow() {
     assert_eq!(


### PR DESCRIPTION
The game updated. The tag module's PE timestamp moved from 2026-07-25 to 2026-08-11 and both SHA-256s changed, so runtime poking refuses to attach with "Unsupported game build, please check you have the latest game and Baboon version."

Adds a profile for it. `NEXT_PROFILE` is renamed `STEAM_2026_07_25_PROFILE` — "next" stopped being true the moment a newer build existed.

## All eight RVAs are unchanged, and that is measured

This is the opposite of what the last two updates did (CU2 → 2026.07.25 moved all eight, by three *different* deltas), so it is not assumed.

| | 2026.07.25 | 2026.08.11 |
|---|---|---|
| PE timestamp | Jul 25 01:39 UTC | Aug 11 00:59 UTC |
| file size | 14,668,560 | 14,668,560 |
| section VAs, `SizeOfImage` | — | identical |
| `.reloc` | — | **byte-identical** |
| `.text` | — | one 16-byte insertion at `0x1C0AA0`; the band up to `0x5C75EC` is displaced +0x10, the rest is in place |

Byte-identical `.reloc` means nothing carrying a relocation changed address, which is a statement about `.data`/`.rdata` — exactly where the eight globals live.

The check that can disagree is a reference census. For every 4-byte window in `.text`, compute `rva + 4 + disp32` and bucket by target; run it over each module **independently** and compare. If a global had moved, its old address would have lost every reference to it.

| global | RVA | sites (old) | sites (new) |
|---|---|---|---|
| `tag_table_pointer` | `0x0182D1E8` | 1244 | 1244 |
| `segment_table` | `0x02C2CCC0` | 3776 | 3776 |
| `string_id_storage` | `0x01357490` | 11 | 11 |
| `string_id_storage_used` | `0x01357498` | 12 | 12 |
| `string_id_strings` | `0x013574A0` | 7 | 7 |
| `string_id_count` | `0x013574A8` | 9 | 9 |
| `string_id_mapping_table` | `0x013574C0` | 12 | 12 |
| `string_id_builtin_table` | `0x0082F0A0` | 2 | 2 |

Every site matches one-for-one under the +0x10 displacement.

## The hardcoded layout constants still hold

The profile is only addresses; the module separately hardcodes 1046528 buckets, 523264 entries, 26163200 storage bytes, 2678 built-ins, 1068 dynamic-id base and `0x30` tag entries.

- All five constants occur the same number of times as u32 immediates in each module's `.text` (2 / 5 / 4 / 1 / 105).
- All 53 `string_id` reference sites sit in functions that disassemble instruction-for-instruction identically once the code shift is normalised out — 208, 190, 64 and 33 instructions.
- Whole module: **32,639 of 33,052** `.pdata` functions identical under that normalisation. Every remaining difference is a branch into the two churn clusters at the shift boundaries, or trailing jump-table data the disassembler decodes as code past a `ret`. None is structural.

## The new test

`profile_table_hashes_are_unique_and_comparable`. Profiles are selected by the first matching `dll_sha256`, so a duplicated hash silently shadows a later profile, and a hash written in lowercase never matches `format!("{:X}")` at all. Either way the profile looks alive and is dead. Confirmed the test fails by lowercasing a hash rather than trusting that it would.

Also corrected the `PROFILES` doc comment, which claimed a build is identified by the host executable *and* the tag module. Selection reads `dll_sha256` only; `host_sha256` is recorded and never consulted, which is what lets one RVA set serve both the Steam and XboxApp packagings of the same tag module.

## Not verified

- **Nothing here was run against the game.** No Windows machine on this box and the poking path is Windows-only, so the addresses are established by equivalence to a build that did work, not by attaching. I did confirm a plain `cargo check` on macOS genuinely compiles `PROFILES` (planted a deliberate typo and watched it error) rather than assuming either way.
- **The XboxApp packaging of 2026.08.11 has no profile** — only the Steam executable and tag module were available to hash. It is a two-line addition once that DLL can be hashed.

778 + 5 + 9 tests pass, release build clean.