### PR TITLE
Refine tag and folder context menus

### DIFF
--- a/assets/Button Icons/List Dropdown - Left.svg
+++ b/assets/Button Icons/List Dropdown - Left.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M5.29297 8L9.14648 11.8535L9.85352 11.1465L6.70703 8L9.85352 4.85352L9.14648 4.14648L5.29297 8Z" fill="currentColor"/>
+</svg>

--- a/assets/Button Icons/List Dropdown - Right.svg
+++ b/assets/Button Icons/List Dropdown - Right.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10.707 8L6.85352 11.8535L6.14648 11.1465L9.29297 8L6.14648 4.85352L6.85352 4.14648L10.707 8Z" fill="currentColor"/>
+</svg>

--- a/src/app/browser/tree.rs
+++ b/src/app/browser/tree.rs
@@ -3,6 +3,8 @@
 
 use super::*;
 
+pub(in crate::app) const CONTEXT_MENU_WIDTH: f32 = 340.0;
+
 /// A pending "reveal in tree" request threaded through the tree draw: it force-
 /// opens the folder nodes along `remaining` (ancestor labels not yet descended)
 /// and scrolls the matching leaf (`key`) into view. One-shot — cleared by the
@@ -113,29 +115,144 @@ pub(in crate::app) fn hover_tooltip_beside_pointer(ui: &Ui, response: &egui::Res
 }
 
 pub(in crate::app) fn context_menu_button(ui: &mut Ui, label: &str) -> egui::Response {
-    let text = RichText::new(label).color(text_dark());
-    let button = match context_menu_icon(label) {
-        Some(icon) => {
-            egui::Button::image_and_text(button_icon_image(ui, icon, text_dark(), 16.0), text)
+    let size = Vec2::new(ui.available_width().max(1.0), 28.0);
+    let (rect, response) = ui.allocate_exact_size(size, Sense::click());
+    response.widget_info(|| {
+        egui::WidgetInfo::labeled(egui::WidgetType::Button, ui.is_enabled(), label)
+    });
+
+    if ui.is_rect_visible(rect) {
+        let visuals = ui.style().interact(&response);
+        if response.hovered() || response.has_focus() {
+            ui.painter().rect(
+                rect.expand(visuals.expansion),
+                visuals.rounding,
+                visuals.bg_fill,
+                Stroke::NONE,
+            );
         }
-        None => egui::Button::new(text),
-    };
-    ui.add_sized([ui.available_width().max(280.0), 28.0], button)
+
+        let enabled = ui.is_enabled();
+        let color = if enabled {
+            text_dark()
+        } else {
+            ui.visuals().widgets.noninteractive.fg_stroke.color
+        };
+        let mut text_x = rect.left() + 8.0;
+        if let Some(image) = context_menu_app_icon(label) {
+            let icon_rect = egui::Rect::from_center_size(
+                egui::pos2(rect.left() + 16.0, rect.center().y),
+                Vec2::splat(16.0),
+            );
+            image
+                .tint(if enabled {
+                    Color32::WHITE
+                } else {
+                    Color32::from_white_alpha(90)
+                })
+                .paint_at(ui, icon_rect);
+            text_x += 22.0;
+        } else if let Some(icon) = context_menu_icon(label) {
+            let icon_rect = egui::Rect::from_center_size(
+                egui::pos2(rect.left() + 16.0, rect.center().y),
+                Vec2::splat(16.0),
+            );
+            button_icon_image(ui, icon, color, 16.0).paint_at(ui, icon_rect);
+            text_x += 22.0;
+        }
+        ui.painter().text(
+            egui::pos2(text_x, rect.center().y),
+            Align2::LEFT_CENTER,
+            label,
+            FontId::proportional(12.0),
+            color,
+        );
+    }
+    response
 }
 
-fn context_menu_primary_button(ui: &mut Ui, label: &str, enabled: bool) -> egui::Response {
-    let text = RichText::new(label).color(text_dark());
-    let button = match context_menu_icon(label) {
-        Some(icon) => {
-            egui::Button::image_and_text(button_icon_image(ui, icon, text_dark(), 16.0), text)
+fn context_menu_primary_button(
+    ui: &mut Ui,
+    label: &str,
+    enabled: bool,
+    width: f32,
+) -> egui::Response {
+    ui.add_enabled_ui(enabled, |ui| {
+        const ICON_SIZE: f32 = 16.0;
+        const ICON_TEXT_GAP: f32 = 4.0;
+        const VERTICAL_PADDING: f32 = 8.0;
+
+        let font_id = FontId::proportional(12.0);
+        let text_galley = ui.painter().layout_no_wrap(
+            label.to_owned(),
+            font_id,
+            if ui.is_enabled() {
+                text_dark()
+            } else {
+                ui.visuals().widgets.noninteractive.fg_stroke.color
+            },
+        );
+        let button_height =
+            VERTICAL_PADDING * 2.0 + ICON_SIZE + ICON_TEXT_GAP + text_galley.size().y;
+        let size = Vec2::new(width, button_height);
+        let (rect, response) = ui.allocate_exact_size(size, Sense::click());
+        response.widget_info(|| {
+            egui::WidgetInfo::labeled(egui::WidgetType::Button, ui.is_enabled(), label)
+        });
+
+        if ui.is_rect_visible(rect) {
+            let system_visuals = foundation_visuals();
+            let interactive = ui.is_enabled();
+            let hovered = interactive && (response.hovered() || response.has_focus());
+            let pressed = interactive && response.is_pointer_button_down_on();
+            let fill = if pressed {
+                system_visuals.widgets.active.weak_bg_fill
+            } else if hovered {
+                context_menu_hover()
+            } else if interactive {
+                system_visuals.widgets.inactive.weak_bg_fill
+            } else {
+                system_visuals.widgets.noninteractive.weak_bg_fill
+            };
+            let stroke = if hovered || pressed {
+                Stroke::new(1.0, foundation_input_edge())
+            } else {
+                Stroke::NONE
+            };
+            ui.painter().rect(rect, 3.0, fill, stroke);
+
+            let color = if interactive {
+                text_dark()
+            } else {
+                ui.visuals().widgets.noninteractive.fg_stroke.color
+            };
+            if let Some(icon) = context_menu_icon(label) {
+                let icon_rect = egui::Rect::from_center_size(
+                    egui::pos2(
+                        rect.center().x,
+                        rect.top() + VERTICAL_PADDING + ICON_SIZE * 0.5,
+                    ),
+                    Vec2::splat(ICON_SIZE),
+                );
+                if interactive {
+                    button_icon_image(ui, icon, color, ICON_SIZE).paint_at(ui, icon_rect);
+                } else {
+                    paint_button_icon_at(ui, icon, icon_rect, color);
+                }
+            }
+            let text_pos = egui::pos2(
+                rect.center().x - text_galley.size().x * 0.5,
+                rect.top() + VERTICAL_PADDING + ICON_SIZE + ICON_TEXT_GAP,
+            );
+            ui.painter().galley(text_pos, text_galley, color);
         }
-        None => egui::Button::new(text),
-    };
-    ui.add_enabled(enabled, button.min_size(Vec2::new(92.0, 44.0)))
+        response
+    })
+    .inner
 }
 
 fn context_menu_icon(label: &str) -> Option<ButtonIcon> {
-    match label {
+    let exact = match label {
         "Rename" => Some(ButtonIcon::Rename),
         "Duplicate" => Some(ButtonIcon::Duplicate),
         "Delete" => Some(ButtonIcon::Garbage),
@@ -143,12 +260,123 @@ fn context_menu_icon(label: &str) -> Option<ButtonIcon> {
         "Open with File Explorer" => Some(ButtonIcon::FileExplorer),
         "Add to Favorites" | "Remove from Favorites" => Some(ButtonIcon::Favourite),
         "Copy Tag Path" => Some(ButtonIcon::CopyPath),
+        "Copy Folder Path" => Some(ButtonIcon::CopyPath),
         "Find Tag References..." => Some(ButtonIcon::Find),
         "Dump Tag to JSON..." => Some(ButtonIcon::Json),
         "Dump Tag References..." => Some(ButtonIcon::Doc),
-        "Open in Sapien" | "Open in tag_test" => Some(ButtonIcon::Open),
+        "Reimport" => Some(ButtonIcon::Import),
         _ => None,
+    };
+    exact.or_else(|| {
+        if label.starts_with("Move to") {
+            Some(ButtonIcon::Move)
+        } else if label.starts_with("Copy to") {
+            Some(ButtonIcon::Copy)
+        } else if label.starts_with("Import ") {
+            Some(ButtonIcon::Import)
+        } else if label.starts_with("Open in new tab") {
+            Some(ButtonIcon::Open)
+        } else if label.starts_with("New tag") {
+            Some(ButtonIcon::Add)
+        } else if label.starts_with("New folder") {
+            Some(ButtonIcon::FolderClosed)
+        } else if label.starts_with("Rename folder") {
+            Some(ButtonIcon::Rename)
+        } else if label.starts_with("Delete folder") {
+            Some(ButtonIcon::Garbage)
+        } else if label.starts_with("Dump folder") {
+            Some(ButtonIcon::Json)
+        } else if label.starts_with("Extract") {
+            Some(ButtonIcon::Export)
+        } else {
+            None
+        }
+    })
+}
+
+/// Right-opening submenu interaction using the same row geometry and SVG
+/// direction marker as the left-opening header-menu counterpart.
+fn context_menu_submenu_button(
+    ui: &mut Ui,
+    label: &str,
+    icon: ButtonIcon,
+    add_contents: impl FnOnce(&mut Ui) -> Option<BrowserAction>,
+) -> Option<BrowserAction> {
+    let response = context_menu_button(ui, label);
+    let icon_rect = egui::Rect::from_center_size(
+        egui::pos2(
+            response.rect.left() + 16.0,
+            response.rect.center().y,
+        ),
+        Vec2::splat(16.0),
+    );
+    paint_button_icon_at(ui, icon, icon_rect, text_dark());
+    paint_submenu_icon(ui, &response, false);
+    let popup_id = response.id.with(("right_submenu", label));
+    let action = right_opening_menu_popup(ui, &response, popup_id, CONTEXT_MENU_WIDTH, |ui| {
+        style_tag_context_menu(ui);
+        add_contents(ui)
+    })
+    .flatten();
+    if action.is_some() {
+        ui.close_menu();
+        ui.data_mut(|data| data.insert_temp(popup_id, false));
     }
+    action
+}
+
+/// Header menus are anchored to the right edge of a pane, where egui's native
+/// right-opening submenu has nowhere to go and is constrained back over its
+/// parent. This counterpart keeps the same row treatment but places the child
+/// popup immediately to the parent's left.
+fn left_opening_context_menu_submenu_button(
+    ui: &mut Ui,
+    label: &str,
+    _icon: ButtonIcon,
+    add_contents: impl FnOnce(&mut Ui) -> Option<BrowserAction>,
+) -> Option<BrowserAction> {
+    let response = context_menu_button(ui, label);
+    paint_submenu_icon(ui, &response, true);
+    let popup_id = response.id.with(("left_submenu", label));
+    let action = left_opening_menu_popup(ui, &response, popup_id, CONTEXT_MENU_WIDTH, |ui| {
+        style_tag_context_menu(ui);
+        add_contents(ui)
+    })
+    .flatten();
+    if action.is_some() {
+        ui.close_menu();
+        ui.data_mut(|data| data.insert_temp(popup_id, false));
+    }
+    action
+}
+
+fn supports_tag_reimport(entry: &TagEntry) -> bool {
+    entry
+        .group_name
+        .as_deref()
+        .and_then(geometry_import_verb_for_group_name)
+        .or_else(|| {
+            blam_tags::paths::group_tag_to_extension(entry.group_tag)
+                .and_then(geometry_import_verb_for_group_name)
+        })
+        .is_some()
+}
+
+/// The scenario launch rows use the same bundled application artwork as the
+/// tag header instead of the generic vector icon used by ordinary Open actions.
+fn context_menu_app_icon(label: &str) -> Option<egui::Image<'static>> {
+    let (uri, bytes): (&'static str, &'static [u8]) = match label {
+        "Open in Sapien" => (
+            "bytes://baboon_app_icons/sapien.png",
+            include_bytes!("../../../assets/App Icons/Sapien.png"),
+        ),
+        "Open in Tag Test" => (
+            "bytes://baboon_app_icons/tag-test.png",
+            include_bytes!("../../../assets/App Icons/Tag Test.png"),
+        ),
+        _ => return None,
+    };
+    Some(egui::Image::from_bytes(uri, bytes).fit_to_exact_size(Vec2::splat(16.0)))
 }
 
 pub(in crate::app) fn context_menu_separator(ui: &mut Ui) {
@@ -157,15 +385,112 @@ pub(in crate::app) fn context_menu_separator(ui: &mut Ui) {
     ui.add_space(3.0);
 }
 
-pub(in crate::app) fn style_tag_context_menu(ui: &mut Ui) {
-    ui.set_min_width(300.0);
+/// Shared geometry and interaction treatment for ordinary list menus. egui's
+/// menu implementation deliberately replaces normal button padding with a
+/// two-point inset, so restore the roomier application row here.
+pub(in crate::app) fn style_list_menu(ui: &mut Ui) {
     ui.spacing_mut().item_spacing = Vec2::new(0.0, 1.0);
     ui.spacing_mut().button_padding = Vec2::new(8.0, 4.0);
     ui.spacing_mut().interact_size.y = 28.0;
     ui.visuals_mut().override_text_color = Some(text_dark());
     ui.visuals_mut().widgets.inactive.bg_fill = Color32::TRANSPARENT;
+    ui.visuals_mut().widgets.inactive.weak_bg_fill = Color32::TRANSPARENT;
     ui.visuals_mut().widgets.hovered.bg_fill = context_menu_hover();
+    ui.visuals_mut().widgets.hovered.weak_bg_fill = context_menu_hover();
+    ui.visuals_mut().widgets.hovered.bg_stroke = Stroke::NONE;
     ui.visuals_mut().widgets.active.bg_fill = context_menu_hover();
+    ui.visuals_mut().widgets.active.weak_bg_fill = context_menu_hover();
+    ui.visuals_mut().widgets.active.bg_stroke = Stroke::NONE;
+}
+
+pub(in crate::app) fn style_tag_context_menu(ui: &mut Ui) {
+    // `set_min_width` is not enough here: during egui's menu sizing pass the
+    // full-width rows can see a larger available width and grow the popup to
+    // it. Fix both bounds so 328 points of content plus the default 6-point
+    // inset on each side produces a 340-point frame at 100% display scaling.
+    let menu_margin = ui.spacing().menu_margin;
+    ui.set_width((CONTEXT_MENU_WIDTH - menu_margin.left - menu_margin.right).max(1.0));
+    style_list_menu(ui);
+}
+
+/// Full-width submenu row for the tag's format-specific extraction actions.
+/// Kept out of the primary action strip because it is a menu trigger, not a
+/// direct command.
+fn tag_extract_menu_button(
+    ui: &mut Ui,
+    entry: &TagEntry,
+    open_left: bool,
+) -> Option<BrowserAction> {
+    // The stock submenu row owns the drill-down interaction and arrow, but its
+    // label has no image slot. Make that label transparent and paint the same
+    // 16-point icon + 6-point gap geometry as every other context-menu row.
+    let contents = |ui: &mut Ui| {
+        let mut action = None;
+        ui.set_min_width(280.0);
+        if supports_tag_geometry_extraction(entry.group_tag)
+            && context_menu_button(ui, "Extract model geometry").clicked()
+        {
+            action = Some(BrowserAction::ExtractGeometry(entry.key.clone()));
+            ui.close_menu();
+        }
+        if supports_bsp_geometry_extraction(entry.group_tag)
+            && context_menu_button(ui, "Extract BSP geometry").clicked()
+        {
+            action = Some(BrowserAction::ExtractGeometry(entry.key.clone()));
+            ui.close_menu();
+        }
+        if supports_scenario_geometry_extraction(entry.group_tag)
+            && context_menu_button(ui, "Extract level geometry (one file per BSP)").clicked()
+        {
+            action = Some(BrowserAction::ExtractGeometry(entry.key.clone()));
+            ui.close_menu();
+        }
+        if supports_particle_geometry_extraction(entry.group_tag)
+            && context_menu_button(ui, "Extract particle geometry (JMI + one JMS per object)")
+                .clicked()
+        {
+            action = Some(BrowserAction::ExtractGeometry(entry.key.clone()));
+            ui.close_menu();
+        }
+        if supports_animation_extraction(entry.group_tag)
+            && context_menu_button(ui, "Extract animations").clicked()
+        {
+            action = Some(BrowserAction::ExtractAnimation(entry.key.clone()));
+            ui.close_menu();
+        }
+        if supports_tag_import_info_extraction(entry.group_tag)
+            && context_menu_button(ui, "Extract import-info").clicked()
+        {
+            action = Some(BrowserAction::ExtractImportInfo(entry.key.clone()));
+            ui.close_menu();
+        }
+        if is_bitmap_group(entry.group_tag)
+            && context_menu_button(ui, "Extract bitmap images...").clicked()
+        {
+            action = Some(BrowserAction::ExtractBitmap(entry.key.clone()));
+            ui.close_menu();
+        }
+        if is_material_shader_group(entry.group_tag)
+            && context_menu_button(ui, "Extract source shaders...").clicked()
+        {
+            action = Some(BrowserAction::ExtractMaterialShaderSources(
+                entry.key.clone(),
+            ));
+            ui.close_menu();
+        }
+        if is_hlsl_include_group(entry.group_tag)
+            && context_menu_button(ui, "Extract HLSL include...").clicked()
+        {
+            action = Some(BrowserAction::ExtractHlslIncludeSource(entry.key.clone()));
+            ui.close_menu();
+        }
+        action
+    };
+    if open_left {
+        left_opening_context_menu_submenu_button(ui, "Extract", ButtonIcon::Export, contents)
+    } else {
+        context_menu_submenu_button(ui, "Extract", ButtonIcon::Export, contents)
+    }
 }
 
 fn entry_filename_lower(entry: &TagEntry) -> String {
@@ -587,6 +912,7 @@ pub(in crate::app) fn draw_tree_node_lazy(
         },
     );
     response.context_menu(|ui| {
+        style_tag_context_menu(ui);
         let favorited = browser_favorite_folders(ui).map(|folders| {
             folders
                 .iter()
@@ -606,53 +932,20 @@ pub(in crate::app) fn draw_tree_node_lazy(
             });
             ui.close_menu();
         }
-        ui.separator();
-        if ui.button("Dump folder to JSON...").clicked() {
+        if context_menu_button(ui, "Copy Folder Path").clicked() {
+            clicked = Some(BrowserAction::CopyFolderPath(node.rel_path.clone()));
+            ui.close_menu();
+        }
+        context_menu_separator(ui);
+        if context_menu_button(ui, "Dump folder to JSON...").clicked() {
             clicked = Some(BrowserAction::DumpLooseFolderJson {
                 rel_path: node.rel_path.clone(),
                 label: node.label.clone(),
             });
             ui.close_menu();
         }
-        let bitmap_keys = collect_bitmap_keys(node, entries);
-        if bitmap_keys.is_empty() {
-            ui.label(RichText::new("No loaded bitmap tags in this folder").color(subtle_dark()));
-        } else if ui
-            .button(format!("Extract loaded bitmaps... ({})", bitmap_keys.len()))
-            .clicked()
-        {
-            clicked = Some(BrowserAction::ExtractBitmapFolder(bitmap_keys));
-            ui.close_menu();
-        }
-        let material_shader_keys = collect_material_shader_keys(node, entries);
-        if material_shader_keys.is_empty() {
-            ui.label(
-                RichText::new("No loaded material shaders in this folder").color(subtle_dark()),
-            );
-        } else if ui
-            .button(format!(
-                "Extract loaded material shader sources... ({})",
-                material_shader_keys.len()
-            ))
-            .clicked()
-        {
-            clicked = Some(BrowserAction::ExtractMaterialShaderSourceFolder(
-                material_shader_keys,
-            ));
-            ui.close_menu();
-        }
-        let hlsl_include_keys = collect_hlsl_include_keys(node, entries);
-        if hlsl_include_keys.is_empty() {
-            ui.label(RichText::new("No loaded HLSL includes in this folder").color(subtle_dark()));
-        } else if ui
-            .button(format!(
-                "Extract loaded HLSL includes... ({})",
-                hlsl_include_keys.len()
-            ))
-            .clicked()
-        {
-            clicked = Some(BrowserAction::ExtractHlslIncludeFolder(hlsl_include_keys));
-            ui.close_menu();
+        if let Some(action) = folder_extract_menu_button(ui, node, entries, false, true) {
+            clicked = Some(action);
         }
     });
     if response.double_clicked() {
@@ -793,6 +1086,7 @@ pub(in crate::app) fn draw_tree_node(
         )
     };
     header_response.context_menu(|ui| {
+        style_tag_context_menu(ui);
         if !groups_mode && favorite_keys.is_some() {
             let favorited = browser_favorite_folders(ui).map(|folders| {
                 folders
@@ -808,6 +1102,17 @@ pub(in crate::app) fn draw_tree_node(
             ) {
                 clicked = Some(action);
             }
+            if context_menu_button(ui, "Open with File Explorer").clicked() {
+                clicked = Some(BrowserAction::OpenLooseFolderInExplorer {
+                    rel_path: node.rel_path.clone(),
+                });
+                ui.close_menu();
+            }
+            if context_menu_button(ui, "Copy Folder Path").clicked() {
+                clicked = Some(BrowserAction::CopyFolderPath(node.rel_path.clone()));
+                ui.close_menu();
+            }
+            context_menu_separator(ui);
         }
         // Campaign Evolved folder authoring (Folders mode only — in Groups mode
         // the node path is a group label, not a folder).
@@ -823,11 +1128,11 @@ pub(in crate::app) fn draw_tree_node(
             // means rewriting every tag beneath it — a container write, not a
             // workspace edit, and not what this menu does.
             if let Some(rel) = folder_rel.filter(|_| folder_is_pending_and_empty(node)) {
-                if ui.button("Rename folder...").clicked() {
+                if context_menu_button(ui, "Rename folder...").clicked() {
                     clicked = Some(BrowserAction::RenameContainerFolder { rel: rel.clone() });
                     ui.close_menu();
                 }
-                if ui.button("Delete folder").clicked() {
+                if context_menu_button(ui, "Delete folder").clicked() {
                     clicked = Some(BrowserAction::DeleteContainerFolder { rel });
                     ui.close_menu();
                 }
@@ -835,42 +1140,25 @@ pub(in crate::app) fn draw_tree_node(
             context_menu_separator(ui);
         }
 
+        // Loose folders receive this from the shared primary menu above;
+        // indexed/cache folders have no Favorites context, but their browser
+        // path is still useful on the clipboard.
+        if !groups_mode && favorite_keys.is_none() {
+            if context_menu_button(ui, "Copy Folder Path").clicked() {
+                clicked = Some(BrowserAction::CopyFolderPath(node.rel_path.clone()));
+                ui.close_menu();
+            }
+            context_menu_separator(ui);
+        }
+
         let tag_keys = collect_tag_keys(node, entries);
         if tag_keys.is_empty() {
             ui.label(RichText::new("No tags in this folder").color(subtle_dark()));
-        } else if ui
-            .button(format!("Dump folder to JSON... ({})", tag_keys.len()))
+        } else if context_menu_button(ui, &format!("Dump folder to JSON... ({})", tag_keys.len()))
             .clicked()
         {
             clicked = Some(BrowserAction::DumpLoadedFolderJson(tag_keys));
             ui.close_menu();
-        }
-
-        // Folders mode only. In Groups mode this node is a group label rather
-        // than a folder, and the extraction lays tags out by their own paths —
-        // so a group node would write a tree that has nothing to do with the
-        // node that was clicked.
-        if is_container && !groups_mode {
-            let container_keys = collect_container_tag_keys(node, entries);
-            if container_keys.is_empty() {
-                ui.label(RichText::new("No shipped tags in this folder").color(subtle_dark()));
-            } else if ui
-                .button(format!(
-                    "Extract tags to folder... ({})",
-                    container_keys.len()
-                ))
-                .on_hover_text(
-                    "Write every tag this folder ships to a folder on disk, laid out like an \
-                     editing kit",
-                )
-                .clicked()
-            {
-                clicked = Some(BrowserAction::ExtractContainerFolderTags {
-                    label: folder_display_path(node),
-                    keys: container_keys,
-                });
-                ui.close_menu();
-            }
         }
 
         // Monolithic caches only. The tags in one are big-endian and read-only,
@@ -880,8 +1168,7 @@ pub(in crate::app) fn draw_tree_node(
         if !groups_mode {
             let cache_tags = count_cache_tags(node, entries);
             if cache_tags > 0
-                && ui
-                    .button(format!("Import into editing kit... ({cache_tags})"))
+                && context_menu_button(ui, &format!("Import into editing kit... ({cache_tags})"))
                     .on_hover_text(
                         "Convert this folder to little-endian tags in an open editing kit, \
                          at the same paths, pulling in whatever they reference",
@@ -895,45 +1182,13 @@ pub(in crate::app) fn draw_tree_node(
             }
         }
 
-        let bitmap_keys = collect_bitmap_keys(node, entries);
-        if bitmap_keys.is_empty() {
-            ui.label(RichText::new("No bitmap tags in this folder").color(subtle_dark()));
-        } else if ui
-            .button(format!("Extract all bitmaps... ({})", bitmap_keys.len()))
-            .clicked()
+        // A group node is not a real folder, so only Folders mode may offer a
+        // raw container-folder extraction. Type-specific bulk exports remain
+        // valid in either view, matching their previous availability.
+        if let Some(action) =
+            folder_extract_menu_button(ui, node, entries, is_container && !groups_mode, false)
         {
-            clicked = Some(BrowserAction::ExtractBitmapFolder(bitmap_keys));
-            ui.close_menu();
-        }
-
-        let material_shader_keys = collect_material_shader_keys(node, entries);
-        if material_shader_keys.is_empty() {
-            ui.label(RichText::new("No material shaders in this folder").color(subtle_dark()));
-        } else if ui
-            .button(format!(
-                "Extract material shader sources... ({})",
-                material_shader_keys.len()
-            ))
-            .clicked()
-        {
-            clicked = Some(BrowserAction::ExtractMaterialShaderSourceFolder(
-                material_shader_keys,
-            ));
-            ui.close_menu();
-        }
-
-        let hlsl_include_keys = collect_hlsl_include_keys(node, entries);
-        if hlsl_include_keys.is_empty() {
-            ui.label(RichText::new("No HLSL includes in this folder").color(subtle_dark()));
-        } else if ui
-            .button(format!(
-                "Extract HLSL includes... ({})",
-                hlsl_include_keys.len()
-            ))
-            .clicked()
-        {
-            clicked = Some(BrowserAction::ExtractHlslIncludeFolder(hlsl_include_keys));
-            ui.close_menu();
+            clicked = Some(action);
         }
     });
     if !groups_mode && header_response.double_clicked() {
@@ -952,6 +1207,201 @@ fn paths_match_case_insensitive(a: &Path, b: &Path) -> bool {
         .eq_ignore_ascii_case(&b.to_string_lossy().replace('\\', "/"))
 }
 
+/// Collect the folder-wide export commands beneath one row. Keeping this
+/// shared between the lazy loose-folder tree and fully indexed sources makes
+/// their menus differ only in whether they say "loaded" and whether raw
+/// container tags can be extracted.
+fn folder_extract_menu_button(
+    ui: &mut Ui,
+    node: &TagTreeNode,
+    entries: &[TagEntry],
+    include_container_tags: bool,
+    loaded_labels: bool,
+) -> Option<BrowserAction> {
+    let container_keys = include_container_tags
+        .then(|| collect_container_tag_keys(node, entries))
+        .unwrap_or_default();
+    let bitmap_keys = collect_bitmap_keys(node, entries);
+    let material_shader_keys = collect_material_shader_keys(node, entries);
+    let hlsl_include_keys = collect_hlsl_include_keys(node, entries);
+    folder_extract_menu_from_keys(
+        ui,
+        folder_display_path(node),
+        container_keys,
+        bitmap_keys,
+        material_shader_keys,
+        hlsl_include_keys,
+        loaded_labels,
+        include_container_tags,
+        false,
+    )
+}
+
+/// Root-tree counterpart used by a folder tab header. A [`TagTree`] has the
+/// same entry/child shape as a folder node but deliberately carries no label,
+/// so the pane supplies the path used by raw-container extraction.
+pub(in crate::app) fn folder_tree_extract_menu_button(
+    ui: &mut Ui,
+    tree: &TagTree,
+    entries: &[TagEntry],
+    label: String,
+    include_container_tags: bool,
+    loaded_labels: bool,
+    open_left: bool,
+) -> Option<BrowserAction> {
+    let mut container_keys = Vec::new();
+    let mut bitmap_keys = Vec::new();
+    let mut material_shader_keys = Vec::new();
+    let mut hlsl_include_keys = Vec::new();
+
+    for &entry_index in &tree.entries {
+        let Some(entry) = entries.get(entry_index) else {
+            continue;
+        };
+        if include_container_tags && matches!(entry.location, TagEntryLocation::Container { .. }) {
+            container_keys.push(entry.key.clone());
+        }
+        if is_bitmap_tag(entry) {
+            bitmap_keys.push(entry.key.clone());
+        }
+        if is_material_shader_browser_tag(entry) {
+            material_shader_keys.push(entry.key.clone());
+        }
+        if is_hlsl_include_tag(entry) {
+            hlsl_include_keys.push(entry.key.clone());
+        }
+    }
+    for child in &tree.children {
+        if include_container_tags {
+            collect_container_tag_keys_into(child, entries, &mut container_keys);
+        }
+        collect_bitmap_keys_into(child, entries, &mut bitmap_keys);
+        collect_material_shader_keys_into(child, entries, &mut material_shader_keys);
+        collect_hlsl_include_keys_into(child, entries, &mut hlsl_include_keys);
+    }
+
+    folder_extract_menu_from_keys(
+        ui,
+        label,
+        container_keys,
+        bitmap_keys,
+        material_shader_keys,
+        hlsl_include_keys,
+        loaded_labels,
+        include_container_tags,
+        open_left,
+    )
+}
+
+fn folder_extract_menu_from_keys(
+    ui: &mut Ui,
+    label: String,
+    container_keys: Vec<String>,
+    bitmap_keys: Vec<String>,
+    material_shader_keys: Vec<String>,
+    hlsl_include_keys: Vec<String>,
+    loaded_labels: bool,
+    include_container_tags: bool,
+    open_left: bool,
+) -> Option<BrowserAction> {
+    let has_extractable = !container_keys.is_empty()
+        || !bitmap_keys.is_empty()
+        || !material_shader_keys.is_empty()
+        || !hlsl_include_keys.is_empty();
+
+    let menu = ui.add_enabled_ui(true, |ui| {
+        let contents = |ui: &mut Ui| {
+            style_tag_context_menu(ui);
+            let mut action = None;
+            if include_container_tags {
+                let count = container_keys.len();
+                let response = ui
+                    .add_enabled_ui(count > 0, |ui| {
+                        context_menu_button(ui, &format!("Extract tags to folder... ({count})"))
+                    })
+                    .inner
+                    .on_hover_text(
+                        "Write every tag this folder ships to a folder on disk, laid out like an \
+                     editing kit",
+                    );
+                if response.clicked() {
+                    action = Some(BrowserAction::ExtractContainerFolderTags {
+                        label: label.clone(),
+                        keys: container_keys,
+                    });
+                    ui.close_menu();
+                }
+            }
+
+            let bitmap_count = bitmap_keys.len();
+            let bitmap_qualifier = if loaded_labels { "loaded " } else { "all " };
+            let bitmap_response = ui
+                .add_enabled_ui(bitmap_count > 0, |ui| {
+                    context_menu_button(
+                        ui,
+                        &format!("Extract {bitmap_qualifier}bitmaps... ({bitmap_count})"),
+                    )
+                })
+                .inner;
+            if bitmap_response.clicked() {
+                action = Some(BrowserAction::ExtractBitmapFolder(bitmap_keys));
+                ui.close_menu();
+            }
+
+            let shader_count = material_shader_keys.len();
+            let shader_qualifier = if loaded_labels { "loaded " } else { "" };
+            let shader_response = ui
+                .add_enabled_ui(shader_count > 0, |ui| {
+                    context_menu_button(
+                        ui,
+                        &format!(
+                            "Extract {shader_qualifier}material shader sources... ({shader_count})"
+                        ),
+                    )
+                })
+                .inner;
+            if shader_response.clicked() {
+                action = Some(BrowserAction::ExtractMaterialShaderSourceFolder(
+                    material_shader_keys,
+                ));
+                ui.close_menu();
+            }
+
+            let hlsl_count = hlsl_include_keys.len();
+            let hlsl_qualifier = if loaded_labels { "loaded " } else { "" };
+            let hlsl_response = ui
+                .add_enabled_ui(hlsl_count > 0, |ui| {
+                    context_menu_button(
+                        ui,
+                        &format!("Extract {hlsl_qualifier}HLSL includes... ({hlsl_count})"),
+                    )
+                })
+                .inner;
+            if hlsl_response.clicked() {
+                action = Some(BrowserAction::ExtractHlslIncludeFolder(hlsl_include_keys));
+                ui.close_menu();
+            }
+
+            if !has_extractable {
+                ui.add_space(3.0);
+                let hint = if loaded_labels {
+                    "No loaded extractable tags — expand the folder to load its contents"
+                } else {
+                    "No extractable tags in this folder"
+                };
+                ui.label(RichText::new(hint).color(subtle_dark()));
+            }
+            action
+        };
+        if open_left {
+            left_opening_context_menu_submenu_button(ui, "Extract", ButtonIcon::Export, contents)
+        } else {
+            context_menu_submenu_button(ui, "Extract", ButtonIcon::Export, contents)
+        }
+    });
+    menu.inner
+}
+
 /// The leading actions shared by loose folders wherever they appear. Keeping
 /// this sequence in one place prevents Favorites, the sidebar, and folder tabs
 /// from silently losing different commands as the menu evolves.
@@ -964,13 +1414,15 @@ fn loose_folder_primary_menu_items(
 ) -> Option<BrowserAction> {
     let mut action = None;
     if let Some(favorited) = favorited {
-        if ui
-            .button(if favorited {
+        if context_menu_button(
+            ui,
+            if favorited {
                 "Remove from Favorites"
             } else {
                 "Add to Favorites"
-            })
-            .clicked()
+            },
+        )
+        .clicked()
         {
             action = Some(BrowserAction::ToggleFolderFavorite(rel_path.to_path_buf()));
             ui.close_menu();
@@ -980,9 +1432,8 @@ fn loose_folder_primary_menu_items(
     if let Some(transfer) = loose_folder_transfer_menu_items(ui, rel_path, label) {
         action = Some(transfer);
     }
-    context_menu_separator(ui);
     if open_in_new_tab {
-        if ui.button("Open in new tab").clicked() {
+        if context_menu_button(ui, "Open in new tab").clicked() {
             action = Some(BrowserAction::OpenFolderBrowser {
                 rel_path: rel_path.to_path_buf(),
                 label: label.to_owned(),
@@ -990,8 +1441,10 @@ fn loose_folder_primary_menu_items(
             });
             ui.close_menu();
         }
-        context_menu_separator(ui);
     }
+    // Explorer and clipboard-path commands form the next section at every
+    // right-click entry point that consumes this shared primary block.
+    context_menu_separator(ui);
     action
 }
 
@@ -1002,14 +1455,14 @@ pub(in crate::app) fn loose_folder_transfer_menu_items(
     rel_path: &Path,
     label: &str,
 ) -> Option<BrowserAction> {
-    if ui.button("Move to...").clicked() {
+    if context_menu_button(ui, "Move to...").clicked() {
         ui.close_menu();
         return Some(BrowserAction::MoveLooseFolder {
             rel_path: rel_path.to_path_buf(),
             label: label.to_owned(),
         });
     }
-    if ui.button("Copy to...").clicked() {
+    if context_menu_button(ui, "Copy to...").clicked() {
         ui.close_menu();
         return Some(BrowserAction::CopyLooseFolder {
             rel_path: rel_path.to_path_buf(),
@@ -1018,8 +1471,7 @@ pub(in crate::app) fn loose_folder_transfer_menu_items(
     }
     // Import is intentionally not Expert-gated: converting content from
     // another game is a primary folder operation and confirms before writing.
-    if ui
-        .button("Import tags here...")
+    if context_menu_button(ui, "Import tags here...")
         .on_hover_text(
             "Convert a tag, or a whole folder of them, from another game into this folder",
         )
@@ -1057,19 +1509,19 @@ fn container_authoring_menu_items(
     folder_rel: Option<String>,
 ) -> Option<BrowserAction> {
     let mut clicked = None;
-    if ui.button("New tag here...").clicked() {
+    if context_menu_button(ui, "New tag here...").clicked() {
         clicked = Some(BrowserAction::NewTagInFolder {
             folder_rel: folder_rel.clone(),
         });
         ui.close_menu();
     }
-    if ui.button("Import tag here...").clicked() {
+    if context_menu_button(ui, "Import tag here...").clicked() {
         clicked = Some(BrowserAction::ImportTagInFolder {
             folder_rel: folder_rel.clone(),
         });
         ui.close_menu();
     }
-    if ui.button("New folder here...").clicked() {
+    if context_menu_button(ui, "New folder here...").clicked() {
         clicked = Some(BrowserAction::NewContainerFolder {
             parent_rel: folder_rel,
         });
@@ -1096,6 +1548,7 @@ fn draw_container_root_target(ui: &mut Ui) -> Option<BrowserAction> {
     let (_, response) = ui.allocate_exact_size(size, Sense::click());
     let mut clicked = None;
     response.context_menu(|ui| {
+        style_tag_context_menu(ui);
         // Right-clicking blank space is ambiguous about what it acts on, so the
         // menu says.
         ui.label(RichText::new("Container root").color(subtle_dark()).small());
@@ -1769,7 +2222,7 @@ pub(in crate::app) fn draw_entry(
     };
     let mut action = open_requested.then(|| BrowserAction::Select(entry.key.clone()));
     response.context_menu(|ui| {
-        if let Some(menu_action) = draw_tag_context_menu_contents(ui, entry, favorite_keys) {
+        if let Some(menu_action) = draw_tag_context_menu_contents(ui, entry, favorite_keys, false) {
             action = Some(menu_action);
         }
     });
@@ -1780,6 +2233,7 @@ pub(in crate::app) fn draw_tag_context_menu_contents(
     ui: &mut Ui,
     entry: &TagEntry,
     favorite_keys: Option<&HashSet<String>>,
+    open_submenus_left: bool,
 ) -> Option<BrowserAction> {
     let mut action = None;
     style_tag_context_menu(ui);
@@ -1804,16 +2258,26 @@ pub(in crate::app) fn draw_tag_context_menu_contents(
     let deletable = browser_deletable_keys(ui);
     let delete_enabled = supports_delete_menu(entry, deletable.as_deref());
     let extract_enabled = supports_tag_extract_menu(entry.group_tag);
+    const PRIMARY_BUTTON_GAP: f32 = 4.0;
+    let primary_button_width = (ui.available_width() - PRIMARY_BUTTON_GAP * 3.0) / 4.0;
     ui.horizontal(|ui| {
-        if context_menu_primary_button(ui, "Rename", rename_enabled).clicked() {
+        ui.spacing_mut().item_spacing.x = PRIMARY_BUTTON_GAP;
+        if context_menu_primary_button(ui, "Rename", rename_enabled, primary_button_width).clicked()
+        {
             action = Some(BrowserAction::RenameTag(entry.key.clone()));
             ui.close_menu();
         }
-        if context_menu_primary_button(ui, "Duplicate", duplicate_enabled).clicked() {
+        if context_menu_primary_button(ui, "Move", rename_enabled, primary_button_width).clicked() {
+            action = Some(BrowserAction::MoveTag(entry.key.clone()));
+            ui.close_menu();
+        }
+        if context_menu_primary_button(ui, "Duplicate", duplicate_enabled, primary_button_width)
+            .clicked()
+        {
             action = Some(BrowserAction::DuplicateTag(entry.key.clone()));
             ui.close_menu();
         }
-        if context_menu_primary_button(ui, "Delete", delete_enabled)
+        if context_menu_primary_button(ui, "Delete", delete_enabled, primary_button_width)
             .on_disabled_hover_text(
                 "Only loose tags and Campaign Evolved tags duplicated by Baboon can be deleted",
             )
@@ -1822,92 +2286,11 @@ pub(in crate::app) fn draw_tag_context_menu_contents(
             action = Some(BrowserAction::DeleteTag(entry.key.clone()));
             ui.close_menu();
         }
-        if context_menu_primary_button(ui, "Move", rename_enabled).clicked() {
-            action = Some(BrowserAction::MoveTag(entry.key.clone()));
-            ui.close_menu();
-        }
-        ui.add_enabled_ui(extract_enabled, |ui| {
-            ui.allocate_ui(Vec2::new(92.0, 44.0), |ui| {
-                ui.set_min_width(92.0);
-                let extract_menu = ui.menu_button("     Extract", |ui| {
-                    ui.set_min_width(280.0);
-                    if supports_tag_geometry_extraction(entry.group_tag)
-                        && context_menu_button(ui, "Extract model geometry").clicked()
-                    {
-                        action = Some(BrowserAction::ExtractGeometry(entry.key.clone()));
-                        ui.close_menu();
-                    }
-                    if supports_bsp_geometry_extraction(entry.group_tag)
-                        && context_menu_button(ui, "Extract BSP geometry").clicked()
-                    {
-                        action = Some(BrowserAction::ExtractGeometry(entry.key.clone()));
-                        ui.close_menu();
-                    }
-                    if supports_scenario_geometry_extraction(entry.group_tag)
-                        && context_menu_button(ui, "Extract level geometry (one file per BSP)")
-                            .clicked()
-                    {
-                        action = Some(BrowserAction::ExtractGeometry(entry.key.clone()));
-                        ui.close_menu();
-                    }
-                    if supports_particle_geometry_extraction(entry.group_tag)
-                        && context_menu_button(
-                            ui,
-                            "Extract particle geometry (JMI + one JMS per object)",
-                        )
-                        .clicked()
-                    {
-                        action = Some(BrowserAction::ExtractGeometry(entry.key.clone()));
-                        ui.close_menu();
-                    }
-                    if supports_animation_extraction(entry.group_tag)
-                        && context_menu_button(ui, "Extract animations").clicked()
-                    {
-                        action = Some(BrowserAction::ExtractAnimation(entry.key.clone()));
-                        ui.close_menu();
-                    }
-                    if supports_tag_import_info_extraction(entry.group_tag)
-                        && context_menu_button(ui, "Extract import-info").clicked()
-                    {
-                        action = Some(BrowserAction::ExtractImportInfo(entry.key.clone()));
-                        ui.close_menu();
-                    }
-                    if is_bitmap_group(entry.group_tag)
-                        && context_menu_button(ui, "Extract bitmap images...").clicked()
-                    {
-                        action = Some(BrowserAction::ExtractBitmap(entry.key.clone()));
-                        ui.close_menu();
-                    }
-                    if is_material_shader_group(entry.group_tag)
-                        && context_menu_button(ui, "Extract source shaders...").clicked()
-                    {
-                        action = Some(BrowserAction::ExtractMaterialShaderSources(
-                            entry.key.clone(),
-                        ));
-                        ui.close_menu();
-                    }
-                    if is_hlsl_include_group(entry.group_tag)
-                        && context_menu_button(ui, "Extract HLSL include...").clicked()
-                    {
-                        action = Some(BrowserAction::ExtractHlslIncludeSource(entry.key.clone()));
-                        ui.close_menu();
-                    }
-                });
-                let icon_rect = egui::Rect::from_center_size(
-                    egui::pos2(
-                        extract_menu.response.rect.left() + 17.0,
-                        extract_menu.response.rect.center().y,
-                    ),
-                    Vec2::splat(16.0),
-                );
-                paint_button_icon_at(ui, ButtonIcon::Export, icon_rect, text_dark());
-            });
-        });
     });
 
     // Whole-tag operations, inline: the raw payload, and the scenario's
-    // script source. Per-asset extraction lives in the Extract submenu
-    // above instead.
+    // script source. Per-asset extraction lives in the Extract submenu lower
+    // in the full-width command list.
     // Campaign Evolved only for the script pair: the scenario keeps its
     // original `.hsc` source, and replacing it is only meaningful where that
     // round-trip is known to hold.
@@ -1931,14 +2314,28 @@ pub(in crate::app) fn draw_tag_context_menu_contents(
         }
     }
 
+    context_menu_separator(ui);
+    if let Some(favorite_keys) = favorite_keys {
+        let label = if favorite_keys.contains(&entry.key) {
+            "Remove from Favorites"
+        } else {
+            "Add to Favorites"
+        };
+        if context_menu_button(ui, label).clicked() {
+            action = Some(BrowserAction::ToggleFavorite(entry.key.clone()));
+            ui.close_menu();
+        }
+    }
+
     // The same two launches the tag pane's header offers, so a scenario can
-    // be opened in the kit's tools without opening the tag first. Shown only
-    // where the kit can launch at all; Sapien is *hidden* rather than
-    // disabled where it takes no scenario argument, matching the toolbar —
-    // a control that can never work is not offered greyed out.
+    // be opened in the kit's tools without opening the tag first. Keep them
+    // together directly below Favorites. Sapien is hidden where the kit can
+    // never accept a scenario; missing executables remain visible but disabled.
     let launch = browser_scenario_launch(ui);
     if launch.supported && is_scenario_group(entry.group_tag) {
-        context_menu_separator(ui);
+        if favorite_keys.is_some() {
+            context_menu_separator(ui);
+        }
         if launch.offers_sapien {
             let response = ui
                 .add_enabled_ui(launch.sapien_present, |ui| {
@@ -1955,7 +2352,7 @@ pub(in crate::app) fn draw_tag_context_menu_contents(
         }
         let response = ui
             .add_enabled_ui(launch.tag_test_present, |ui| {
-                context_menu_button(ui, "Open in tag_test")
+                context_menu_button(ui, "Open in Tag Test")
             })
             .inner;
         if response.clicked() {
@@ -1967,21 +2364,35 @@ pub(in crate::app) fn draw_tag_context_menu_contents(
         }
     }
 
+    if favorite_keys.is_some() || launch.supported && is_scenario_group(entry.group_tag) {
+        context_menu_separator(ui);
+    }
+    if supports_tag_reimport(entry) {
+        let enabled = matches!(entry.location, TagEntryLocation::LooseFile(_));
+        let response = ui
+            .add_enabled_ui(enabled, |ui| context_menu_button(ui, "Reimport"))
+            .inner;
+        if response.clicked() {
+            action = Some(BrowserAction::ReimportGeometry(entry.key.clone()));
+            ui.close_menu();
+        }
+        if !enabled {
+            response.on_disabled_hover_text("Reimport requires a loose editing-kit tag");
+        }
+    }
+    let extract_action = ui
+        .add_enabled_ui(extract_enabled, |ui| {
+            tag_extract_menu_button(ui, entry, open_submenus_left)
+        })
+        .inner;
+    if extract_action.is_some() {
+        action = extract_action;
+    }
+
     context_menu_separator(ui);
     if context_menu_button(ui, "Open with File Explorer").clicked() {
         action = Some(BrowserAction::OpenInExplorer(entry.key.clone()));
         ui.close_menu();
-    }
-    if let Some(favorite_keys) = favorite_keys {
-        let label = if favorite_keys.contains(&entry.key) {
-            "Remove from Favorites"
-        } else {
-            "Add to Favorites"
-        };
-        if context_menu_button(ui, label).clicked() {
-            action = Some(BrowserAction::ToggleFavorite(entry.key.clone()));
-            ui.close_menu();
-        }
     }
     if context_menu_button(ui, "Copy Tag Path").clicked() {
         action = Some(BrowserAction::CopyTagName(entry.key.clone()));
@@ -2011,6 +2422,8 @@ pub(in crate::app) fn draw_tag_context_menu_contents(
 pub(in crate::app) fn draw_favorites(
     ui: &mut Ui,
     entries: &[TagEntry],
+    folder_entries: &[TagEntry],
+    tags_root: Option<&Path>,
     selected: Option<&str>,
     filter: &str,
     show_prefixes: bool,
@@ -2063,6 +2476,7 @@ pub(in crate::app) fn draw_favorites(
                 });
             }
             response.context_menu(|ui| {
+                style_tag_context_menu(ui);
                 if let Some(folder_action) = loose_folder_primary_menu_items(
                     ui,
                     folder,
@@ -2074,12 +2488,41 @@ pub(in crate::app) fn draw_favorites(
                 }
                 if context_menu_button(ui, "Open with File Explorer").clicked() {
                     action = Some(BrowserAction::OpenLooseFolderInExplorer {
-                        rel_path: folder.clone(),
+                        // Bind a favorite to the root it was rendered from.
+                        // This avoids resolving it against a different active
+                        // workspace if focus changes during the menu click.
+                        rel_path: tags_root
+                            .map(|root| root.join(folder))
+                            .unwrap_or_else(|| folder.clone()),
                     });
                     ui.close_menu();
                 }
-                ui.separator();
-                if ui.button("Dump folder to JSON...").clicked() {
+                if context_menu_button(ui, "Copy Folder Path").clicked() {
+                    action = Some(BrowserAction::CopyFolderPath(folder.clone()));
+                    ui.close_menu();
+                }
+                context_menu_separator(ui);
+                // Favorite folders do not own a tree node in this section.
+                // Rebuild only their loaded subtree while the menu is open so
+                // the shared extraction menu can collect the same keys as a
+                // manually navigated folder without doing I/O on right-click.
+                let subtree = crate::source::build_tree_beneath(folder_entries, folder);
+                let folder_node = TagTreeNode {
+                    label: label.clone(),
+                    rel_path: folder.clone(),
+                    children: subtree.children,
+                    children_loaded: true,
+                    entries: subtree.entries,
+                    entries_loaded: true,
+                    pending: false,
+                };
+                if let Some(folder_action) =
+                    folder_extract_menu_button(ui, &folder_node, folder_entries, false, true)
+                {
+                    action = Some(folder_action);
+                }
+                context_menu_separator(ui);
+                if context_menu_button(ui, "Dump folder to JSON...").clicked() {
                     action = Some(BrowserAction::DumpLooseFolderJson {
                         rel_path: folder.clone(),
                         label: label.clone(),
@@ -2605,6 +3048,62 @@ mod tests {
     #[test]
     fn duplicate_context_button_uses_duplicate_asset_icon() {
         assert_eq!(context_menu_icon("Duplicate"), Some(ButtonIcon::Duplicate));
+    }
+
+    #[test]
+    fn reimport_context_button_uses_import_icon() {
+        assert_eq!(context_menu_icon("Reimport"), Some(ButtonIcon::Import));
+    }
+
+    #[test]
+    fn folder_context_commands_have_matching_icons() {
+        assert_eq!(context_menu_icon("Move to..."), Some(ButtonIcon::Move));
+        assert_eq!(context_menu_icon("Copy to..."), Some(ButtonIcon::Copy));
+        assert_eq!(
+            context_menu_icon("Copy Folder Path"),
+            Some(ButtonIcon::CopyPath)
+        );
+        assert_eq!(
+            context_menu_icon("Import tags here..."),
+            Some(ButtonIcon::Import)
+        );
+        assert_eq!(
+            context_menu_icon("New folder here..."),
+            Some(ButtonIcon::FolderClosed)
+        );
+        assert_eq!(
+            context_menu_icon("Dump folder to JSON... (12)"),
+            Some(ButtonIcon::Json)
+        );
+        assert_eq!(
+            context_menu_icon("Extract loaded HLSL includes... (3)"),
+            Some(ButtonIcon::Export)
+        );
+    }
+
+    #[test]
+    fn reimport_menu_matches_the_reference_field_tag_types() {
+        let loose = TagEntryLocation::LooseFile(PathBuf::from(
+            "objects/characters/example/example.render_model",
+        ));
+        for group_name in [
+            "render_model",
+            "collision_model",
+            "physics_model",
+            "model_animation_graph",
+        ] {
+            let candidate = TagEntry {
+                group_name: Some(group_name.to_owned()),
+                ..entry(loose.clone())
+            };
+            assert!(supports_tag_reimport(&candidate), "{group_name}");
+        }
+
+        let bitmap = TagEntry {
+            group_name: Some("bitmap".to_owned()),
+            ..entry(loose)
+        };
+        assert!(!supports_tag_reimport(&bitmap));
     }
 
     /// The count that decides whether a folder offers the cache import at all.

--- a/src/app/button_icons.rs
+++ b/src/app/button_icons.rs
@@ -38,6 +38,8 @@ pub(super) enum ButtonIcon {
     JumpTo,
     JumpUp,
     Left,
+    ListDropdownLeft,
+    ListDropdownRight,
     Move,
     Opened,
     Other,
@@ -91,6 +93,12 @@ pub(super) fn button_icon_svg(icon: ButtonIcon) -> &'static str {
         ButtonIcon::JumpTo => include_str!("../../assets/Button Icons/Jump To.svg"),
         ButtonIcon::JumpUp => include_str!("../../assets/Button Icons/Jump Up.svg"),
         ButtonIcon::Left => include_str!("../../assets/Button Icons/Left.svg"),
+        ButtonIcon::ListDropdownLeft => {
+            include_str!("../../assets/Button Icons/List Dropdown - Left.svg")
+        }
+        ButtonIcon::ListDropdownRight => {
+            include_str!("../../assets/Button Icons/List Dropdown - Right.svg")
+        }
         ButtonIcon::Move => include_str!("../../assets/Button Icons/Move.svg"),
         ButtonIcon::Opened => include_str!("../../assets/Button Icons/Opened.svg"),
         ButtonIcon::Other => include_str!("../../assets/Button Icons/Other.svg"),
@@ -214,12 +222,89 @@ pub(super) fn selectable_icon_text_button(
     label: impl Into<egui::WidgetText>,
     selected: bool,
 ) -> egui::Response {
-    let image = button_icon_image(ui, icon, text_dark(), BUTTON_ICON_SIZE);
-    ui.add(
-        egui::Button::image_and_text(image, label)
-            .selected(selected)
-            .min_size(Vec2::new(0.0, BUTTON_HEIGHT)),
-    )
+    ui.scope(|ui| {
+        if selected {
+            let selection = ui.visuals().selection;
+            let hover_color = if is_dark_mode() {
+                Color32::WHITE
+            } else {
+                Color32::BLACK
+            };
+            let widgets = &mut ui.visuals_mut().widgets;
+
+            // egui's built-in `Button::selected` paints with square corners.
+            // Apply the selected palette through the normal button states so
+            // toggles retain their usual rounding and hover expansion.
+            widgets.inactive.weak_bg_fill = selection.bg_fill;
+            widgets.inactive.bg_stroke = selection.stroke;
+            widgets.hovered.weak_bg_fill = selection.bg_fill;
+            widgets.hovered.bg_stroke = Stroke::new(selection.stroke.width, hover_color);
+            widgets.hovered.expansion = widgets.hovered.expansion.max(1.0);
+            widgets.active.weak_bg_fill = selection.bg_fill;
+            widgets.active.bg_stroke = Stroke::new(selection.stroke.width, hover_color);
+            widgets.active.expansion = widgets.active.expansion.max(1.0);
+        }
+
+        let image = button_icon_image(ui, icon, text_dark(), BUTTON_ICON_SIZE);
+        ui.add(
+            egui::Button::image_and_text(image, label)
+                .min_size(Vec2::new(0.0, BUTTON_HEIGHT)),
+        )
+    })
+    .inner
+}
+
+/// egui offsets a popup frame to align its first row with the trigger. Shift
+/// only the positioning response by that inset so the frame edge aligns with
+/// the real button while retaining the frame's visible content padding.
+fn aligned_menu_custom_button<R>(
+    ui: &mut Ui,
+    button: egui::Button<'_>,
+    right_aligned_width: Option<f32>,
+    add_contents: impl FnOnce(&mut Ui) -> R,
+) -> egui::InnerResponse<Option<R>> {
+    let bar_id = ui.id();
+    let mut bar_state = egui::menu::BarState::load(ui.ctx(), bar_id);
+    let button_response = ui.add(button);
+    let mut positioning_response = button_response.clone();
+    let frame_left = Frame::menu(&ui.ctx().style()).total_margin().left;
+    positioning_response.rect.min.x = right_aligned_width
+        .map_or(positioning_response.rect.min.x + frame_left, |width| {
+            button_response.rect.right() - width + frame_left
+        });
+    let inner = bar_state.bar_menu(&positioning_response, add_contents);
+    bar_state.store(ui.ctx(), bar_id);
+    egui::InnerResponse::new(inner.map(|response| response.inner), button_response)
+}
+
+pub(super) fn aligned_menu_button<R>(
+    ui: &mut Ui,
+    title: impl Into<egui::WidgetText>,
+    add_contents: impl FnOnce(&mut Ui) -> R,
+) -> egui::InnerResponse<Option<R>> {
+    let previous_padding = ui.spacing().button_padding.x;
+    ui.spacing_mut().button_padding.x = 8.0;
+    let menu = aligned_menu_custom_button(ui, egui::Button::new(title), None, add_contents);
+    ui.spacing_mut().button_padding.x = previous_padding;
+    menu
+}
+
+pub(super) fn right_aligned_menu_button<R>(
+    ui: &mut Ui,
+    title: impl Into<egui::WidgetText>,
+    popup_width: f32,
+    add_contents: impl FnOnce(&mut Ui) -> R,
+) -> egui::InnerResponse<Option<R>> {
+    let previous_padding = ui.spacing().button_padding.x;
+    ui.spacing_mut().button_padding.x = 8.0;
+    let menu = aligned_menu_custom_button(
+        ui,
+        egui::Button::new(title),
+        Some(popup_width),
+        add_contents,
+    );
+    ui.spacing_mut().button_padding.x = previous_padding;
+    menu
 }
 
 /// A menu trigger with the same fixed square geometry as the app's other
@@ -231,15 +316,207 @@ pub(super) fn icon_menu_button<R>(
     tooltip: &str,
     add_contents: impl FnOnce(&mut Ui) -> R,
 ) -> egui::Response {
-    let menu = egui::menu::menu_custom_button(
+    let menu = aligned_menu_custom_button(
         ui,
         egui::Button::new("").min_size(ICON_BUTTON_SIZE),
+        None,
         add_contents,
     );
     let icon_rect =
         egui::Rect::from_center_size(menu.response.rect.center(), Vec2::splat(BUTTON_ICON_SIZE));
     paint_button_icon_at(ui, icon, icon_rect, text_dark());
     menu.response.on_hover_text(tooltip)
+}
+
+/// Header action menus sit against the right edge of their pane. Align their
+/// popup's outer right edge to the trigger instead of using the usual left
+/// edge anchor.
+pub(super) fn right_aligned_icon_menu_button<R>(
+    ui: &mut Ui,
+    icon: ButtonIcon,
+    tooltip: &str,
+    popup_width: f32,
+    add_contents: impl FnOnce(&mut Ui) -> R,
+) -> egui::Response {
+    let menu = aligned_menu_custom_button(
+        ui,
+        egui::Button::new("").min_size(ICON_BUTTON_SIZE),
+        Some(popup_width),
+        add_contents,
+    );
+    let icon_rect =
+        egui::Rect::from_center_size(menu.response.rect.center(), Vec2::splat(BUTTON_ICON_SIZE));
+    paint_button_icon_at(ui, icon, icon_rect, text_dark());
+    menu.response.on_hover_text(tooltip)
+}
+
+pub(super) fn paint_submenu_icon(ui: &Ui, response: &egui::Response, opens_left: bool) {
+    let color = if ui.is_enabled() {
+        text_dark()
+    } else {
+        ui.visuals().widgets.noninteractive.fg_stroke.color
+    };
+    let rect = egui::Rect::from_center_size(
+        egui::pos2(response.rect.right() - 12.0, response.rect.center().y),
+        Vec2::splat(16.0),
+    );
+    let icon = if opens_left {
+        ButtonIcon::ListDropdownLeft
+    } else {
+        ButtonIcon::ListDropdownRight
+    };
+    let image = button_icon_image(ui, icon, color, 16.0);
+    image.paint_at(ui, rect);
+}
+
+/// Show a hover submenu to the left of a row in a right-anchored parent menu.
+/// The union of the row and the last popup rectangle forms a pointer corridor,
+/// so crossing the small inter-menu gap does not collapse the child.
+pub(super) fn left_opening_menu_popup<R>(
+    ui: &mut Ui,
+    response: &egui::Response,
+    popup_id: egui::Id,
+    popup_width: f32,
+    add_contents: impl FnOnce(&mut Ui) -> R,
+) -> Option<R> {
+    let previous_rect = egui::AreaState::load(ui.ctx(), popup_id).map(|state| state.rect());
+    let pointer = ui.input(|input| input.pointer.hover_pos());
+    let was_open = ui.data(|data| data.get_temp::<bool>(popup_id).unwrap_or(false));
+    let pointer_in_path = pointer.is_some_and(|pointer| {
+        previous_rect
+            .map(|rect| rect.union(response.rect).contains(pointer))
+            .unwrap_or(false)
+    });
+    if !(response.hovered() || response.clicked() || was_open && pointer_in_path) {
+        ui.data_mut(|data| data.insert_temp(popup_id, false));
+        return None;
+    }
+
+    let menu_frame = Frame::menu(ui.style());
+    let parent_outer_left = ui.max_rect().left() - menu_frame.total_margin().left;
+    let position = egui::pos2(
+        parent_outer_left - ui.spacing().menu_spacing,
+        response.rect.top(),
+    );
+    let shown = egui::Area::new(popup_id)
+        .kind(egui::UiKind::Menu)
+        .order(egui::Order::Foreground)
+        .pivot(Align2::RIGHT_TOP)
+        .fixed_pos(position)
+        .default_width(popup_width)
+        .show(ui.ctx(), |ui| {
+            menu_frame
+                .show(ui, |ui| {
+                    ui.with_layout(
+                        egui::Layout::top_down_justified(egui::Align::LEFT),
+                        add_contents,
+                    )
+                    .inner
+                })
+                .inner
+        });
+
+    let keep_open =
+        pointer.is_some_and(|pointer| shown.response.rect.union(response.rect).contains(pointer));
+    ui.data_mut(|data| data.insert_temp(popup_id, keep_open));
+    Some(shown.inner)
+}
+
+pub(super) fn right_opening_menu_popup<R>(
+    ui: &mut Ui,
+    response: &egui::Response,
+    popup_id: egui::Id,
+    popup_width: f32,
+    add_contents: impl FnOnce(&mut Ui) -> R,
+) -> Option<R> {
+    let previous_rect = egui::AreaState::load(ui.ctx(), popup_id).map(|state| state.rect());
+    let pointer = ui.input(|input| input.pointer.hover_pos());
+    let was_open = ui.data(|data| data.get_temp::<bool>(popup_id).unwrap_or(false));
+    let pointer_in_path = pointer.is_some_and(|pointer| {
+        previous_rect
+            .map(|rect| rect.union(response.rect).contains(pointer))
+            .unwrap_or(false)
+    });
+    if !(response.hovered() || response.clicked() || was_open && pointer_in_path) {
+        ui.data_mut(|data| data.insert_temp(popup_id, false));
+        return None;
+    }
+
+    let menu_frame = Frame::menu(ui.style());
+    let parent_outer_right = ui.max_rect().right() + menu_frame.total_margin().right;
+    let position = egui::pos2(
+        parent_outer_right + ui.spacing().menu_spacing,
+        response.rect.top(),
+    );
+    let shown = egui::Area::new(popup_id)
+        .kind(egui::UiKind::Menu)
+        .order(egui::Order::Foreground)
+        .pivot(Align2::LEFT_TOP)
+        .fixed_pos(position)
+        .default_width(popup_width)
+        .show(ui.ctx(), |ui| {
+            menu_frame
+                .show(ui, |ui| {
+                    ui.with_layout(
+                        egui::Layout::top_down_justified(egui::Align::LEFT),
+                        add_contents,
+                    )
+                    .inner
+                })
+                .inner
+        });
+
+    let keep_open =
+        pointer.is_some_and(|pointer| shown.response.rect.union(response.rect).contains(pointer));
+    ui.data_mut(|data| data.insert_temp(popup_id, keep_open));
+    Some(shown.inner)
+}
+
+pub(super) fn right_opening_menu_button<R>(
+    ui: &mut Ui,
+    label: impl Into<egui::WidgetText>,
+    popup_width: f32,
+    add_contents: impl FnOnce(&mut Ui) -> R,
+) -> egui::InnerResponse<Option<R>> {
+    let response = ui.button(label);
+    paint_submenu_icon(ui, &response, false);
+    let popup_id = response.id.with("right_submenu");
+    let group_id = ui.layer_id().id.with("active_right_submenu");
+    let active_before_hover = ui.data(|data| data.get_temp::<egui::Id>(group_id));
+    if response.hovered() || response.clicked() {
+        if let Some(previous_popup_id) = active_before_hover.filter(|id| *id != popup_id) {
+            ui.data_mut(|data| data.insert_temp(previous_popup_id, false));
+        }
+        ui.data_mut(|data| data.insert_temp(group_id, popup_id));
+    }
+    let active = ui.data(|data| data.get_temp::<egui::Id>(group_id));
+    // When moving between sibling rows, keep the popup drawn earlier in this
+    // frame (if any) and draw the newly hovered child on the next frame. This
+    // avoids one-frame overlap without depending on sibling draw order.
+    let switching_siblings = response.hovered()
+        && active_before_hover.is_some_and(|previous| previous != popup_id);
+    let inner = if active == Some(popup_id) && !switching_siblings {
+        right_opening_menu_popup(ui, &response, popup_id, popup_width, add_contents)
+    } else {
+        ui.data_mut(|data| data.insert_temp(popup_id, false));
+        None
+    };
+    if inner.is_none() && active == Some(popup_id) && !switching_siblings {
+        ui.data_mut(|data| data.remove::<egui::Id>(group_id));
+    }
+    egui::InnerResponse::new(inner, response)
+}
+
+pub(super) fn left_opening_menu_button<R>(
+    ui: &mut Ui,
+    label: &str,
+    popup_width: f32,
+    add_contents: impl FnOnce(&mut Ui) -> R,
+) -> Option<R> {
+    let response = ui.button(label);
+    paint_submenu_icon(ui, &response, true);
+    let popup_id = response.id.with(("left_submenu", label));
+    left_opening_menu_popup(ui, &response, popup_id, popup_width, add_contents)
 }
 
 fn button_icon_uri_for_pixels_per_point(

--- a/src/app/chimp.rs
+++ b/src/app/chimp.rs
@@ -936,18 +936,7 @@ impl egui_tiles::Behavior<String> for ChimpPaneBehavior<'_> {
             }
             if has_mesh {
                 ui.separator();
-                ui.menu_button("Extract mesh", |ui| {
-                    for format in [
-                        ChimpMeshFormat::Jms,
-                        ChimpMeshFormat::Psk,
-                        ChimpMeshFormat::Pskx,
-                    ] {
-                        if ui.button(format.label()).clicked() {
-                            self.extract_mesh = Some((package.clone(), format));
-                            ui.close_menu();
-                        }
-                    }
-                });
+                chimp_mesh_export_menu(ui, &package, &mut self.extract_mesh);
             }
             if chimp_looks_like_level(&package) {
                 ui.separator();
@@ -6101,19 +6090,11 @@ fn draw_chimp_folder_node(
                     }
                 }
                 if actions.mesh {
-                    ui.menu_button("Extract mesh", |ui| {
-                        for format in [
-                            ChimpMeshFormat::Jms,
-                            ChimpMeshFormat::Psk,
-                            ChimpMeshFormat::Pskx,
-                        ] {
-                            if ui.button(format.label()).clicked() {
-                                clicked =
-                                    Some(ChimpTreeClick::ExtractMesh(package.name.clone(), format));
-                                ui.close_menu();
-                            }
-                        }
-                    });
+                    let mut requested = None;
+                    chimp_mesh_export_menu(ui, &package.name, &mut requested);
+                    if let Some((package, format)) = requested {
+                        clicked = Some(ChimpTreeClick::ExtractMesh(package, format));
+                    }
                 }
                 if actions.level {
                     let mut requested = None;
@@ -6157,18 +6138,25 @@ fn chimp_mesh_export_menu(
     package: &str,
     requested: &mut Option<(String, ChimpMeshFormat)>,
 ) {
-    ui.menu_button("Extract mesh", |ui| {
+    let format = right_opening_menu_button(ui, "Extract mesh", 220.0, |ui| {
+        style_list_menu(ui);
         for format in [
             ChimpMeshFormat::Jms,
             ChimpMeshFormat::Psk,
             ChimpMeshFormat::Pskx,
         ] {
             if ui.button(format.label()).clicked() {
-                *requested = Some((package.to_owned(), format));
-                ui.close_menu();
+                return Some(format);
             }
         }
-    });
+        None
+    })
+    .inner
+    .flatten();
+    if let Some(format) = format {
+        *requested = Some((package.to_owned(), format));
+        ui.close_menu();
+    }
 }
 
 /// Offered only where it means something: a package with `_Generated_` cells
@@ -6178,18 +6166,25 @@ fn chimp_level_export_menu(
     package: &str,
     requested: &mut Option<(String, ChimpLevelFormat)>,
 ) {
-    ui.menu_button("Export level", |ui| {
+    let selected = right_opening_menu_button(ui, "Export level", 220.0, |ui| {
+        style_list_menu(ui);
         for format in [ChimpLevelFormat::SegmentedUsd, ChimpLevelFormat::Blender] {
             if ui
                 .button(format.label())
                 .on_hover_text(format.summary())
                 .clicked()
             {
-                *requested = Some((package.to_owned(), format));
-                ui.close_menu();
+                return Some(format);
             }
         }
-    });
+        None
+    })
+    .inner
+    .flatten();
+    if let Some(format) = selected {
+        *requested = Some((package.to_owned(), format));
+        ui.close_menu();
+    }
 }
 
 use super::controller::{
@@ -6671,10 +6666,14 @@ fn draw_chimp_property_block(
             })
             .collect();
         if !omitted.is_empty() {
-            ui.menu_button(
+            let added = right_opening_menu_button(
+                ui,
                 format!("Add omitted property… ({})", omitted.len()),
+                300.0,
                 |ui| {
+                    style_list_menu(ui);
                     ui.set_max_height(360.0);
+                    let mut added = false;
                     egui::ScrollArea::vertical().show(ui, |ui| {
                         for (name, slot, ty) in &omitted {
                             let label = if slot.array_index == 0 {
@@ -6695,12 +6694,18 @@ fn draw_chimp_property_block(
                                 .is_ok()
                             {
                                 changed = true;
-                                ui.close_menu();
+                                added = true;
                             }
                         }
                     });
+                    added
                 },
-            );
+            )
+            .inner
+            .unwrap_or(false);
+            if added {
+                ui.close_menu();
+            }
             ui.separator();
         }
     }

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -9298,17 +9298,18 @@ mod tests {
 
     #[test]
     fn favorite_folder_explorer_path_stays_bound_to_its_rendered_tags_root() {
-        let rendered = Path::new(r"D:\HREK\tags\objects\characters");
+        let windows_rendered = Path::new(r"D:\HREK\tags\objects\characters");
         assert_eq!(
-            loose_folder_explorer_path(Path::new(r"C:\OtherKit\tags"), rendered),
-            rendered
+            loose_folder_explorer_path(Path::new(r"C:\OtherKit\tags"), windows_rendered),
+            windows_rendered
         );
+
+        let native_tags_root = std::env::temp_dir().join("baboon-hrek").join("tags");
+        let native_relative = Path::new("objects").join("characters");
+        let native_rendered = native_tags_root.join(&native_relative);
         assert_eq!(
-            loose_folder_explorer_path(
-                Path::new(r"D:\HREK\tags"),
-                Path::new(r"objects\characters")
-            ),
-            rendered
+            loose_folder_explorer_path(&native_tags_root, &native_relative),
+            native_rendered
         );
     }
 

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -600,11 +600,28 @@ fn explorer_select_args(path: &Path) -> [std::ffi::OsString; 2] {
 }
 
 fn loose_folder_explorer_path(tags_root: &Path, requested: &Path) -> PathBuf {
-    if requested.is_absolute() {
+    if requested.is_absolute() || looks_like_absolute_windows_path(requested) {
         requested.to_path_buf()
     } else {
         tags_root.join(requested)
     }
+}
+
+/// `Path::is_absolute` follows the host platform, but favorite-folder actions
+/// can carry an Explorer path while this pure helper is exercised by Unix CI.
+/// Recognize the Windows forms explicitly so an already-rooted favorite is
+/// never appended to whichever kit happens to be active.
+fn looks_like_absolute_windows_path(path: &Path) -> bool {
+    let text = path.as_os_str().to_string_lossy();
+    let bytes = text.as_bytes();
+    let drive_absolute = bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && matches!(bytes[2], b'\\' | b'/');
+    let network_or_device_absolute = bytes.len() >= 2
+        && matches!(bytes[0], b'\\' | b'/')
+        && matches!(bytes[1], b'\\' | b'/');
+    drive_absolute || network_or_device_absolute
 }
 
 /// What a stashed overlay is, for the export review.

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -599,6 +599,14 @@ fn explorer_select_args(path: &Path) -> [std::ffi::OsString; 2] {
     ]
 }
 
+fn loose_folder_explorer_path(tags_root: &Path, requested: &Path) -> PathBuf {
+    if requested.is_absolute() {
+        requested.to_path_buf()
+    } else {
+        tags_root.join(requested)
+    }
+}
+
 /// What a stashed overlay is, for the export review.
 ///
 /// Pure so the rule can be tested without a mounted game, which is what
@@ -3692,14 +3700,6 @@ impl Baboon {
                 label,
                 open_in_new_tab,
             } => {
-                let needs_scan = self.kits[self.active]
-                    .source
-                    .as_ref()
-                    .is_some_and(|source| {
-                        matches!(source.source, TagSource::LooseFolder { .. })
-                            && source.all_entries.is_empty()
-                    })
-                    && !self.kits[self.active].scanning_entries;
                 let matching_key = if open_in_new_tab {
                     None
                 } else {
@@ -3763,14 +3763,12 @@ impl Baboon {
                 let selected = self.kits[self.active].selected_key.clone();
                 self.kits[self.active].open_tag_pane(&key);
                 self.kits[self.active].selected_key = selected;
-                if needs_scan {
-                    self.begin_scan_all_entries(ctx);
-                }
             }
             BrowserAction::ToggleFolderFavorite(rel_path) => self.toggle_folder_favorite(&rel_path),
             BrowserAction::Select(key) => self.select_entry(key, ctx),
             BrowserAction::ToggleFavorite(key) => self.toggle_favorite(&key),
             BrowserAction::CopyTagName(key) => self.copy_tag_name(&key, &ctx),
+            BrowserAction::CopyFolderPath(path) => self.copy_folder_path(&path, &ctx),
             BrowserAction::DumpJson(key) => self.begin_export_json(key, ctx),
             BrowserAction::OpenInExplorer(key) => self.open_entry_in_explorer(&key),
             BrowserAction::DumpLoadedFolderJson(keys) => {
@@ -3815,6 +3813,7 @@ impl Baboon {
             BrowserAction::ExtractHlslIncludeFolder(keys) => {
                 self.begin_extract_hlsl_include_folder(keys, ctx)
             }
+            BrowserAction::ReimportGeometry(key) => self.begin_reimport_geometry(&key),
             BrowserAction::ExtractContainerFolderTags { label, keys } => {
                 self.begin_extract_container_folder_tags(label, keys)
             }
@@ -3849,6 +3848,12 @@ impl Baboon {
             return;
         };
         let copied_path = crate::format::to_native_path_string(&entry.display_path);
+        ctx.output_mut(|output| output.copied_text = copied_path.clone());
+        self.status = format!("Copied {copied_path}");
+    }
+
+    pub(super) fn copy_folder_path(&mut self, path: &Path, ctx: &egui::Context) {
+        let copied_path = crate::format::to_native_path_string(&path.to_string_lossy());
         ctx.output_mut(|output| output.copied_text = copied_path.clone());
         self.status = format!("Copied {copied_path}");
     }
@@ -3936,7 +3941,8 @@ impl Baboon {
             self.status = "This workspace has no tags folder on disk".to_owned();
             return;
         };
-        self.open_folder_in_explorer(root.join(rel_path), "Tag");
+        let path = loose_folder_explorer_path(&root, rel_path);
+        self.open_folder_in_explorer(path, "Tag");
     }
 
     pub(super) fn open_folder_in_explorer(&mut self, path: PathBuf, label: &str) {
@@ -8339,6 +8345,27 @@ impl Baboon {
         self.spawn_terminal_command(command, ctx.clone());
     }
 
+    /// Queue the same editing-kit geometry import that a compatible tag
+    /// reference offers, deriving the tool source folder from the clicked tag.
+    pub(super) fn begin_reimport_geometry(&mut self, key: &str) {
+        let Some(entry) = self.entry_for_key(key).cloned() else {
+            self.status = "The tag is no longer in the browser".to_owned();
+            return;
+        };
+        if !matches!(entry.location, TagEntryLocation::LooseFile(_)) {
+            self.status = "Reimport requires a loose editing-kit tag".to_owned();
+            return;
+        }
+        let Some(verb) = geometry_import_verb(self.names(), entry.group_tag) else {
+            self.status = "This tag type does not support reimport".to_owned();
+            return;
+        };
+        self.pending_tool_import = Some(ToolImportRequest {
+            verb,
+            source_dir: model_source_dir(&entry_rel_path(&entry)),
+        });
+    }
+
     /// Starts potentially expensive source or export work off the UI thread.
     /// The worker owns cloned inputs and reports status without mutating UI state.
     pub(super) fn begin_reimport_bitmap(&mut self, key: String, ctx: egui::Context) {
@@ -9249,6 +9276,22 @@ mod tests {
                 std::ffi::OsString::from("/select,"),
                 path.as_os_str().to_owned(),
             ]
+        );
+    }
+
+    #[test]
+    fn favorite_folder_explorer_path_stays_bound_to_its_rendered_tags_root() {
+        let rendered = Path::new(r"D:\HREK\tags\objects\characters");
+        assert_eq!(
+            loose_folder_explorer_path(Path::new(r"C:\OtherKit\tags"), rendered),
+            rendered
+        );
+        assert_eq!(
+            loose_folder_explorer_path(
+                Path::new(r"D:\HREK\tags"),
+                Path::new(r"objects\characters")
+            ),
+            rendered
         );
     }
 

--- a/src/app/foundation/references.rs
+++ b/src/app/foundation/references.rs
@@ -449,6 +449,12 @@ pub(in crate::app) fn geometry_import_verb(
     let group_name = names
         .name_for(group_tag)
         .or_else(|| blam_tags::paths::group_tag_to_extension(group_tag))?;
+    geometry_import_verb_for_group_name(group_name)
+}
+
+pub(in crate::app) fn geometry_import_verb_for_group_name(
+    group_name: &str,
+) -> Option<&'static str> {
     match group_name {
         "render_model" => Some("render"),
         "collision_model" => Some("collision"),

--- a/src/app/state/browser.rs
+++ b/src/app/state/browser.rs
@@ -15,6 +15,7 @@ pub(in crate::app) enum BrowserAction {
     Select(String),
     ToggleFavorite(String),
     CopyTagName(String),
+    CopyFolderPath(PathBuf),
     DumpJson(String),
     OpenInExplorer(String),
     DumpLoadedFolderJson(Vec<String>),
@@ -65,6 +66,9 @@ pub(in crate::app) enum BrowserAction {
     ExtractMaterialShaderSourceFolder(Vec<String>),
     ExtractHlslIncludeSource(String),
     ExtractHlslIncludeFolder(Vec<String>),
+    /// Rebuild a loose geometry/animation tag from its editing-kit data files
+    /// using the same tool command offered beside compatible tag references.
+    ReimportGeometry(String),
     /// Write every shipped tag beneath one container folder to a chosen folder,
     /// laid out like an editing kit. The narrow-scope twin of File → Extract All
     /// Tags to Folder, and it shares that action's worker, progress and cancel.

--- a/src/app/tests/button_icons.rs
+++ b/src/app/tests/button_icons.rs
@@ -35,6 +35,8 @@ fn button_icon_lookup_uses_expected_assets() {
         ButtonIcon::JumpTo,
         ButtonIcon::JumpUp,
         ButtonIcon::Left,
+        ButtonIcon::ListDropdownLeft,
+        ButtonIcon::ListDropdownRight,
         ButtonIcon::Move,
         ButtonIcon::Open,
         ButtonIcon::Opened,
@@ -60,6 +62,14 @@ fn colorized_icon_replaces_current_color() {
     let svg = colorized_icon_svg(ButtonIcon::Open, Color32::from_rgb(1, 2, 3));
     assert!(svg.contains("#010203"));
     assert!(!svg.contains("currentColor"));
+}
+
+#[test]
+fn submenu_directions_use_distinct_assets() {
+    assert_ne!(
+        button_icon_svg(ButtonIcon::ListDropdownLeft),
+        button_icon_svg(ButtonIcon::ListDropdownRight)
+    );
 }
 
 #[test]

--- a/src/app/ui.rs
+++ b/src/app/ui.rs
@@ -751,20 +751,25 @@ impl Baboon {
         let commands = monitor_commands_for_game(game);
         let enabled = !commands.is_empty();
         let ctx = ui.ctx().clone();
-        let response = ui
+        let menu = ui
             .add_enabled_ui(enabled, |ui| {
-                ui.menu_button("Monitor", |ui| {
+                right_opening_menu_button(ui, "Monitor", 222.0, |ui| {
+                    style_list_menu(ui);
                     ui.set_min_width(210.0);
                     for command in commands {
                         if ui.button(*command).clicked() {
-                            self.submit_terminal_command(format!("tool {command}"), ctx.clone());
-                            ui.close_menu();
+                            return Some(*command);
                         }
                     }
+                    None
                 })
-                .response
             })
             .inner;
+        if let Some(command) = menu.inner.flatten() {
+            self.submit_terminal_command(format!("tool {command}"), ctx);
+            ui.close_menu();
+        }
+        let response = menu.response;
         if enabled {
             response.on_hover_text("Run monitor command");
         } else {
@@ -776,31 +781,41 @@ impl Baboon {
     /// than one tag at a time.
     fn draw_assets_tools_menu(&mut self, ui: &mut Ui) {
         let enabled = self.source().is_some();
-        let response = ui
+        let menu = ui
             .add_enabled_ui(enabled, |ui| {
-                ui.menu_button("Assets", |ui| {
+                right_opening_menu_button(ui, "Assets", 222.0, |ui| {
+                    style_list_menu(ui);
                     ui.set_min_width(210.0);
                     if ui.button("Bitmap Browser").clicked() {
-                        self.open_bitmap_library();
-                        ui.close_menu();
+                        return Some("bitmap");
                     }
                     if ui.button("Model Browser").clicked() {
-                        self.open_model_library();
-                        ui.close_menu();
+                        return Some("model");
                     }
                     // Baboon's own import pipelines only cover Halo 3 so far,
                     // so the entry only appears there.
                     if self.active_kit_is_halo3() && ui.button("Blam!").clicked() {
-                        // Re-detect on every open: the data folder may have
-                        // changed since the pane was last shown.
-                        self.kits[self.active].blam.scanned_path = None;
-                        self.kits[self.active].open_tag_pane(BLAM_KEY);
-                        ui.close_menu();
+                        return Some("blam");
                     }
+                    None
                 })
-                .response
             })
             .inner;
+        if let Some(asset) = menu.inner.flatten() {
+            match asset {
+                "bitmap" => self.open_bitmap_library(),
+                "model" => self.open_model_library(),
+                "blam" => {
+                    // Re-detect on every open: the data folder may have
+                    // changed since the pane was last shown.
+                    self.kits[self.active].blam.scanned_path = None;
+                    self.kits[self.active].open_tag_pane(BLAM_KEY);
+                }
+                _ => {}
+            }
+            ui.close_menu();
+        }
+        let response = menu.response;
         if !enabled {
             response.on_disabled_hover_text("Load an editing kit to browse its assets");
         }

--- a/src/app/ui/browser_panel.rs
+++ b/src/app/ui/browser_panel.rs
@@ -20,7 +20,7 @@ impl Baboon {
     pub(in crate::app) fn draw_folder_browser_pane(
         &mut self,
         ui: &mut Ui,
-        _ctx: &egui::Context,
+        ctx: &egui::Context,
         kit_index: usize,
         pane_key: &str,
     ) -> Option<BrowserAction> {
@@ -31,17 +31,42 @@ impl Baboon {
 
         self.refresh_modified_tags(kit_index);
         self.refresh_deletable_keys(kit_index);
+        // A loose pane owns a lazy subtree whose indices address the shared
+        // lazy entry vector. Its growth must not rebuild/collapse the pane.
+        // Eager sources still use entry count as cache invalidation.
         let source_len = self.kits[kit_index]
             .source
             .as_ref()
-            .map(|source| source.full_entry_set().len())
+            .map(|source| match source.source {
+                TagSource::LooseFolder { .. } => 0,
+                _ => source.full_entry_set().len(),
+            })
             .unwrap_or(0);
         let generation = self.kits[kit_index].generation;
         if pane.cached_generation != generation || pane.cached_source_len != source_len {
-            if let Some(source) = self.kits[kit_index].source.as_ref() {
-                let entries = source.full_entry_set();
-                pane.tree = crate::source::build_tree_beneath(entries, &pane.rel_path);
-                pane.group_tree = crate::source::build_group_tree_beneath(entries, &pane.rel_path);
+            if let Some(source) = self.kits[kit_index].source.as_mut() {
+                if let TagSource::LooseFolder { root, .. } = &source.source {
+                    let root = root.clone();
+                    let names = source.names.clone();
+                    match crate::source::build_lazy_folder_tree_beneath(
+                        &root,
+                        &pane.rel_path,
+                        &mut source.entries,
+                        &names,
+                    ) {
+                        Ok(tree) => pane.tree = tree,
+                        Err(error) => {
+                            pane.tree = TagTree::default();
+                            self.status = format!("Could not load folder tab: {error}");
+                        }
+                    }
+                    pane.group_tree = TagTree::default();
+                } else {
+                    let entries = source.full_entry_set();
+                    pane.tree = crate::source::build_tree_beneath(entries, &pane.rel_path);
+                    pane.group_tree =
+                        crate::source::build_group_tree_beneath(entries, &pane.rel_path);
+                }
             } else {
                 pane.tree = TagTree::default();
                 pane.group_tree = TagTree::default();
@@ -78,16 +103,15 @@ impl Baboon {
             .as_ref()
             .map(crate::app::controller::scenario_launch_availability)
             .unwrap_or_default();
-        let entries = self.kits[kit_index]
-            .source
-            .as_ref()
-            .map(|source| source.full_entry_set())
-            .unwrap_or_default();
         let mut show_browser_prefixes = self.show_browser_prefixes;
         let mut folders_before_tags = self.folders_before_tags;
         let double_click_to_open = self.double_click_to_open_tags;
         let search_hint = folder_browser_search_hint(&pane.label);
         let mut action = None;
+        let mut need_scan = false;
+        let mut status_update = None;
+        let scanning = self.kits[kit_index].scanning_entries;
+        let source = self.kits[kit_index].source.as_mut();
 
         Frame::none()
             .inner_margin(egui::Margin {
@@ -104,7 +128,27 @@ impl Baboon {
                 set_browser_scenario_launch(ui, scenario_launch);
                 set_browser_is_folder_pane(ui, true);
 
-                draw_folder_pane_header(ui, &mut pane, is_loose, &mut action);
+                let Some(source) = source else {
+                    ui.label(
+                        RichText::new("This folder source is no longer loaded")
+                            .color(subtle_dark()),
+                    );
+                    return;
+                };
+
+                let header_entries = if is_loose {
+                    &source.entries[..]
+                } else {
+                    source.full_entry_set()
+                };
+                draw_folder_pane_header(
+                    ui,
+                    &mut pane,
+                    header_entries,
+                    is_loose,
+                    is_container,
+                    &mut action,
+                );
                 ui.add_space(14.0);
                 ui.separator();
                 ui.add_space(10.0);
@@ -149,55 +193,105 @@ impl Baboon {
 
                 let filter = pane.filter.trim();
                 let groups_mode = pane.mode == BrowserMode::Groups;
-                let (tree, entries) = if filter.is_empty() {
-                    (
-                        if groups_mode {
-                            &pane.group_tree
+                let needs_complete_index = is_loose && (groups_mode || !filter.is_empty());
+                if needs_complete_index && source.all_entries.is_empty() {
+                    need_scan = !scanning;
+                    ui.label(
+                        RichText::new(if scanning {
+                            "Indexing tags…"
                         } else {
-                            &pane.tree
-                        },
-                        entries,
-                    )
-                } else {
-                    pane.filter_cache.refresh_beneath(
-                        pane.cached_generation,
-                        filter,
-                        entries,
-                        groups_mode,
-                        &pane.rel_path,
+                            "Preparing tag index…"
+                        })
+                        .color(subtle_dark())
+                        .small(),
                     );
-                    (
-                        &pane.filter_cache.tree,
-                        pane.filter_cache.entries.as_slice(),
-                    )
-                };
-                ScrollArea::vertical()
-                    .id_salt(("folder_pane", pane_key))
-                    .auto_shrink([false, false])
-                    .show(ui, |ui| {
-                        if entries.is_empty() {
-                            ui.label(RichText::new("No matching tags").color(subtle_dark()));
-                            return;
-                        }
-                        let tree_action = draw_tree(
-                            ui,
-                            tree,
+                } else if is_loose && !groups_mode && filter.is_empty() {
+                    let TagSource::LooseFolder { root, .. } = &source.source else {
+                        unreachable!("is_loose is derived from this source")
+                    };
+                    let root = root.clone();
+                    let names = source.names.clone();
+                    ScrollArea::vertical()
+                        .id_salt(("folder_pane", pane_key))
+                        .auto_shrink([false, false])
+                        .show(ui, |ui| {
+                            let tree_action = draw_tree_lazy(
+                                ui,
+                                &mut pane.tree,
+                                &mut source.entries,
+                                &mut pane.group_tree,
+                                &root,
+                                &names,
+                                selected.as_deref(),
+                                "",
+                                show_browser_prefixes,
+                                double_click_to_open,
+                                &mut status_update,
+                                None,
+                                pane.sort,
+                                folders_before_tags,
+                                Some(&favorite_keys),
+                            );
+                            if action.is_none() {
+                                action = tree_action;
+                            }
+                        });
+                } else {
+                    let entries = source.full_entry_set();
+                    if groups_mode {
+                        pane.group_tree =
+                            crate::source::build_group_tree_beneath(entries, &pane.rel_path);
+                    }
+                    let (tree, visible_entries) = if filter.is_empty() {
+                        (
+                            if groups_mode {
+                                &pane.group_tree
+                            } else {
+                                &pane.tree
+                            },
                             entries,
-                            selected.as_deref(),
+                        )
+                    } else {
+                        pane.filter_cache.refresh_beneath(
+                            pane.cached_generation,
                             filter,
-                            show_browser_prefixes,
-                            double_click_to_open,
+                            entries,
                             groups_mode,
-                            None,
-                            pane.sort,
-                            !groups_mode && folders_before_tags,
-                            is_loose.then_some(&favorite_keys),
-                            is_container,
+                            &pane.rel_path,
                         );
-                        if action.is_none() {
-                            action = tree_action;
-                        }
-                    });
+                        (
+                            &pane.filter_cache.tree,
+                            pane.filter_cache.entries.as_slice(),
+                        )
+                    };
+                    ScrollArea::vertical()
+                        .id_salt(("folder_pane", pane_key))
+                        .auto_shrink([false, false])
+                        .show(ui, |ui| {
+                            if visible_entries.is_empty() {
+                                ui.label(RichText::new("No matching tags").color(subtle_dark()));
+                                return;
+                            }
+                            let tree_action = draw_tree(
+                                ui,
+                                tree,
+                                visible_entries,
+                                selected.as_deref(),
+                                filter,
+                                show_browser_prefixes,
+                                double_click_to_open,
+                                groups_mode,
+                                None,
+                                pane.sort,
+                                !groups_mode && folders_before_tags,
+                                is_loose.then_some(&favorite_keys),
+                                is_container,
+                            );
+                            if action.is_none() {
+                                action = tree_action;
+                            }
+                        });
+                }
             });
 
         self.show_browser_prefixes = show_browser_prefixes;
@@ -218,6 +312,13 @@ impl Baboon {
         self.kits[kit_index]
             .folder_browsers
             .insert(pane_key.to_owned(), pane);
+        if let Some(status) = status_update {
+            self.status = status;
+        }
+        if need_scan {
+            self.active = kit_index;
+            self.begin_scan_all_entries(ctx.clone());
+        }
         action
     }
 
@@ -401,6 +502,14 @@ impl Baboon {
                     let (favorite_action, favorites_visible) = draw_favorites(
                         ui,
                         &active_favorite_entries,
+                        // Favorites follow the visible folder browser's lazy
+                        // boundary; a saved/global index must not make an
+                        // unopened favorite look materialized.
+                        &source.entries,
+                        match &source.source {
+                            TagSource::LooseFolder { root, .. } => Some(root.as_path()),
+                            _ => None,
+                        },
                         selected.as_deref(),
                         &filter,
                         show_prefixes,
@@ -589,6 +698,7 @@ fn browser_toolbar_controls(
         *mode = BrowserMode::Groups;
     }
     icon_menu_button(ui, ButtonIcon::Sort, "Sort", |ui| {
+        style_list_menu(ui);
         for option in BrowserSort::ALL {
             if ui
                 .selectable_label(*sort == option, option.label())
@@ -600,6 +710,7 @@ fn browser_toolbar_controls(
         }
     });
     icon_menu_button(ui, ButtonIcon::Other, "Other browser options", |ui| {
+        style_list_menu(ui);
         ui.checkbox(show_prefixes, "Show prefixes");
         ui.checkbox(folders_before_tags, "Folders before tags");
     });
@@ -628,7 +739,9 @@ fn draw_folder_browser_controls(
 fn draw_folder_pane_header(
     ui: &mut Ui,
     pane: &mut FolderBrowserState,
+    entries: &[TagEntry],
     is_loose: bool,
+    is_container: bool,
     action: &mut Option<BrowserAction>,
 ) {
     let normalized = pane.rel_path.to_string_lossy().replace('\\', "/");
@@ -701,7 +814,9 @@ fn draw_folder_pane_header(
                                     draw_folder_header_common_actions(
                                         ui,
                                         pane,
+                                        entries,
                                         is_loose,
+                                        is_container,
                                         is_favorite,
                                         action,
                                     );
@@ -709,7 +824,15 @@ fn draw_folder_pane_header(
                             );
                         });
                     } else {
-                        draw_folder_header_common_actions(ui, pane, is_loose, is_favorite, action);
+                        draw_folder_header_common_actions(
+                            ui,
+                            pane,
+                            entries,
+                            is_loose,
+                            is_container,
+                            is_favorite,
+                            action,
+                        );
                         ui.add_space(PANE_HEADER_SECTION_GAP);
                         draw_folder_header_launcher(ui, pane, is_loose, action);
                     }
@@ -730,7 +853,15 @@ fn draw_folder_pane_header(
             Vec2::new(ui.available_width(), BUTTON_HEIGHT),
             egui::Layout::right_to_left(egui::Align::Center),
             |ui| {
-                draw_folder_header_common_actions(ui, pane, is_loose, is_favorite, action);
+                draw_folder_header_common_actions(
+                    ui,
+                    pane,
+                    entries,
+                    is_loose,
+                    is_container,
+                    is_favorite,
+                    action,
+                );
             },
         );
     }
@@ -739,29 +870,61 @@ fn draw_folder_pane_header(
 fn draw_folder_header_common_actions(
     ui: &mut Ui,
     pane: &mut FolderBrowserState,
+    entries: &[TagEntry],
     is_loose: bool,
+    is_container: bool,
     is_favorite: bool,
     action: &mut Option<BrowserAction>,
 ) {
     ui.horizontal(|ui| {
         ui.spacing_mut().item_spacing.x = PANE_HEADER_ACTION_GAP;
-        icon_menu_button(ui, ButtonIcon::Other, "Other folder actions", |ui| {
-            if is_loose {
-                if let Some(menu_action) =
-                    loose_folder_transfer_menu_items(ui, &pane.rel_path, &pane.label)
-                {
+        right_aligned_icon_menu_button(
+            ui,
+            ButtonIcon::Other,
+            "Other folder actions",
+            CONTEXT_MENU_WIDTH,
+            |ui| {
+                style_tag_context_menu(ui);
+                if is_loose {
+                    if let Some(menu_action) =
+                        loose_folder_transfer_menu_items(ui, &pane.rel_path, &pane.label)
+                    {
+                        action.replace(menu_action);
+                    }
+                    context_menu_separator(ui);
+                }
+                if context_menu_button(ui, "Copy Folder Path").clicked() {
+                    action.replace(BrowserAction::CopyFolderPath(pane.rel_path.clone()));
+                    ui.close_menu();
+                }
+                context_menu_separator(ui);
+                let extract_label = pane.rel_path.to_string_lossy().replace('\\', "/");
+                let extract_label = if extract_label.is_empty() {
+                    pane.label.clone()
+                } else {
+                    extract_label
+                };
+                if let Some(menu_action) = folder_tree_extract_menu_button(
+                    ui,
+                    &pane.tree,
+                    entries,
+                    extract_label,
+                    is_container,
+                    is_loose,
+                    true,
+                ) {
                     action.replace(menu_action);
                 }
                 context_menu_separator(ui);
-            }
-            if ui.button("Dump folder to JSON...").clicked() {
-                action.replace(BrowserAction::DumpLooseFolderJson {
-                    rel_path: pane.rel_path.clone(),
-                    label: pane.label.clone(),
-                });
-                ui.close_menu();
-            }
-        });
+                if context_menu_button(ui, "Dump folder to JSON...").clicked() {
+                    action.replace(BrowserAction::DumpLooseFolderJson {
+                        rel_path: pane.rel_path.clone(),
+                        label: pane.label.clone(),
+                    });
+                    ui.close_menu();
+                }
+            },
+        );
         let favorite_icon = if is_favorite {
             ButtonIcon::FavouriteFilled
         } else {

--- a/src/app/ui/kit_tiles.rs
+++ b/src/app/ui/kit_tiles.rs
@@ -152,8 +152,12 @@ impl egui_tiles::Behavior<KitId> for KitPaneBehavior<'_> {
     ) {
         wheel_scroll_tab_bar(ui, scroll_offset);
         let recents = self.app.recent_folders.clone();
-        ui.menu_button("+", |ui| {
-            ui.set_min_width(240.0);
+        let menu_margin = Frame::menu(ui.style()).total_margin();
+        let root_popup_width = 320.0 + menu_margin.left + menu_margin.right;
+        let recent_popup_width = 240.0 + menu_margin.left + menu_margin.right;
+        right_aligned_menu_button(ui, "+", root_popup_width, |ui| {
+            style_list_menu(ui);
+            ui.set_width(320.0);
             if ui.button("Load Folder...").clicked() {
                 ui.close_menu();
                 self.add_kit = Some(LoadKind::Folder);
@@ -174,9 +178,16 @@ impl egui_tiles::Behavior<KitId> for KitPaneBehavior<'_> {
                 self.add_kit = Some(LoadKind::Container);
             }
             ui.separator();
-            ui.menu_button("Recent", |ui| {
-                self.recent_action = draw_recent_folders_menu(ui, &recents);
-            });
+            if let Some(recent_action) =
+                left_opening_menu_button(ui, "Recent", recent_popup_width, |ui| {
+                    style_list_menu(ui);
+                    draw_recent_folders_menu(ui, &recents)
+                })
+            .flatten()
+            {
+                self.recent_action = Some(recent_action);
+                ui.close_menu();
+            }
         })
         .response
         .on_hover_text("Open another game in its own workspace");

--- a/src/app/ui/recents.rs
+++ b/src/app/ui/recents.rs
@@ -12,6 +12,32 @@ pub(super) enum RecentAction {
     ForgetAll,
 }
 
+fn recent_folder_path_button(ui: &mut Ui, label: &str, width: f32) -> egui::Response {
+    let size = Vec2::new(width, ui.spacing().interact_size.y);
+    let (rect, response) = ui.allocate_exact_size(size, Sense::click());
+    response.widget_info(|| {
+        egui::WidgetInfo::labeled(egui::WidgetType::Button, ui.is_enabled(), label)
+    });
+
+    if ui.is_rect_visible(rect) {
+        let visuals = ui.style().interact(&response);
+        ui.painter().rect(
+            rect.expand(visuals.expansion),
+            visuals.rounding,
+            visuals.weak_bg_fill,
+            visuals.bg_stroke,
+        );
+        ui.painter().text(
+            egui::pos2(rect.left() + ui.spacing().button_padding.x, rect.center().y),
+            Align2::LEFT_CENTER,
+            label,
+            egui::TextStyle::Button.resolve(ui.style()),
+            visuals.text_color(),
+        );
+    }
+    response
+}
+
 /// Draw the recent-folders list as menu items, each with a button to forget it.
 ///
 /// Returns the choice rather than acting on it: this is rendered inside a menu
@@ -22,12 +48,33 @@ pub(super) fn draw_recent_folders_menu(ui: &mut Ui, recents: &[PathBuf]) -> Opti
         ui.add_enabled(false, egui::Button::new("No recent folders"));
         return None;
     }
+    let font_id = egui::TextStyle::Button.resolve(ui.style());
+    let longest_label = recents
+        .iter()
+        .map(|path| {
+            ui.painter()
+                .layout_no_wrap(recent_folder_menu_label(path), font_id.clone(), text_dark())
+                .size()
+                .x
+        })
+        .fold(0.0_f32, f32::max);
+    let clear_width = 18.0;
+    let gap = 4.0;
+    let row_height = ui.spacing().interact_size.y;
+    let path_padding = ui.spacing().button_padding.x * 2.0;
+    let menu_width = (longest_label + path_padding + gap + clear_width).max(240.0);
+    let path_width = menu_width - clear_width - gap;
+    // Keep this exact and derive every row from it. Basing the button width on
+    // `available_width()` feeds the popup's size from the previous frame back
+    // into its next layout pass, causing the menu to grow continuously.
+    ui.set_width(menu_width);
     let mut action = None;
     for path in recents {
         ui.horizontal(|ui| {
+            ui.spacing_mut().item_spacing.x = gap;
             let full = path.display().to_string();
-            if ui
-                .button(recent_folder_menu_label(path))
+            let label = recent_folder_menu_label(path);
+            if recent_folder_path_button(ui, &label, path_width)
                 .on_hover_text(&full)
                 .clicked()
             {
@@ -35,7 +82,10 @@ pub(super) fn draw_recent_folders_menu(ui: &mut Ui, recents: &[PathBuf]) -> Opti
                 ui.close_menu();
             }
             if ui
-                .add(egui::Button::new("×").min_size(Vec2::splat(18.0)))
+                .add_sized(
+                    [clear_width, row_height],
+                    egui::Button::new("×"),
+                )
                 .on_hover_text("Remove from recent folders")
                 .clicked()
             {
@@ -46,7 +96,7 @@ pub(super) fn draw_recent_folders_menu(ui: &mut Ui, recents: &[PathBuf]) -> Opti
         });
     }
     ui.separator();
-    if ui.button("Clear Recent Folders").clicked() {
+    if icon_text_button(ui, ButtonIcon::Clear, "Clear Recent Folders", true).clicked() {
         action = Some(RecentAction::ForgetAll);
         ui.close_menu();
     }

--- a/src/app/ui/shell.rs
+++ b/src/app/ui/shell.rs
@@ -25,7 +25,8 @@ impl Baboon {
             }))
             .show(ctx, |ui| {
                 egui::menu::bar(ui, |ui| {
-                    ui.menu_button("File", |ui| {
+                    aligned_menu_button(ui, "File", |ui| {
+                        style_list_menu(ui);
                         if ui.button("New Tag...").clicked() {
                             ui.close_menu();
                             self.open_new_tag_dialog();
@@ -133,11 +134,19 @@ impl Baboon {
                             ui.close_menu();
                             self.open_loaded_data_folder();
                         }
-                        let mut recent_action = None;
-                        ui.menu_button("Recent Folders", |ui| {
-                            recent_action = draw_recent_folders_menu(ui, &self.recent_folders);
-                        });
+                        let recent_action = right_opening_menu_button(
+                            ui,
+                            "Recent Folders",
+                            280.0,
+                            |ui| {
+                                style_list_menu(ui);
+                                draw_recent_folders_menu(ui, &self.recent_folders)
+                            },
+                        )
+                        .inner
+                        .flatten();
                         if let Some(action) = recent_action {
+                            ui.close_menu();
                             self.apply_recent_action(action, ctx);
                         }
                         ui.separator();
@@ -353,7 +362,8 @@ impl Baboon {
                             ui.close_menu();
                         }
                     });
-                    ui.menu_button("Edit", |ui| {
+                    aligned_menu_button(ui, "Edit", |ui| {
+                        style_list_menu(ui);
                         if ui
                             .add_enabled(
                                 self.can_undo_current(),
@@ -427,7 +437,8 @@ impl Baboon {
                             }
                         }
                     });
-                    ui.menu_button("Tools", |ui| {
+                    aligned_menu_button(ui, "Tools", |ui| {
+                        style_list_menu(ui);
                         if ui.button("Run Tool...").clicked() {
                             ui.close_menu();
                             self.tool_commands.open = true;
@@ -533,7 +544,8 @@ impl Baboon {
                             self.keyword_chooser_open = true;
                         }
                     });
-                    ui.menu_button("View", |ui| {
+                    aligned_menu_button(ui, "View", |ui| {
+                        style_list_menu(ui);
                         // The browser view belongs to a workspace, so this
                         // menu shows and sets the focused kit's — matching the
                         // Folders/Groups buttons in that kit's own toolbar.
@@ -553,17 +565,32 @@ impl Baboon {
                             ui.close_menu();
                         }
                         ui.separator();
-                        ui.menu_button(format!("Sort by: {}", kit.browser_sort.label()), |ui| {
-                            for option in BrowserSort::ALL {
-                                if ui
-                                    .selectable_label(kit.browser_sort == option, option.label())
-                                    .clicked()
-                                {
-                                    kit.browser_sort = option;
-                                    ui.close_menu();
+                        let selected_sort = right_opening_menu_button(
+                            ui,
+                            format!("Sort by: {}", kit.browser_sort.label()),
+                            220.0,
+                            |ui| {
+                                style_list_menu(ui);
+                                for option in BrowserSort::ALL {
+                                    if ui
+                                        .selectable_label(
+                                            kit.browser_sort == option,
+                                            option.label(),
+                                        )
+                                        .clicked()
+                                    {
+                                        return Some(option);
+                                    }
                                 }
-                            }
-                        });
+                                None
+                            },
+                        )
+                        .inner
+                        .flatten();
+                        if let Some(option) = selected_sort {
+                            kit.browser_sort = option;
+                            ui.close_menu();
+                        }
                         ui.separator();
                         ui.checkbox(&mut self.show_browser_prefixes, "Show [tag]/[folder]");
                         ui.checkbox(&mut self.show_block_sizes, "Show block sizes");
@@ -592,7 +619,8 @@ impl Baboon {
                             ui.close_menu();
                         }
                     });
-                    ui.menu_button("Help", |ui| {
+                    aligned_menu_button(ui, "Help", |ui| {
+                        style_list_menu(ui);
                         if ui.button("About...").clicked() {
                             self.help_panel_tab = HelpPanelTab::About;
                             self.about_open = true;
@@ -631,7 +659,7 @@ impl Baboon {
                             }
                         }
                     });
-                    ui.menu_button("Editing Kits", |ui| {
+                    aligned_menu_button(ui, "Editing Kits", |ui| {
                         ui.set_min_width(EDITING_KIT_MENU_MIN_WIDTH);
                         let entries = visible_editing_kit_menu_entries(
                             &self.custom_editing_kit_profiles,

--- a/src/app/ui/tag_pane.rs
+++ b/src/app/ui/tag_pane.rs
@@ -543,11 +543,18 @@ impl Baboon {
 
         ui.horizontal(|ui| {
             ui.spacing_mut().item_spacing.x = PANE_HEADER_ACTION_GAP;
-            icon_menu_button(ui, ButtonIcon::Other, "Other tag actions", |ui| {
-                if let Some(menu_action) = draw_tag_context_menu_contents(ui, entry, None) {
-                    action = Some(menu_action);
-                }
-            });
+            right_aligned_icon_menu_button(
+                ui,
+                ButtonIcon::Other,
+                "Other tag actions",
+                CONTEXT_MENU_WIDTH,
+                |ui| {
+                    if let Some(menu_action) = draw_tag_context_menu_contents(ui, entry, None, true)
+                    {
+                        action = Some(menu_action);
+                    }
+                },
+            );
 
             let favorite_label = if is_favorite { "Favorited" } else { "Favorite" };
             let favorite_icon = if is_favorite {

--- a/src/app/ui/tag_tiles.rs
+++ b/src/app/ui/tag_tiles.rs
@@ -37,6 +37,7 @@ struct TagPaneBehavior<'a> {
     pending_browser_action: Option<BrowserAction>,
 }
 
+
 impl egui_tiles::Behavior<String> for TagPaneBehavior<'_> {
     fn pane_ui(
         &mut self,
@@ -665,4 +666,3 @@ impl Baboon {
         }
     }
 }
-

--- a/src/app/ui/welcome.rs
+++ b/src/app/ui/welcome.rs
@@ -399,7 +399,7 @@ impl Baboon {
                                                     if welcome_icon_button(
                                                         ui,
                                                         ButtonIcon::Clear,
-                                                        "Clear recent folders",
+                                                        "Clear Recent Folders",
                                                         text_dark(),
                                                     )
                                                     .clicked()

--- a/src/source/index.rs
+++ b/src/source/index.rs
@@ -8,6 +8,7 @@ pub fn index_path(game: &str) -> PathBuf {
     app_cache_path(&format!("{game}_index.json"), "Baboon", "baboon")
 }
 
+
 /// Legacy JSON reverse-dependency path. New saves use [`index_db_path`].
 pub fn reverse_dependency_index_path(game: &str) -> PathBuf {
     app_cache_path(
@@ -740,4 +741,3 @@ pub fn field_row_summaries(tag: &TagFile, names: &TagNameIndex, limit: usize) ->
     }
     rows
 }
-

--- a/src/source/loading.rs
+++ b/src/source/loading.rs
@@ -38,6 +38,7 @@ pub fn load_single_file(path: PathBuf, names: &TagNameIndex) -> Result<LoadedSou
     })
 }
 
+
 /// Resolves an editing-kit tags root and prepares lazy folder browsing.
 /// A saved full index may populate `all_entries`, but `entries` remains lazy and
 /// is filled only as browser folders are expanded.
@@ -1859,4 +1860,3 @@ mod mod_export_tests {
         eprintln!("re-saved {rel_path} into its own exported mod");
     }
 }
-

--- a/src/source/tree.rs
+++ b/src/source/tree.rs
@@ -41,6 +41,34 @@ pub fn build_tree_beneath(entries: &[TagEntry], folder: &Path) -> TagTree {
     }
 }
 
+/// Build the initially visible portion of a loose folder tab without scanning
+/// its descendants. Direct tags are indexed now; each child remains lazy and
+/// is materialized only when the user expands it.
+pub fn build_lazy_folder_tree_beneath(
+    root: &Path,
+    folder: &Path,
+    entries: &mut Vec<TagEntry>,
+    names: &TagNameIndex,
+) -> Result<TagTree> {
+    let children = list_direct_child_nodes(root, folder)?;
+    let mut direct_entries = scan_folder_direct_entries(root, &root.join(folder), names)?;
+    direct_entries.sort_by(|a, b| natural_key(&a.display_path).cmp(&natural_key(&b.display_path)));
+
+    let mut indices = Vec::with_capacity(direct_entries.len());
+    for entry in direct_entries {
+        if let Some(index) = entries.iter().position(|known| known.key == entry.key) {
+            indices.push(index);
+        } else {
+            indices.push(entries.len());
+            entries.push(entry);
+        }
+    }
+    Ok(TagTree {
+        children,
+        entries: indices,
+    })
+}
+
 /// Build a group tree containing only entries beneath `folder`, while keeping
 /// every stored index pointed at the original `entries` slice.
 pub fn build_group_tree_beneath(entries: &[TagEntry], folder: &Path) -> TagTree {


### PR DESCRIPTION
## Summary

- Refreshed tag context menus with new button styling for primary actions (Rename, Move, Duplicate, Delete)
- Added icons to Folder context menus and included a Copy Folder Path button
- Added reimport actions to the context menu for tags that support this (render, collision, physics, animation models)
- Make context menus consistent across the tag browser, favorites, and tab headers,
- Unify toolbar and context-menu list button styling
- Right-aligned menu drop downs will now have their submenus appear to the left of them to avoid overlapping.
- Misc. UI improvements and fixes